### PR TITLE
[#5] Feat: 개인정보 등록 API 마무리

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/UserController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/UserController.java
@@ -38,7 +38,7 @@ public class UserController {
         refreshTokenCookie.setHttpOnly(true);
         refreshTokenCookie.setSecure(true); // 배포환경에서만 true
         refreshTokenCookie.setPath("/");
-        refreshTokenCookie.setMaxAge(60 * 60 * 24 * 7); // 7일
+        refreshTokenCookie.setMaxAge(userInfoResponseDto.getRefreshSecondsUntilExpiry()); // 만료일자까지 남은 시간
 
         response.addCookie(refreshTokenCookie);
 

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/UserController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/UserController.java
@@ -5,9 +5,13 @@ import com.hertz.hertz_be.domain.user.dto.response.UserInfoResponseDto;
 import com.hertz.hertz_be.domain.user.service.UserService;
 import com.hertz.hertz_be.global.common.ResponseCode;
 import com.hertz.hertz_be.global.common.ResponseDto;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.HashMap;
 import java.util.Map;
 
 @RestController
@@ -20,17 +24,35 @@ public class UserController {
     }
 
     /**
-     * 사용자 생성
+     * 사용자 생성 (개인정보 등록)
      * @param userInfoRequestDto
      * @author daisy.lee
      */
     @PostMapping("/users")
-    public ResponseEntity<ResponseDto<UserInfoResponseDto>> createUser(@RequestBody UserInfoRequestDto userInfoRequestDto) {
-        UserInfoResponseDto userInfoResponseDto = userService.createUser(userInfoRequestDto);
+    public ResponseEntity<ResponseDto<Map<String, Object>>> createUser(@RequestBody UserInfoRequestDto userInfoRequestDto,
+                                                                       HttpServletResponse response,
+                                                                       HttpServletRequest request) {
+        UserInfoResponseDto userInfoResponseDto = userService.createUser(userInfoRequestDto, request);
+
+        Cookie refreshTokenCookie = new Cookie("refreshToken", userInfoResponseDto.getRefreshToken());
+        refreshTokenCookie.setHttpOnly(true);
+        refreshTokenCookie.setSecure(true); // 배포환경에서만 true
+        refreshTokenCookie.setPath("/");
+        refreshTokenCookie.setMaxAge(60 * 60 * 24 * 7); // 7일
+
+        response.addCookie(refreshTokenCookie);
+
+        // 응답 바디에 포함할 정보만 따로 구성
+        Map<String, Object> data = new HashMap<>();
+        data.put("userId", userInfoResponseDto.getUserId());
+        data.put("accessToken", userInfoResponseDto.getAccessToken());
 
         return ResponseEntity.ok(
-                new ResponseDto<>(ResponseCode.PROFILE_SAVED_SUCCESSFULLY, "개인정보가 정상적으로 저장되었습니다.", userInfoResponseDto)
+                new ResponseDto<>(ResponseCode.PROFILE_SAVED_SUCCESSFULLY,
+                        "개인정보가 정상적으로 저장되었습니다.",
+                        data)
         );
+
     }
 
     /**

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/request/UserInfoRequestDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/request/UserInfoRequestDto.java
@@ -17,13 +17,16 @@ import jakarta.validation.constraints.NotNull;
 public class UserInfoRequestDto {
 
     @NotBlank
-    private Long providerId;
+    private String providerId;
 
     @NotBlank
     private String provider;
 
     @NotBlank
     private String profileImage;
+
+    @NotBlank
+    private String email;
 
     @NotBlank
     private String nickname;
@@ -36,4 +39,6 @@ public class UserInfoRequestDto {
 
     @NotBlank
     private String oneLineIntroduction;
+
+
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/response/UserInfoResponseDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/response/UserInfoResponseDto.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -13,4 +15,5 @@ public class UserInfoResponseDto {
     private Long userId;
     private String accessToken;
     private String refreshToken;
+    private int refreshSecondsUntilExpiry;
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/response/UserInfoResponseDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/response/UserInfoResponseDto.java
@@ -11,6 +11,6 @@ import lombok.NoArgsConstructor;
 @Builder
 public class UserInfoResponseDto {
     private Long userId;
-    private String nickname;
-    private String profileImage;
+    private String accessToken;
+    private String refreshToken;
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/entity/User.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/entity/User.java
@@ -44,17 +44,21 @@ public class User {
     private String oneLineIntroduction;
 
     @Enumerated(EnumType.STRING)
+    @Builder.Default
     @Column(name = "membership_type", nullable = false, length = 25)
-    private MembershipType membershipType;
+    private MembershipType membershipType = MembershipType.GENERAL_USER;
 
+    @Builder.Default
     @Column(name = "is_friend_allowed", nullable = false)
-    private Boolean isFriendAllowed;
+    private Boolean isFriendAllowed = true;
 
+    @Builder.Default
     @Column(name = "is_couple_allowed", nullable = false)
-    private Boolean isCoupleAllowed;
+    private Boolean isCoupleAllowed = true;
 
+    @Builder.Default
     @Column(name = "is_meal_friend_allowed", nullable = false)
-    private Boolean isMealFriendAllowed;
+    private Boolean isMealFriendAllowed = true;
 
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private UserOauth userOauth;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/entity/UserOauth.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/entity/UserOauth.java
@@ -21,7 +21,7 @@ public class UserOauth {
     @JoinColumn(name = "user_id", nullable = false, unique = true)
     private User user;
 
-    @Column(name = "provider_id", nullable = false)
+    @Column(name = "provider_id", nullable = false, unique = true)
     private String providerId;
 
     @Column(nullable = false, length = 10)

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/service/UserService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/service/UserService.java
@@ -16,6 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 
 @Service
@@ -42,6 +43,9 @@ public class UserService {
 
         String refreshTokenValue = redisValue.split(",")[0];
         LocalDateTime refreshTokenExpiredAt = LocalDateTime.parse(redisValue.split(",")[1]);
+        // 현재 시간과 refreshToken의 만료 일시까지를 계산 (cookie 만료 시간 설정 시 만료일자를 정할 수 없기 때문)
+        long secondsUntilExpiry = Duration.between(LocalDateTime.now(), refreshTokenExpiredAt).getSeconds();
+        int maxAge = (int) Math.max(0, secondsUntilExpiry);
 
         User user = User.builder()
                 .ageGroup(userInfoRequestDto.getAgeGroup())
@@ -68,6 +72,7 @@ public class UserService {
                 .userId(savedUser.getId())
                 .accessToken((String) request.getAttribute("accessToken"))
                 .refreshToken(refreshTokenValue)
+                .refreshSecondsUntilExpiry(maxAge)
                 .build();
 
     }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/auth/filter/JwtAuthenticationFilter.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/auth/filter/JwtAuthenticationFilter.java
@@ -38,6 +38,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     new UsernamePasswordAuthenticationToken(userId, null, Collections.emptyList());
 
             SecurityContextHolder.getContext().setAuthentication(authentication);
+            request.setAttribute("accessToken", token);
         }
 
         filterChain.doFilter(request, response);

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseCode.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseCode.java
@@ -25,6 +25,7 @@ public class ResponseCode {
     public static final String DUPLICATE_NICKNAME = "DUPLICATE_NICKNAME";
     public static final String NICKNAME_CREATED = "NICKNAME_CREATED";
     public static final String NICKNAME_API_FAILED = "NICKNAME_API_FAILED";
+    public static final String NICKNAME_GENERATION_TIMEOUT = "NICKNAME_GENERATION_TIMEOUT";
 
     // 취향 선택 응답 code
     public static final String INTERESTS_SAVED_SUCCESSFULLY = "INTERESTS_SAVED_SUCCESSFULLY";


### PR DESCRIPTION
## 🔗 관련 이슈
- #5 

## ✏️ 변경 사항
- API 내 Redis/refreshToken 로직 추가
- accessToken은 body로 반환, refreshToken은 Cookie로 반환하도록 수정
- User entity 및 DTO 관련 오류로 인한 타입 수정

## 📋 상세 설명
- API 내에서 Redis 내의 refreshToken을 받아오는 로직을 추가했습니다.
- header를 통해 받아온 accessToken을 다시 body로 넣어주는 작업을 추가했습니다.
- cookie내 refreshToken 만료 기간 설정 시 계산하는 과정을 추가했습니다.

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 이상한 부분 있으면 말씀 부탁드려요!

## 📎 참고 자료 (선택)
- 
