### PR TITLE
[#14] Feat: 추천 사용자 대상 첫 메세지 전송 API 구현 및 채팅방 생성 처리 

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/ChannelController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/ChannelController.java
@@ -1,0 +1,33 @@
+package com.hertz.hertz_be.domain.channel.controller;
+
+
+import com.hertz.hertz_be.domain.channel.dto.request.SendSignalRequestDTO;
+import com.hertz.hertz_be.domain.channel.dto.response.SendSignalResponseDTO;
+import com.hertz.hertz_be.domain.channel.service.ChannelService;
+import com.hertz.hertz_be.global.auth.token.JwtTokenProvider;
+import com.hertz.hertz_be.global.common.ResponseCode;
+import com.hertz.hertz_be.global.common.ResponseDto;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class ChannelController {
+
+    private final ChannelService channelService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @PostMapping("/v1/tuning/signal")
+    public ResponseEntity<ResponseDto<SendSignalResponseDTO>> sendSignal(
+            @RequestBody @Valid SendSignalRequestDTO requestDTO, @AuthenticationPrincipal Long userId) {
+        SendSignalResponseDTO response = channelService.sendSignal(userId, requestDTO);
+        return ResponseEntity.status(201).body(
+                new ResponseDto<>(ResponseCode.SIGNAL_ROOM_CREATED, "시그널 룸이 성공적으로 생성되었습니다.", response)
+        );
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/request/SendSignalRequestDTO.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/request/SendSignalRequestDTO.java
@@ -1,0 +1,15 @@
+package com.hertz.hertz_be.domain.channel.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class SendSignalRequestDTO {
+
+    @NotNull
+    private Long receiverUserId;
+
+    @NotBlank
+    private String message;
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/SendSignalResponseDTO.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/SendSignalResponseDTO.java
@@ -1,0 +1,10 @@
+package com.hertz.hertz_be.domain.channel.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SendSignalResponseDTO {
+    private Long channelRoomId;
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/SignalMessage.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/SignalMessage.java
@@ -1,0 +1,40 @@
+package com.hertz.hertz_be.domain.channel.entity;
+
+import com.hertz.hertz_be.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "signal_message")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SignalMessage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "signal_room_id", nullable = false)
+    private SignalRoom signalRoomId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_user_id", nullable = false)
+    private User senderUserId;
+
+    @Column(nullable = false, length = 300)
+    private String message;
+
+    @Column(name = "is_read", nullable = false)
+    private Boolean isRead = false;
+
+    @CreationTimestamp
+    @Column(name = "send_at", nullable = false)
+    private LocalDateTime sendAt;
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/SignalRoom.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/SignalRoom.java
@@ -1,0 +1,50 @@
+package com.hertz.hertz_be.domain.channel.entity;
+
+import com.hertz.hertz_be.domain.channel.entity.enums.Category;
+import com.hertz.hertz_be.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "signal_room")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SignalRoom {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_user_id", nullable = false)
+    private User senderUser;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver_user_id", nullable = false)
+    private User receiverUser;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    private Category category;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "sender_matching_status", nullable = false, length = 15)
+    private String senderMatchingStatus;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "receiver_matching_status", nullable = false, length = 15)
+    private String receiverMatchingStatus;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}
+

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/SignalRoom.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/SignalRoom.java
@@ -8,6 +8,8 @@ import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "signal_room")
@@ -44,5 +46,8 @@ public class SignalRoom {
     @CreationTimestamp
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
+
+    @OneToMany(mappedBy = "signalRoomId")
+    private List<SignalMessage> messages = new ArrayList<>();
 }
 

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/SignalRoom.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/SignalRoom.java
@@ -1,9 +1,11 @@
 package com.hertz.hertz_be.domain.channel.entity;
 
 import com.hertz.hertz_be.domain.channel.entity.enums.Category;
+import com.hertz.hertz_be.domain.channel.entity.enums.MatchingStatus;
 import com.hertz.hertz_be.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
 
@@ -33,18 +35,14 @@ public class SignalRoom {
 
     @Enumerated(EnumType.STRING)
     @Column(name = "sender_matching_status", nullable = false, length = 15)
-    private String senderMatchingStatus;
+    private MatchingStatus senderMatchingStatus;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "receiver_matching_status", nullable = false, length = 15)
-    private String receiverMatchingStatus;
+    private MatchingStatus receiverMatchingStatus;
 
+    @CreationTimestamp
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
-
-    @PrePersist
-    protected void onCreate() {
-        this.createdAt = LocalDateTime.now();
-    }
 }
 

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/enums/Category.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/enums/Category.java
@@ -1,0 +1,14 @@
+package com.hertz.hertz_be.domain.channel.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Category {
+    FRIEND("친구"),
+    COUPLE("커플"),
+    MEAL_FRIEND("밥친구");
+
+    private final String label;
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/enums/MatchingStatus.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/enums/MatchingStatus.java
@@ -1,0 +1,14 @@
+package com.hertz.hertz_be.domain.channel.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MatchingStatus {
+    SIGNAL("시그널"),
+    MATCHING_ACCEPT("매칭 수락"),
+    MATCHING_REFUSE("매칭 거절");
+
+    private final String label;
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/exception/AlreadyInConversationException.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/exception/AlreadyInConversationException.java
@@ -1,0 +1,17 @@
+package com.hertz.hertz_be.domain.channel.exception;
+
+import com.hertz.hertz_be.global.common.ResponseCode;
+
+public class AlreadyInConversationException extends BaseChannelException{
+    private static final String DEFAULT_MESSAGE = "이미 대화 중인 상대방입니다.";
+    private final String code;
+
+    public AlreadyInConversationException() {
+        super(DEFAULT_MESSAGE);
+        this.code = ResponseCode.ALREADY_IN_CONVERSATION;
+    }
+
+    public String getCode() {
+        return code;
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/exception/BaseChannelException.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/exception/BaseChannelException.java
@@ -1,0 +1,8 @@
+package com.hertz.hertz_be.domain.channel.exception;
+
+public abstract class BaseChannelException extends RuntimeException{
+    public abstract String getCode();
+    public BaseChannelException(String message) {
+        super(message);
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/exception/ChannelExceptionHandler.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/exception/ChannelExceptionHandler.java
@@ -1,0 +1,32 @@
+package com.hertz.hertz_be.domain.channel.exception;
+
+import com.hertz.hertz_be.domain.auth.exception.BaseAuthException;
+import com.hertz.hertz_be.domain.auth.exception.RateLimitException;
+import com.hertz.hertz_be.global.common.ResponseDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(basePackages = "com.hertz.hertz_be.domain.channel")
+public class ChannelExceptionHandler {
+    @ExceptionHandler({
+            AlreadyInConversationException.class
+    })
+    public ResponseEntity<ResponseDto<Void>> handleAlreadyInConversationException(RuntimeException ex) {
+        String code = ((BaseChannelException) ex).getCode();
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body(new ResponseDto<>(code, ex.getMessage(), null));
+    }
+
+    @ExceptionHandler({
+            UserWithdrawnException.class
+    })
+    public ResponseEntity<ResponseDto<Void>> handleUserWithdrawnException(RuntimeException ex) {
+        String code = ((BaseChannelException) ex).getCode();
+        return ResponseEntity
+                .status(HttpStatus.GONE)
+                .body(new ResponseDto<>(code, ex.getMessage(), null));
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/exception/UserWithdrawnException.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/exception/UserWithdrawnException.java
@@ -1,0 +1,18 @@
+package com.hertz.hertz_be.domain.channel.exception;
+
+import com.hertz.hertz_be.domain.auth.exception.BaseAuthException;
+import com.hertz.hertz_be.global.common.ResponseCode;
+
+public class UserWithdrawnException extends BaseChannelException{
+    private static final String DEFAULT_MESSAGE = "상대방이 탈퇴한 사용자입니다.";
+    private final String code;
+
+    public UserWithdrawnException() {
+        super(DEFAULT_MESSAGE);
+        this.code = ResponseCode.USER_DEACTIVATED;
+    }
+
+    public String getCode() {
+        return code;
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/SignalMessageRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/SignalMessageRepository.java
@@ -1,0 +1,7 @@
+package com.hertz.hertz_be.domain.channel.repository;
+
+import com.hertz.hertz_be.domain.channel.entity.SignalMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SignalMessageRepository extends JpaRepository<SignalMessage, Long> {
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/SignalRoomRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/SignalRoomRepository.java
@@ -1,0 +1,9 @@
+package com.hertz.hertz_be.domain.channel.repository;
+
+import com.hertz.hertz_be.domain.channel.entity.SignalRoom;
+import com.hertz.hertz_be.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SignalRoomRepository extends JpaRepository<SignalRoom, Long> {
+    boolean existsBySenderUserAndReceiverUser(User sender, User receiver);
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/ChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/ChannelService.java
@@ -1,0 +1,59 @@
+package com.hertz.hertz_be.domain.channel.service;
+
+import com.hertz.hertz_be.domain.channel.entity.SignalMessage;
+import com.hertz.hertz_be.domain.channel.entity.SignalRoom;
+import com.hertz.hertz_be.domain.channel.entity.enums.Category;
+import com.hertz.hertz_be.domain.channel.entity.enums.MatchingStatus;
+import com.hertz.hertz_be.domain.channel.dto.request.SendSignalRequestDTO;
+import com.hertz.hertz_be.domain.channel.dto.response.SendSignalResponseDTO;
+import com.hertz.hertz_be.domain.channel.exception.AlreadyInConversationException;
+import com.hertz.hertz_be.domain.channel.exception.UserWithdrawnException;
+import com.hertz.hertz_be.domain.channel.repository.SignalRoomRepository;
+import com.hertz.hertz_be.domain.channel.repository.SignalMessageRepository;
+import com.hertz.hertz_be.domain.user.entity.User;
+import com.hertz.hertz_be.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ChannelService {
+
+    private final UserRepository userRepository;
+    private final SignalRoomRepository signalRoomRepository;
+    private final SignalMessageRepository signalMessageRepository;
+
+    @Transactional
+    public SendSignalResponseDTO sendSignal(Long senderUserId, SendSignalRequestDTO dto) {
+        User sender = userRepository.findById(senderUserId)
+                .orElseThrow();
+
+        User receiver = userRepository.findById(dto.getReceiverUserId())
+                .orElseThrow(UserWithdrawnException::new);
+
+        boolean alreadyExists = signalRoomRepository.existsBySenderUserAndReceiverUser(sender, receiver);
+        if (alreadyExists) {
+            throw new AlreadyInConversationException();
+        }
+
+        SignalRoom signalRoom = SignalRoom.builder()
+                .senderUser(sender)
+                .receiverUser(receiver)
+                .category(Category.FRIEND)
+                .senderMatchingStatus(MatchingStatus.SIGNAL)
+                .receiverMatchingStatus(MatchingStatus.SIGNAL)
+                .build();
+        signalRoomRepository.save(signalRoom);
+
+        SignalMessage signalMessage = SignalMessage.builder()
+                .signalRoomId(signalRoom)
+                .senderUserId(sender)
+                .message(dto.getMessage())
+                .isRead(false)
+                .build();
+        signalMessageRepository.save(signalMessage);
+
+        return new SendSignalResponseDTO(signalRoom.getId());
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/UserController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/UserController.java
@@ -1,49 +1,49 @@
-package com.hertz.hertz_be.domain.user.controller;
-
-import com.hertz.hertz_be.domain.user.dto.request.UserInfoRequestDto;
-import com.hertz.hertz_be.domain.user.dto.response.UserInfoResponseDto;
-import com.hertz.hertz_be.domain.user.service.UserService;
-import com.hertz.hertz_be.global.common.ResponseCode;
-import com.hertz.hertz_be.global.common.ResponseDto;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.Map;
-
-@RestController
-@RequestMapping("/api/v1")
-public class UserController {
-    private final UserService userService;
-
-    public UserController(UserService userService) {
-        this.userService = userService;
-    }
-
-    /**
-     * 사용자 생성
-     * @param userInfoRequestDto
-     * @author daisy.lee
-     */
-    @PostMapping("/users")
-    public ResponseEntity<ResponseDto<UserInfoResponseDto>> createUser(@RequestBody UserInfoRequestDto userInfoRequestDto) {
-        UserInfoResponseDto userInfoResponseDto = userService.createUser(userInfoRequestDto);
-
-        return ResponseEntity.ok(
-                new ResponseDto<>(ResponseCode.PROFILE_SAVED_SUCCESSFULLY, "개인정보가 정상적으로 저장되었습니다.", userInfoResponseDto)
-        );
-    }
-
-    /**
-     * 랜덤 닉네임 반환
-     * @author daisy.lee
-     */
-    @GetMapping("/nickname")
-    public ResponseEntity<ResponseDto<Map<String, String>>> generateNickname() {
-        String nickname = userService.fetchRandomNickname();
-        Map<String, String> data = Map.of("nickname", nickname);
-        return ResponseEntity.ok(
-                new ResponseDto<>(ResponseCode.NICKNAME_CREATED, "닉네임이 성공적으로 생성되었습니다.", data)
-        );
-    }
-
-}
+//package com.hertz.hertz_be.domain.user.controller;
+//
+//import com.hertz.hertz_be.domain.user.dto.request.UserInfoRequestDto;
+//import com.hertz.hertz_be.domain.user.dto.response.UserInfoResponseDto;
+//import com.hertz.hertz_be.domain.user.service.UserService;
+//import com.hertz.hertz_be.global.common.ResponseCode;
+//import com.hertz.hertz_be.global.common.ResponseDto;
+//import org.springframework.http.ResponseEntity;
+//import org.springframework.web.bind.annotation.*;
+//
+//import java.util.Map;
+//
+//@RestController
+//@RequestMapping("/api/v1")
+//public class UserController {
+//    private final UserService userService;
+//
+//    public UserController(UserService userService) {
+//        this.userService = userService;
+//    }
+//
+//    /**
+//     * 사용자 생성
+//     * @param userInfoRequestDto
+//     * @author daisy.lee
+//     */
+//    @PostMapping("/users")
+//    public ResponseEntity<ResponseDto<UserInfoResponseDto>> createUser(@RequestBody UserInfoRequestDto userInfoRequestDto) {
+//        UserInfoResponseDto userInfoResponseDto = userService.createUser(userInfoRequestDto);
+//
+//        return ResponseEntity.ok(
+//                new ResponseDto<>(ResponseCode.PROFILE_SAVED_SUCCESSFULLY, "개인정보가 정상적으로 저장되었습니다.", userInfoResponseDto)
+//        );
+//    }
+//
+//    /**
+//     * 랜덤 닉네임 반환
+//     * @author daisy.lee
+//     */
+//    @GetMapping("/nickname")
+//    public ResponseEntity<ResponseDto<Map<String, String>>> generateNickname() {
+//        String nickname = userService.fetchRandomNickname();
+//        Map<String, String> data = Map.of("nickname", nickname);
+//        return ResponseEntity.ok(
+//                new ResponseDto<>(ResponseCode.NICKNAME_CREATED, "닉네임이 성공적으로 생성되었습니다.", data)
+//        );
+//    }
+//
+//}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/request/UserInfoRequestDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/request/UserInfoRequestDto.java
@@ -17,7 +17,7 @@ import jakarta.validation.constraints.NotNull;
 public class UserInfoRequestDto {
 
     @NotBlank
-    private Long providerId;
+    private String providerId;
 
     @NotBlank
     private String provider;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/entity/User.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.hertz.hertz_be.domain.user.entity;
 
+import com.hertz.hertz_be.domain.channel.entity.SignalRoom;
 import com.hertz.hertz_be.domain.user.entity.enums.AgeGroup;
 import com.hertz.hertz_be.domain.user.entity.enums.Gender;
 import com.hertz.hertz_be.domain.user.entity.enums.MembershipType;
@@ -9,6 +10,8 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "user")
@@ -69,4 +72,10 @@ public class User {
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
+
+    @OneToMany(mappedBy = "senderUser")
+    private List<SignalRoom> sentSignalRooms = new ArrayList<>();
+
+    @OneToMany(mappedBy = "receiverUser")
+    private List<SignalRoom> receivedSignalRooms = new ArrayList<>();
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/entity/User.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.hertz.hertz_be.domain.user.entity;
 
+import com.hertz.hertz_be.domain.channel.entity.SignalMessage;
 import com.hertz.hertz_be.domain.channel.entity.SignalRoom;
 import com.hertz.hertz_be.domain.user.entity.enums.AgeGroup;
 import com.hertz.hertz_be.domain.user.entity.enums.Gender;
@@ -78,4 +79,7 @@ public class User {
 
     @OneToMany(mappedBy = "receiverUser")
     private List<SignalRoom> receivedSignalRooms = new ArrayList<>();
+
+    @OneToMany(mappedBy = "senderUserId")
+    private List<SignalMessage> sendMessages = new ArrayList<>();
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/entity/enums/AgeGroup.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/entity/enums/AgeGroup.java
@@ -1,8 +1,10 @@
 package com.hertz.hertz_be.domain.user.entity.enums;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
+@RequiredArgsConstructor
 public enum AgeGroup {
 
     AGE_20S("20대"),
@@ -12,8 +14,4 @@ public enum AgeGroup {
     AGE_60_PLUS("60대 이상");
 
     private final String label;
-
-    AgeGroup(String label) {
-        this.label = label;
-    }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/entity/enums/Gender.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/entity/enums/Gender.java
@@ -1,15 +1,13 @@
 package com.hertz.hertz_be.domain.user.entity.enums;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
+@RequiredArgsConstructor
 public enum Gender {
     MALE("남자"),
     FEMALE("여자");
 
     private final String label;
-
-    Gender(String label) {
-        this.label = label;
-    }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/entity/enums/MembershipType.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/entity/enums/MembershipType.java
@@ -1,10 +1,13 @@
 package com.hertz.hertz_be.domain.user.entity.enums;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum MembershipType {
     GENERAL_USER("일반 사용자"),
     PREMIUM_USER("멤버십 사용자");
 
     private final String label;
-
-    MembershipType(String label) {this.label = label;}
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/service/UserService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/service/UserService.java
@@ -1,95 +1,95 @@
-package com.hertz.hertz_be.domain.user.service;
-
-import com.hertz.hertz_be.domain.user.dto.OauthTokenInfo;
-import com.hertz.hertz_be.domain.user.dto.request.UserInfoRequestDto;
-import com.hertz.hertz_be.domain.user.dto.response.UserInfoResponseDto;
-import com.hertz.hertz_be.domain.user.entity.User;
-import com.hertz.hertz_be.domain.user.entity.UserOauth;
-import com.hertz.hertz_be.domain.user.exception.UserException;
-import com.hertz.hertz_be.domain.user.repository.UserRepository;
-import com.hertz.hertz_be.global.common.ResponseCode;
-import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
-
-@Service
-@RequiredArgsConstructor
-public class UserService {
-    private final UserRepository userRepository;
-    private final RedisTemplate<String, Object> redisTemplate;
-    private final RestTemplate restTemplate = new RestTemplate();
-    private final long TIMEOUT_NANOS = 5_000_000_000L; // // 5초 = 5_000_000_000 나노초
-
-    @Value("${external.api.nickname-url}")
-    private String NICKNAME_API_URL;
-
-
-    public UserInfoResponseDto createUser(UserInfoRequestDto userInfoRequestDto) {
-        // 랜덤 닉네임 반환 (무한루프)
-
-        String redisKey = "kakao:oauth:providerId:" + userInfoRequestDto.getProviderId();
-
-        OauthTokenInfo tokenInfo = (OauthTokenInfo) redisTemplate.opsForValue().get(redisKey);
-        if (tokenInfo == null) {
-            // throw new InvalidOauthStateException("OAuth 인증 정보가 만료되었거나 존재하지 않습니다.");
-        }
-
-        User user = User.builder()
-                .ageGroup(userInfoRequestDto.getAgeGroup())
-                .profileImageUrl(userInfoRequestDto.getProfileImage())
-                .nickname(userInfoRequestDto.getNickname())
-                .gender(userInfoRequestDto.getGender())
-                .oneLineIntroduction(userInfoRequestDto.getOneLineIntroduction())
-                .build();
-
-        UserOauth userOauth = UserOauth.builder()
-                .provider(userInfoRequestDto.getProvider())
-                .providerId(userInfoRequestDto.getProviderId())
-                .refreshToken(tokenInfo.getRefreshToken())
-                .refreshTokenExpiresAt(tokenInfo.getRefreshTokenExpiresAt())
-                .user(user)
-                .build();
-
-        user.setUserOauth(userOauth);
-
-        User savedUser = userRepository.save(user);
-
-        return UserInfoResponseDto.builder()
-                .userId(savedUser.getId())
-                .build();
-
-    }
-
-    public String fetchRandomNickname() {
-        final long startTime = System.nanoTime();
-
-        while (true) {
-            if (System.nanoTime() - startTime > TIMEOUT_NANOS) {
-                throw new UserException("NICKNAME_GENERATION_TIMEOUT", "5초 내에 중복되지 않은 닉네임을 찾지 못했습니다.");
-            }
-
-            String nickname;
-            try {
-                nickname = callExternalNicknameApi();
-            } catch (Exception e) {
-                throw new UserException(ResponseCode.NICKNAME_API_FAILED, "닉네임 생성 API 호출 실패");
-            }
-
-            if (!userRepository.existsByNickname(nickname)) {
-                return nickname;
-            }
-        }
-    }
-
-    private String callExternalNicknameApi() {
-        ResponseEntity<String> response = restTemplate.getForEntity(NICKNAME_API_URL, String.class);
-        if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
-            return response.getBody().trim();
-        }
-        throw new UserException(ResponseCode.NICKNAME_API_FAILED, "닉네임 생성 API 응답 실패");
-    }
-}
-
+//package com.hertz.hertz_be.domain.user.service;
+//
+//import com.hertz.hertz_be.domain.user.dto.OauthTokenInfo;
+//import com.hertz.hertz_be.domain.user.dto.request.UserInfoRequestDto;
+//import com.hertz.hertz_be.domain.user.dto.response.UserInfoResponseDto;
+//import com.hertz.hertz_be.domain.user.entity.User;
+//import com.hertz.hertz_be.domain.user.entity.UserOauth;
+//import com.hertz.hertz_be.domain.user.exception.UserException;
+//import com.hertz.hertz_be.domain.user.repository.UserRepository;
+//import com.hertz.hertz_be.global.common.ResponseCode;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.beans.factory.annotation.Value;
+//import org.springframework.data.redis.core.RedisTemplate;
+//import org.springframework.http.ResponseEntity;
+//import org.springframework.stereotype.Service;
+//import org.springframework.web.client.RestTemplate;
+//
+//@Service
+//@RequiredArgsConstructor
+//public class UserService {
+//    private final UserRepository userRepository;
+//    private final RedisTemplate<String, Object> redisTemplate;
+//    private final RestTemplate restTemplate = new RestTemplate();
+//    private final long TIMEOUT_NANOS = 5_000_000_000L; // // 5초 = 5_000_000_000 나노초
+//
+//    @Value("${external.api.nickname-url}")
+//    private String NICKNAME_API_URL;
+//
+//
+//    public UserInfoResponseDto createUser(UserInfoRequestDto userInfoRequestDto) {
+//        // 랜덤 닉네임 반환 (무한루프)
+//
+//        String redisKey = "kakao:oauth:providerId:" + userInfoRequestDto.getProviderId();
+//
+//        OauthTokenInfo tokenInfo = (OauthTokenInfo) redisTemplate.opsForValue().get(redisKey);
+//        if (tokenInfo == null) {
+//            // throw new InvalidOauthStateException("OAuth 인증 정보가 만료되었거나 존재하지 않습니다.");
+//        }
+//
+//        User user = User.builder()
+//                .ageGroup(userInfoRequestDto.getAgeGroup())
+//                .profileImageUrl(userInfoRequestDto.getProfileImage())
+//                .nickname(userInfoRequestDto.getNickname())
+//                .gender(userInfoRequestDto.getGender())
+//                .oneLineIntroduction(userInfoRequestDto.getOneLineIntroduction())
+//                .build();
+//
+//        UserOauth userOauth = UserOauth.builder()
+//                .provider(userInfoRequestDto.getProvider())
+//                .providerId(userInfoRequestDto.getProviderId())
+//                .refreshToken(tokenInfo.getRefreshToken())
+//                .refreshTokenExpiresAt(tokenInfo.getRefreshTokenExpiresAt())
+//                .user(user)
+//                .build();
+//
+//        user.setUserOauth(userOauth);
+//
+//        User savedUser = userRepository.save(user);
+//
+//        return UserInfoResponseDto.builder()
+//                .userId(savedUser.getId())
+//                .build();
+//
+//    }
+//
+//    public String fetchRandomNickname() {
+//        final long startTime = System.nanoTime();
+//
+//        while (true) {
+//            if (System.nanoTime() - startTime > TIMEOUT_NANOS) {
+//                throw new UserException("NICKNAME_GENERATION_TIMEOUT", "5초 내에 중복되지 않은 닉네임을 찾지 못했습니다.");
+//            }
+//
+//            String nickname;
+//            try {
+//                nickname = callExternalNicknameApi();
+//            } catch (Exception e) {
+//                throw new UserException(ResponseCode.NICKNAME_API_FAILED, "닉네임 생성 API 호출 실패");
+//            }
+//
+//            if (!userRepository.existsByNickname(nickname)) {
+//                return nickname;
+//            }
+//        }
+//    }
+//
+//    private String callExternalNicknameApi() {
+//        ResponseEntity<String> response = restTemplate.getForEntity(NICKNAME_API_URL, String.class);
+//        if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
+//            return response.getBody().trim();
+//        }
+//        throw new UserException(ResponseCode.NICKNAME_API_FAILED, "닉네임 생성 API 응답 실패");
+//    }
+//}
+//

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseCode.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseCode.java
@@ -30,4 +30,9 @@ public class ResponseCode {
     public static final String INTERESTS_SAVED_SUCCESSFULLY = "INTERESTS_SAVED_SUCCESSFULLY";
     public static final String EMPTY_LIST_NOT_ALLOWED = "EMPTY_LIST_NOT_ALLOWED";
 
+    //시그널 관련 응답 code
+    public static final String SIGNAL_ROOM_CREATED = "SIGNAL_ROOM_CREATED";
+    public static final String USER_DEACTIVATED = "USER_DEACTIVATED";
+    public static final String ALREADY_IN_CONVERSATION = "ALREADY_IN_CONVERSATION";
+
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/exception/GlobalExceptionHandler.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/exception/GlobalExceptionHandler.java
@@ -3,18 +3,46 @@ package com.hertz.hertz_be.global.exception;
 import com.hertz.hertz_be.domain.user.exception.UserException;
 import com.hertz.hertz_be.global.common.ResponseCode;
 import com.hertz.hertz_be.global.common.ResponseDto;
+import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(UserException.class)
+    @ExceptionHandler(UserException.class) // Todo: User 도메인에 있는 exception으로 위치 수정 필요
     public ResponseEntity handleUserException(UserException ex) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(new ResponseDto(ex.getCode(), ex.getMessage(), null));
     }
 
+    // DTO @Valid 검증 실패
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ResponseDto<Void>> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ResponseDto<>(ResponseCode.BAD_REQUEST, "잘못된 요청입니다.", null));
+    }
+
+    // JSON 형식 오류 (e.g. null, 오타 등)
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ResponseDto<Void>> handleMessageNotReadable(HttpMessageNotReadableException ex) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ResponseDto<>(ResponseCode.BAD_REQUEST, "잘못된 요청입니다.", null));
+    }
+
+    // 경로 변수나 쿼리 파라미터 @Valid 실패 시
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ResponseDto<Void>> handleConstraintViolation(ConstraintViolationException ex) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ResponseDto<>(ResponseCode.BAD_REQUEST, "잘못된 요청입니다.", null));
+    }
 }


### PR DESCRIPTION
## 🔗 관련 이슈  
- #14 

## ✏️ 변경 사항  
- 첫 메세지 전송 시 채팅방 생성 또는 기존 채팅방 ID 반환 기능 추가  

## 📋 상세 설명  
- 추천 사용자 중 마음에 드는 사용자에게 요청/승인 과정 없이 바로 첫 메세지를 전송할 수 있도록 기능 구현  
- 상대방과의 채팅방이 존재하지 않을 경우, 새로운 채팅방을 생성하고 첫 메세지를 포함시켜 저장  
- 이미 채팅방이 존재할 경우, 해당 채팅방 ID를 반환하여 중복 생성을 방지  
- 사용자 간 매칭 상태나 별도의 승인 절차 없이 즉시 대화 시작 가능  
- 주요 예외 상황 및 응답 처리:

### 📌 예외 처리 및 응답 예시
1. ✅ **성공적인 요청 시**
   <img width="565" alt="성공 응답" src="https://github.com/user-attachments/assets/abef552b-2f60-4bae-87d2-c0a3e16b36b9" />

2. 🔁 **이미 대화 중인 사용자일 경우**
   <img width="577" alt="기존 채팅방 응답" src="https://github.com/user-attachments/assets/054c7238-d65e-4141-935d-75e0eae0ec56" />

3. ❌ **상대방이 탈퇴한 사용자일 경우**
   <img width="546" alt="탈퇴 사용자 예외" src="https://github.com/user-attachments/assets/99911568-1be2-4bff-a834-10888a931e2c" />

## ✅ 체크리스트  
- [x] 기능이 정상적으로 동작하는지 확인했습니다.  
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.  
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)  
