### PR TITLE
[#3] Feat: Refresh Token 기반 Access Token 재발급 API 구현

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/auth/controller/AuthController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/auth/controller/AuthController.java
@@ -1,0 +1,59 @@
+package com.hertz.hertz_be.auth.controller;
+
+import com.hertz.hertz_be.auth.dto.response.ReissueAccessTokenResponseDTO;
+import com.hertz.hertz_be.auth.service.AuthTokenService;
+import com.hertz.hertz_be.auth.exception.RefreshTokenInvalidException;
+import com.hertz.hertz_be.global.common.ResponseCode;
+import com.hertz.hertz_be.global.common.ResponseDto;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthTokenService authTokenService;
+
+    @PostMapping("/v1/auth/token")
+    public ResponseEntity<ResponseDto<ReissueAccessTokenResponseDTO>> reissueAccessToken(
+            HttpServletRequest request,
+            HttpServletResponse response) {
+
+        String refreshToken = extractRefreshTokenFromCookie(request);
+        if (refreshToken == null) {
+            throw new RefreshTokenInvalidException();
+        }
+
+        Map.Entry<ReissueAccessTokenResponseDTO, String> result = authTokenService.reissueAccessToken(refreshToken);
+        ReissueAccessTokenResponseDTO accessTokenResponse = result.getKey();
+        String newRefreshToken = result.getValue();
+
+        String cookieValue = String.format( // Todo: 나중에 util 클래스로 분리
+                "refreshToken=%s; Max-Age=%d; Path=/; HttpOnly; Secure; SameSite=None",
+                newRefreshToken, 1209600
+        );
+        response.setHeader("Set-Cookie", cookieValue);
+
+        return ResponseEntity.ok(
+                new ResponseDto<>(ResponseCode.ACCESS_TOKEN_REISSUED, "Access Token이 재발급되었습니다.", accessTokenResponse)
+        );
+    }
+
+
+    private String extractRefreshTokenFromCookie(HttpServletRequest request) {
+        if (request.getCookies() == null) return null;
+        for (Cookie cookie : request.getCookies()) {
+            if (cookie.getName().equals("refreshToken")) {
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/auth/dto/response/ReissueAccessTokenResponseDTO.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/auth/dto/response/ReissueAccessTokenResponseDTO.java
@@ -1,0 +1,14 @@
+package com.hertz.hertz_be.auth.dto.response;
+
+public class ReissueAccessTokenResponseDTO {
+    private final String accessToken;
+
+    public ReissueAccessTokenResponseDTO(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+}
+

--- a/hertz-be/src/main/java/com/hertz/hertz_be/auth/exception/RefreshTokenExceptionHandler.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/auth/exception/RefreshTokenExceptionHandler.java
@@ -1,0 +1,17 @@
+package com.hertz.hertz_be.auth.exception;
+
+import com.hertz.hertz_be.global.common.ResponseDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(basePackages = "com.hertz.hertz_be.auth") // TODO: 병합 이후에 경로 수정
+public class RefreshTokenExceptionHandler {
+    @ExceptionHandler(RefreshTokenInvalidException.class)
+    public ResponseEntity<?> handleRefreshTokenError(RefreshTokenInvalidException ex) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ResponseDto<>(ex.getCode(), ex.getMessage(), null));
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/auth/exception/RefreshTokenInvalidException.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/auth/exception/RefreshTokenInvalidException.java
@@ -1,0 +1,18 @@
+package com.hertz.hertz_be.auth.exception;
+
+import com.hertz.hertz_be.global.common.ResponseCode;
+
+public class RefreshTokenInvalidException extends RuntimeException {
+
+    private static final String DEFAULT_MESSAGE = "Refresh Token이 유효하지 않거나 만료되었습니다. 다시 로그인 해주세요.";
+    private final String code;
+
+    public RefreshTokenInvalidException() {
+        super(DEFAULT_MESSAGE);
+        this.code = ResponseCode.REFRESH_TOKEN_INVALID;
+    }
+
+    public String getCode() {
+        return code;
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/auth/service/AuthTokenService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/auth/service/AuthTokenService.java
@@ -1,0 +1,42 @@
+package com.hertz.hertz_be.auth.service;
+
+import com.hertz.hertz_be.auth.dto.response.ReissueAccessTokenResponseDTO;
+import com.hertz.hertz_be.auth.exception.RefreshTokenInvalidException;
+import com.hertz.hertz_be.global.auth.token.JwtTokenProvider;
+import io.jsonwebtoken.JwtException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import java.util.AbstractMap;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class AuthTokenService {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenService refreshTokenService;
+
+    public Map.Entry<ReissueAccessTokenResponseDTO, String> reissueAccessToken(String refreshToken) {
+        try {
+            Long userId = jwtTokenProvider.getUserIdFromRefreshToken(refreshToken);
+            String storedToken = refreshTokenService.getRefreshToken(userId);
+
+            if (storedToken == null || !storedToken.equals(refreshToken)) {
+                throw new RefreshTokenInvalidException();
+            }
+
+            String newAccessToken = jwtTokenProvider.createAccessToken(userId);
+            String newRefreshToken = jwtTokenProvider.createRefreshToken(userId);
+
+            long expiration = 1209600L; // 14일 (초 단위),  Todo: 공통 상수로 관리 필요
+            refreshTokenService.saveRefreshToken(userId, newRefreshToken, expiration);
+
+            return new AbstractMap.SimpleEntry<>(
+                    new ReissueAccessTokenResponseDTO(newAccessToken),
+                    newRefreshToken
+            );
+        } catch (JwtException e) {
+            throw new RefreshTokenInvalidException();
+        }
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/auth/service/RefreshTokenService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/auth/service/RefreshTokenService.java
@@ -1,19 +1,17 @@
-package com.hertz.hertz_be.global.auth.token;
+package com.hertz.hertz_be.auth.service;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 
 @Service
+@RequiredArgsConstructor
 public class RefreshTokenService {
 
     private final StringRedisTemplate redisTemplate;
     private static final String REFRESH_TOKEN_PREFIX = "RT:";
-
-    public RefreshTokenService(StringRedisTemplate redisTemplate) {
-        this.redisTemplate = redisTemplate;
-    }
 
     public void saveRefreshToken(Long userId, String refreshToken, long expirationSeconds) {
         String key = REFRESH_TOKEN_PREFIX + userId;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/TestLoginController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/TestLoginController.java
@@ -1,0 +1,48 @@
+package com.hertz.hertz_be.global;
+
+import com.hertz.hertz_be.global.auth.token.JwtTokenProvider;
+import com.hertz.hertz_be.auth.service.RefreshTokenService;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/auth")
+public class TestLoginController {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenService refreshTokenService;
+
+    public TestLoginController(JwtTokenProvider jwtTokenProvider, RefreshTokenService refreshTokenService) {
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.refreshTokenService = refreshTokenService;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@RequestBody TestLoginRequestDTO request,
+                                   HttpServletResponse response) {
+        Long userId = request.getUserId();  // 클라이언트가 userId를 보냈다고 가정
+
+        // Access Token 발급
+        String accessToken = jwtTokenProvider.createAccessToken(userId);
+
+        // Refresh Token 발급
+        String refreshToken = jwtTokenProvider.createRefreshToken(userId);
+
+        // Redis에 Refresh Token 저장
+        refreshTokenService.saveRefreshToken(userId, refreshToken, 1209600L); // 14일 (초 단위)
+
+        // Set-Cookie 수동 설정 (SameSite=None + Secure + HttpOnly)
+        String cookieValue = String.format(
+                "refreshToken=%s; Max-Age=%d; Path=/; HttpOnly; Secure; SameSite=None",
+                refreshToken, 1209600
+        );
+        response.setHeader("Set-Cookie", cookieValue);
+
+        // Access Token은 JSON body로 반환
+        return ResponseEntity.ok()
+                .body(Map.of("accessToken", accessToken));
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/TestLoginRequestDTO.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/TestLoginRequestDTO.java
@@ -1,0 +1,18 @@
+package com.hertz.hertz_be.global;
+
+
+public class TestLoginRequestDTO {
+
+    private Long userId; // 간단히 userId만 받는다고 가정
+
+    public TestLoginRequestDTO() {
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/auth/handler/CustomAuthenticationEntryPoint.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/auth/handler/CustomAuthenticationEntryPoint.java
@@ -26,7 +26,7 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
         response.setContentType("application/json;charset=UTF-8");
 
         Map<String, Object> errorResponse = new HashMap<>();
-        errorResponse.put("code", ResponseCode.UNAUTHORIZED); // TODO: 추후에 상수화 처리 할 것
+        errorResponse.put("code", ResponseCode.UNAUTHORIZED); // TODO: 추후에 ResponceCode로 수정 될 예정
         errorResponse.put("message", "지정한 리소스에 대한 액세스 권한이 없습니다.");
         errorResponse.put("data", null);
 

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/auth/token/JwtTokenProvider.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/auth/token/JwtTokenProvider.java
@@ -65,4 +65,9 @@ public class JwtTokenProvider {
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
     }
+
+    public Long getUserIdFromRefreshToken(String token) {
+        Claims claims = parseClaims(token);
+        return Long.parseLong(claims.getSubject());
+    }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseCode.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseCode.java
@@ -2,11 +2,15 @@ package com.hertz.hertz_be.global.common;
 
 public class ResponseCode {
 
-    // 공통 예외 code
+    // 공통 예외 응답 code
     public static final String UNAUTHORIZED = "UNAUTHORIZED";
     public static final String FORBIDDEN = "NOT_FOUND";
     public static final String BAD_REQUEST = "BAD_REQUEST";
     public static final String INTERNAL_ERROR = "INTERNAL_SERVER_ERROR";
     public static final String NOT_IMPLEMENTED = "NOT_IMPLEMENTED";
+
+    // RT 관련 응답 code
+    public static final String ACCESS_TOKEN_REISSUED = "ACCESS_TOKEN_REISSUED";
+    public static final String REFRESH_TOKEN_INVALID = "REFRESH_TOKEN_INVALID";
 
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseDto.java
@@ -1,0 +1,16 @@
+package com.hertz.hertz_be.global.common;
+
+import lombok.Getter;
+
+@Getter
+public class ResponseDto<T> {
+    private final String code;
+    private final String message;
+    private final T data;
+
+    public ResponseDto(String code, String message, T data) {
+        this.code = code;
+        this.message = message;
+        this.data = data;
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/config/SecurityConfig.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/config/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
                         .authenticationEntryPoint(customAuthenticationEntryPoint)
                 )
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll() // TODO: 추후에 프론트엔드 서버와 AI 서버 도메인만 남기기
+                        .requestMatchers("/auth/**","/api/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll() // TODO: 추후에 수정
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/exception/GlobalExceptionHandler.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,14 @@
+package com.hertz.hertz_be.global.exception;
+
+import com.hertz.hertz_be.auth.exception.RefreshTokenInvalidException;
+import com.hertz.hertz_be.global.common.ResponseCode;
+import com.hertz.hertz_be.global.common.ResponseDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+}

--- a/hertz-be/src/main/resources/application.properties
+++ b/hertz-be/src/main/resources/application.properties
@@ -18,6 +18,6 @@ springdoc.swagger-ui.enabled=${SWAGGER_ENABLED:false}
 springdoc.swagger-ui.path=/swagger-ui.html
 
 # Redis
-spring.data.redis.host=localhost
-spring.data.redis.port=6379
-spring.data.redis.password=yourStrongPassword123!
+spring.data.redis.host=${REDIS_HOST}
+spring.data.redis.port=${REDIS_PORT}
+spring.data.redis.password=${REDIS_PASSWORD}


### PR DESCRIPTION
## 🔗 관련 이슈
- #3 

## ✏️ 변경 사항
- Auth 도메인 추가
- 공통 예외 처리를 위한 클래스 추가
- 공통 상수 관리를 위한 클래스 추가
- 공통 ResponseDTO와 ResponseCode 클래스 추가
- Redis 관련 설정과 환경변수 추가
- RT에 Secure와 SameSite 설정

## 📋 상세 설명
- 유효기간이 지난 AT를 재발급 받기 위한 API 구현 (RT도 같이 유효기간 리셋)
- user라는 도메인 안에서 AT, RT, 소셜 로그인 관련 로딕을 관리하게되면   
user 도메인이 너무 많은 책임을 맡을 것 같아, Auth 관련 로직을 위한 domain 추가

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 문서 또는 관련 설정을 수정했습니다. (필요 시)
