### PR TITLE
[#9] Feat: kakao oauth 테스트를 위해 cors 설정을 HttpSecurity에 추가

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/OAuthController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/OAuthController.java
@@ -19,7 +19,7 @@ public class OAuthController {
 
     private final OAuthService oAuthService;
 
-    @GetMapping("/v1/oauth/{provider}/redirect")
+    @GetMapping("/v1/oauth/{provider}/redirection")
     public ResponseEntity<Void> getOAuthRedirectUrl(@PathVariable String provider) {
         String url = oAuthService.getRedirectUrl(provider);
         return ResponseEntity.status(302)

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/repository/OAuthRedisRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/repository/OAuthRedisRepository.java
@@ -26,11 +26,11 @@ public class OAuthRedisRepository {
         redisTemplate.opsForValue().set(key, value, Duration.ofDays(2));
     }
 
-    public String get(String providerId) {
+    public String get(String providerId) { //Todo: 메서드 네임 리팩토링 필요
         return redisTemplate.opsForValue().get(PREFIX + providerId);
     }
 
-    public void delete(String providerId) {
+    public void delete(String providerId) { //Todo: 메서드 네임 리팩토링 필요
         redisTemplate.delete(PREFIX + providerId);
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/config/SecurityConfig.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/config/SecurityConfig.java
@@ -9,6 +9,11 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
 
 @Configuration
 public class SecurityConfig {
@@ -24,9 +29,9 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-
         return http
                 .csrf(csrf -> csrf.disable())
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .formLogin(form -> form.disable())
                 .httpBasic(basic -> basic.disable())
                 .sessionManagement(session -> session
@@ -35,10 +40,24 @@ public class SecurityConfig {
                         .authenticationEntryPoint(customAuthenticationEntryPoint)
                 )
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/**","/api/**", "/swagger-ui/**", "/v3/api-docs/**", "/signup/**").permitAll() // TODO: 추후에 수정
+                        .requestMatchers("/api/**", "/swagger-ui/**", "/v3/api-docs/**").permitAll() // TODO: 추후에 수정
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
                 .build();
+    }
+
+    @Bean
+    protected CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration corsConfiguration = new CorsConfiguration();
+        corsConfiguration.setAllowedOriginPatterns(List.of("*"));
+        corsConfiguration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+        corsConfiguration.setAllowedHeaders(List.of("*"));
+        corsConfiguration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", corsConfiguration); // TODO: 임시로 모든 경로에 적용 추후에 수정
+
+        return source;
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
#12 

## ✏️ 변경 사항
- cors() 설정을 HttpSecurity에 추가
- 카카오 소셜 로그인 APIㄹ 주소 오타 수정

## 📋 상세 설명
- cors() 설정을 일단 모든 엔드포인트 허용 (개발단계용)

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.

