### PR TITLE
[#24] Feat: api tuning match dummy

### DIFF
--- a/hertz-be/build.gradle
+++ b/hertz-be/build.gradle
@@ -28,11 +28,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'com.giffing.bucket4j.spring.boot.starter:bucket4j-spring-boot-starter:0.9.0'
 
-
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
@@ -41,7 +40,6 @@ dependencies {
 	testImplementation 'io.projectreactor:reactor-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'me.paulschwarz:spring-dotenv:4.0.0'
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/ChannelController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/ChannelController.java
@@ -3,6 +3,7 @@ package com.hertz.hertz_be.domain.channel.controller;
 
 import com.hertz.hertz_be.domain.channel.dto.request.SendSignalRequestDTO;
 import com.hertz.hertz_be.domain.channel.dto.response.SendSignalResponseDTO;
+import com.hertz.hertz_be.domain.channel.dto.response.TuningResponseDTO;
 import com.hertz.hertz_be.domain.channel.service.ChannelService;
 import com.hertz.hertz_be.global.auth.token.JwtTokenProvider;
 import com.hertz.hertz_be.global.common.ResponseCode;
@@ -20,7 +21,6 @@ import org.springframework.web.bind.annotation.*;
 public class ChannelController {
 
     private final ChannelService channelService;
-    private final JwtTokenProvider jwtTokenProvider;
 
     @PostMapping("/v1/tuning/signal")
     public ResponseEntity<ResponseDto<SendSignalResponseDTO>> sendSignal(
@@ -28,6 +28,14 @@ public class ChannelController {
         SendSignalResponseDTO response = channelService.sendSignal(userId, requestDTO);
         return ResponseEntity.status(201).body(
                 new ResponseDto<>(ResponseCode.SIGNAL_ROOM_CREATED, "시그널 룸이 성공적으로 생성되었습니다.", response)
+        );
+    }
+
+    @GetMapping("/v1/tuning")
+    public ResponseEntity<ResponseDto<TuningResponseDTO>> getTunedUser(@AuthenticationPrincipal Long userId) {
+        TuningResponseDTO response = channelService.getTunedUser(userId);
+        return ResponseEntity.ok(
+                new ResponseDto<>(ResponseCode.TUNING_SUCCESS, "튜닝된 사용자가 정상적으로 조회되었습니다.", response)
         );
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/TuningResponseDTO.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/TuningResponseDTO.java
@@ -1,0 +1,19 @@
+package com.hertz.hertz_be.domain.channel.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@AllArgsConstructor
+public class TuningResponseDTO {
+    private Long userId;
+    private String profileImage;
+    private String nickname;
+    private String gender;
+    private String oneLineIntroduction;
+    private Map<String, String> keywords;
+    private Map<String, List<String>> sameInterests;
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/ChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/ChannelService.java
@@ -1,5 +1,6 @@
 package com.hertz.hertz_be.domain.channel.service;
 
+import com.hertz.hertz_be.domain.channel.dto.response.TuningResponseDTO;
 import com.hertz.hertz_be.domain.channel.entity.SignalMessage;
 import com.hertz.hertz_be.domain.channel.entity.SignalRoom;
 import com.hertz.hertz_be.domain.channel.entity.enums.Category;
@@ -15,6 +16,9 @@ import com.hertz.hertz_be.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -55,5 +59,31 @@ public class ChannelService {
         signalMessageRepository.save(signalMessage);
 
         return new SendSignalResponseDTO(signalRoom.getId());
+    }
+
+    public TuningResponseDTO getTunedUser(Long userId) {
+        return new TuningResponseDTO(
+                2L,
+                "../image/profile.jpg",
+                "행복한 개구리",
+                "남성",
+                "안녕하세요, 프론트엔드 개발자입니다.",
+                Map.of(
+                        "MBTI", "ESTP",
+                        "religion", "NON_RELIGIOUS",
+                        "smoking", "NO_SMOKING",
+                        "drinking", "SOMETIMES"
+                ),
+                Map.of(
+                        "personality", List.of(),
+                        "preferredPeople", List.of("DOESNT_SWEAR"),
+                        "currentInterests", List.of(),
+                        "favoriteFoods", List.of("STREET_FOOD"),
+                        "likedSports", List.of("YOGA"),
+                        "pets", List.of("RABBIT"),
+                        "selfDevelopment", List.of("DIET"),
+                        "hobbies", List.of("GAMING")
+                )
+        );
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseCode.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseCode.java
@@ -35,5 +35,6 @@ public class ResponseCode {
     public static final String SIGNAL_ROOM_CREATED = "SIGNAL_ROOM_CREATED";
     public static final String USER_DEACTIVATED = "USER_DEACTIVATED";
     public static final String ALREADY_IN_CONVERSATION = "ALREADY_IN_CONVERSATION";
+    public static final String TUNING_SUCCESS = "TUNING_SUCCESS";
 
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/config/SecurityConfig.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/config/SecurityConfig.java
@@ -40,7 +40,15 @@ public class SecurityConfig {
                         .authenticationEntryPoint(customAuthenticationEntryPoint)
                 )
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/**").permitAll() // TODO: 추후에 수정
+                        .requestMatchers(
+                                "/api/**",
+                                "/swagger-ui.html",
+                                "/swagger-ui/**",
+                                "/v3/api-docs",
+                                "/v3/api-docs/**",
+                                "/swagger-resources/**",
+                                "/webjars/**"
+                        ).permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
@@ -50,13 +58,13 @@ public class SecurityConfig {
     @Bean
     protected CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration corsConfiguration = new CorsConfiguration();
-        corsConfiguration.setAllowedOriginPatterns(List.of("http://localhost:3000","https://hertz-tuning.com"));
+        corsConfiguration.setAllowedOriginPatterns(List.of("http://localhost:3000", "https://hertz-tuning.com"));
         corsConfiguration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         corsConfiguration.setAllowedHeaders(List.of("*"));
         corsConfiguration.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", corsConfiguration); // TODO: 임시로 모든 경로에 적용 추후에 수정
+        source.registerCorsConfiguration("/**", corsConfiguration);
 
         return source;
     }


### PR DESCRIPTION
## 🔗 관련 이슈
- #24 

## ✏️ 변경 사항
- GET `/api/v1/tuning` API 엔드포인트 추가
- 임시 더미 데이터를 반환하는 서비스 로직 구현
- `TuningResponseDTO`, `TuningService`, `TuningController` 생성
- 공통 응답 포맷(`ResponseDto`) 기반으로 응답 구성

## 📋 상세 설명
AI 기반의 튜닝 상대 추천 시스템이 아직 완성되지 않아, 프론트엔드 UI 개발을 위한 더미 데이터 기반 API를 임시로 구현했습니다.  
이번 PR의 목적은 실제 AI 서버 응답을 가정한 JSON 데이터를 반환함으로써 프론트에서 화면 흐름과 컴포넌트 개발을 원활히 진행할 수 있도록 하는 것입니다.

- `@AuthenticationPrincipal Long userId`를 통해 사용자 인증 정보를 받습니다.
- 서비스 계층에서 더미 데이터를 반환하며, 실제 AI 서버 연동 시 해당 로직은 교체될 예정입니다.
- API 응답 구조는 실제 응답 포맷과 최대한 유사하게 구성되어 향후 변경 작업이 최소화되도록 설계했습니다.

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (Swagger 연동 등 필요 시 예정)

## API 테스트 결과
1. 요청 성공

<img src="https://github.com/user-attachments/assets/08448bf4-717c-4e86-a9d3-014389b393fb" width="400" />

<img src="https://github.com/user-attachments/assets/d1421e29-b8f8-4507-8fec-cc51371bc6dd" width="400" />
