### PR TITLE
[#22] Feat: JWT 비밀키 환경 변수 설정으로 외부화

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/SignalMessage.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/SignalMessage.java
@@ -10,7 +10,6 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "signal_message")
 @Getter
-@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -32,7 +31,7 @@ public class SignalMessage {
     private String message;
 
     @Column(name = "is_read", nullable = false)
-    private Boolean isRead = false;
+    private Boolean isRead;
 
     @CreationTimestamp
     @Column(name = "send_at", nullable = false)

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/auth/token/JwtTokenProvider.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/auth/token/JwtTokenProvider.java
@@ -2,21 +2,29 @@ package com.hertz.hertz_be.global.auth.token;
 
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
 import org.springframework.stereotype.Component;
+import org.springframework.beans.factory.annotation.Value;
 
 import java.security.Key;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Base64;
 import java.util.Date;
 
 @Component
 public class JwtTokenProvider {
 
-    private final Key key;
+    @Value("${jwt.secret}")
+    private String secretKeyBase64;
 
-    public JwtTokenProvider() {
-        this.key = Keys.secretKeyFor(SignatureAlgorithm.HS256);
-    } // TODO: 추후에 비밀키로 관리할 것
+    private Key key;
+
+    @PostConstruct
+    public void init() {
+        byte[] decodedKey = Base64.getDecoder().decode(secretKeyBase64);
+        this.key = Keys.hmacShaKeyFor(decodedKey);
+    }
 
     public String createAccessToken(Long userId) {
         Date now = new Date();

--- a/hertz-be/src/main/resources/application.properties
+++ b/hertz-be/src/main/resources/application.properties
@@ -33,3 +33,6 @@ oauth.kakao.redirect-uri=${REDIRECT_URL}
 logging.level.root=INFO
 logging.level.org.springframework=INFO
 logging.level.com.hertz=DEBUG
+
+# JWT secret key
+jwt.secret=${JWT_SECRET}


### PR DESCRIPTION
## 🔗 관련 이슈
- #22 

## ✏️ 변경 사항
- JWT 비밀키를 코드 내 고정 생성 방식에서 외부 설정 방식으로 변경
- application.properties 또는 환경변수에서 비밀키 주입받도록 구현

## 📋 상세 설명
- 기존에는 `JwtTokenProvider`에서 서버 실행 시마다 새로운 비밀키를 생성하고 있었습니다.
  ```java
  this.key = Keys.secretKeyFor(SignatureAlgorithm.HS256);
- 이로 인해 서버 재시작 시 이전에 발급된 토큰이 모두 무효화되는 문제가 있었습니다.
- 이를 해결하기 위해 @Value("${jwt.secret}")를 통해 Base64 인코딩된 비밀키를 외부에서 주입받도록 수정하였고,
@PostConstruct에서 디코딩 후 Key 객체로 변환하는 로직을 추가했습니다.
- 비밀키는 application.properties, application.yml, 또는 .env 파일에서 관리할 수 있으며,
운영 환경에서는 환경변수 JWT_SECRET으로 설정하면 됩니다.

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 문서 또는 관련 설정을 수정했습니다. (필요 시)

##🆕 ENV 템플릿 업데이트
```
# MySQL 접속 정보
DB_HOST=database_host
DB_PORT=database_port
DB_NAME=your_database_name
DB_USERNAME=your_database_username
DB_PASSWORD=your_database_password

# Swagger 설정 (배포 환경에서는 사용 x)
SWAGGER_ENABLED=true

# Redis
REDIS_HOST=redis_host
REDIS_PORT=redis_port
REDIS_PASSWORD=redis_password

# Kakao
KAKAO_CLIENT_ID=kakao_key
REDIRECT_URL=hertz-tuning.com/onboarding/information

# JWT secret key
JWT_SECRET=jwt_secret_key
```

