### PR TITLE
[#26] Feat: 채널방 새 메시지 여부 조회 API 구현

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/exception/OAuthStateInvalidException.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/exception/OAuthStateInvalidException.java
@@ -2,6 +2,9 @@ package com.hertz.hertz_be.domain.auth.exception;
 
 import com.hertz.hertz_be.global.common.ResponseCode;
 
+import lombok.Getter;
+
+@Getter
 public class OAuthStateInvalidException extends BaseAuthException{
     private static final String DEFAULT_MESSAGE = "잘못된 인증 요청입니다. 다시 로그인해주세요.";
     private final String code;
@@ -9,9 +12,5 @@ public class OAuthStateInvalidException extends BaseAuthException{
     public OAuthStateInvalidException() {
         super(DEFAULT_MESSAGE);
         this.code = ResponseCode.OAUTH_STATE_INVALID;
-    }
-
-    public String getCode() {
-        return code;
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/exception/ProviderInvalidException.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/exception/ProviderInvalidException.java
@@ -1,7 +1,9 @@
 package com.hertz.hertz_be.domain.auth.exception;
 
 import com.hertz.hertz_be.global.common.ResponseCode;
+import lombok.Getter;
 
+@Getter
 public class ProviderInvalidException extends BaseAuthException{
     private static final String DEFAULT_MESSAGE = "지원하지 않는 OAuth provider입니다.";
     private final String code;
@@ -9,9 +11,5 @@ public class ProviderInvalidException extends BaseAuthException{
     public ProviderInvalidException() {
         super(DEFAULT_MESSAGE);
         this.code = ResponseCode.UNSUPPORTED_PROVIDER;
-    }
-
-    public String getCode() {
-        return code;
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/exception/RateLimitException.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/exception/RateLimitException.java
@@ -1,7 +1,9 @@
 package com.hertz.hertz_be.domain.auth.exception;
 
 import com.hertz.hertz_be.global.common.ResponseCode;
+import lombok.Getter;
 
+@Getter
 public class RateLimitException extends BaseAuthException{
     private static final String DEFAULT_MESSAGE = "로그인 요청 제한(Rate Limit)에 걸렸습니다. 잠시 후 다시 시도해주세요.";
     private final String code;
@@ -11,7 +13,4 @@ public class RateLimitException extends BaseAuthException{
         this.code = ResponseCode.RATE_LIMIT;
     }
 
-    public String getCode() {
-        return code;
-    }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/exception/RefreshTokenInvalidException.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/exception/RefreshTokenInvalidException.java
@@ -1,7 +1,9 @@
 package com.hertz.hertz_be.domain.auth.exception;
 
 import com.hertz.hertz_be.global.common.ResponseCode;
+import lombok.Getter;
 
+@Getter
 public class RefreshTokenInvalidException extends BaseAuthException {
 
     private static final String DEFAULT_MESSAGE = "Refresh Token이 유효하지 않거나 만료되었습니다. 다시 로그인 해주세요.";
@@ -12,7 +14,4 @@ public class RefreshTokenInvalidException extends BaseAuthException {
         this.code = ResponseCode.REFRESH_TOKEN_INVALID;
     }
 
-    public String getCode() {
-        return code;
-    }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/ChannelController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/ChannelController.java
@@ -38,4 +38,19 @@ public class ChannelController {
                 new ResponseDto<>(ResponseCode.TUNING_SUCCESS, "튜닝된 사용자가 정상적으로 조회되었습니다.", response)
         );
     }
+
+    @GetMapping("/v1/new-messages")
+    public ResponseEntity<ResponseDto<Void>> checkNewMessages(@AuthenticationPrincipal Long userId) {
+        boolean hasNewMessage = channelService.hasNewMessages(userId);
+
+        if (hasNewMessage) {
+            return ResponseEntity.ok(
+                    new ResponseDto<>(ResponseCode.NEW_MESSAGE, "새 메시지가 정상적으로 조회되었습니다.", null)
+            );
+        } else {
+            return ResponseEntity.ok(
+                    new ResponseDto<>(ResponseCode.NO_ANY_NEW_MESSAGE, "새 메시지가 없습니다.", null)
+            );
+        }
+    }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/exception/AlreadyInConversationException.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/exception/AlreadyInConversationException.java
@@ -1,7 +1,9 @@
 package com.hertz.hertz_be.domain.channel.exception;
 
 import com.hertz.hertz_be.global.common.ResponseCode;
+import lombok.Getter;
 
+@Getter
 public class AlreadyInConversationException extends BaseChannelException{
     private static final String DEFAULT_MESSAGE = "이미 대화 중인 상대방입니다.";
     private final String code;
@@ -11,7 +13,4 @@ public class AlreadyInConversationException extends BaseChannelException{
         this.code = ResponseCode.ALREADY_IN_CONVERSATION;
     }
 
-    public String getCode() {
-        return code;
-    }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/exception/UserWithdrawnException.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/exception/UserWithdrawnException.java
@@ -2,7 +2,9 @@ package com.hertz.hertz_be.domain.channel.exception;
 
 import com.hertz.hertz_be.domain.auth.exception.BaseAuthException;
 import com.hertz.hertz_be.global.common.ResponseCode;
+import lombok.Getter;
 
+@Getter
 public class UserWithdrawnException extends BaseChannelException{
     private static final String DEFAULT_MESSAGE = "상대방이 탈퇴한 사용자입니다.";
     private final String code;
@@ -10,9 +12,5 @@ public class UserWithdrawnException extends BaseChannelException{
     public UserWithdrawnException() {
         super(DEFAULT_MESSAGE);
         this.code = ResponseCode.USER_DEACTIVATED;
-    }
-
-    public String getCode() {
-        return code;
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/SignalMessageRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/SignalMessageRepository.java
@@ -1,7 +1,13 @@
 package com.hertz.hertz_be.domain.channel.repository;
 
 import com.hertz.hertz_be.domain.channel.entity.SignalMessage;
+import com.hertz.hertz_be.domain.channel.entity.SignalRoom;
+import com.hertz.hertz_be.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface SignalMessageRepository extends JpaRepository<SignalMessage, Long> {
+    boolean existsBySignalRoomIdInAndSenderUserIdNotAndIsReadFalse(List<SignalRoom> signalRooms, User senderUser);
+
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/ChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/ChannelService.java
@@ -13,12 +13,15 @@ import com.hertz.hertz_be.domain.channel.repository.SignalRoomRepository;
 import com.hertz.hertz_be.domain.channel.repository.SignalMessageRepository;
 import com.hertz.hertz_be.domain.user.entity.User;
 import com.hertz.hertz_be.domain.user.repository.UserRepository;
+import com.hertz.hertz_be.global.exception.InternalServerErrorException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -85,5 +88,20 @@ public class ChannelService {
                         "hobbies", List.of("GAMING")
                 )
         );
+    }
+
+    @Transactional(readOnly = true)
+    public boolean hasNewMessages(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(InternalServerErrorException::new);
+
+        List<SignalRoom> allRooms = Stream.concat(
+                user.getSentSignalRooms().stream(),
+                user.getReceivedSignalRooms().stream()
+        ).collect(Collectors.toList());
+
+        if (allRooms.isEmpty()) return false;
+
+        return signalMessageRepository.existsBySignalRoomIdInAndSenderUserIdNotAndIsReadFalse(allRooms, user);
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/ChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/ChannelService.java
@@ -34,7 +34,7 @@ public class ChannelService {
     @Transactional
     public SendSignalResponseDTO sendSignal(Long senderUserId, SendSignalRequestDTO dto) {
         User sender = userRepository.findById(senderUserId)
-                .orElseThrow();
+                .orElseThrow(InternalServerErrorException::new);
 
         User receiver = userRepository.findById(dto.getReceiverUserId())
                 .orElseThrow(UserWithdrawnException::new);

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseCode.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseCode.java
@@ -8,6 +8,7 @@ public class ResponseCode {
     public static final String BAD_REQUEST = "BAD_REQUEST";
     public static final String INTERNAL_ERROR = "INTERNAL_SERVER_ERROR";
     public static final String NOT_IMPLEMENTED = "NOT_IMPLEMENTED";
+    public static final String INTERNAL_SERVER_ERROR = "INTERNAL_SERVER_ERROR";
 
     // OAuth 관련 응답 code
     public static final String UNSUPPORTED_PROVIDER = "UNSUPPORTED_PROVIDER";
@@ -31,10 +32,12 @@ public class ResponseCode {
     public static final String INTERESTS_SAVED_SUCCESSFULLY = "INTERESTS_SAVED_SUCCESSFULLY";
     public static final String EMPTY_LIST_NOT_ALLOWED = "EMPTY_LIST_NOT_ALLOWED";
 
-    //시그널 관련 응답 code
+    //채널의 시그널 관련 응답 code
     public static final String SIGNAL_ROOM_CREATED = "SIGNAL_ROOM_CREATED";
     public static final String USER_DEACTIVATED = "USER_DEACTIVATED";
     public static final String ALREADY_IN_CONVERSATION = "ALREADY_IN_CONVERSATION";
     public static final String TUNING_SUCCESS = "TUNING_SUCCESS";
+    public static final String NEW_MESSAGE = "NEW_MESSAGE";
+    public static final String NO_ANY_NEW_MESSAGE = "NO_ANY_NEW_MESSAGE";
 
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/exception/GlobalExceptionHandler.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/exception/GlobalExceptionHandler.java
@@ -45,4 +45,15 @@ public class GlobalExceptionHandler {
                 .status(HttpStatus.BAD_REQUEST)
                 .body(new ResponseDto<>(ResponseCode.BAD_REQUEST, "잘못된 요청입니다.", null));
     }
+
+    @ExceptionHandler(InternalServerErrorException.class)
+    public ResponseEntity<ResponseDto<Void>> handleInternalServerError(InternalServerErrorException ex) {
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ResponseDto<>(
+                        ex.getCode(),
+                        ex.getMessage(),
+                        null
+                ));
+    }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/exception/InternalServerErrorException.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/exception/InternalServerErrorException.java
@@ -1,0 +1,16 @@
+package com.hertz.hertz_be.global.exception;
+
+
+import com.hertz.hertz_be.global.common.ResponseCode;
+
+public class InternalServerErrorException extends RuntimeException {
+    private static final String DEFAULT_MESSAGE = "내부 서버에서 오류가 발생했습니다.";
+    private final String code;
+
+    public InternalServerErrorException() {
+        super(DEFAULT_MESSAGE);
+        this.code = ResponseCode.INTERNAL_SERVER_ERROR;
+    }
+
+    public String getCode() { return code;}
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/exception/InternalServerErrorException.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/exception/InternalServerErrorException.java
@@ -2,7 +2,9 @@ package com.hertz.hertz_be.global.exception;
 
 
 import com.hertz.hertz_be.global.common.ResponseCode;
+import lombok.Getter;
 
+@Getter
 public class InternalServerErrorException extends RuntimeException {
     private static final String DEFAULT_MESSAGE = "내부 서버에서 오류가 발생했습니다.";
     private final String code;
@@ -12,5 +14,4 @@ public class InternalServerErrorException extends RuntimeException {
         this.code = ResponseCode.INTERNAL_SERVER_ERROR;
     }
 
-    public String getCode() { return code;}
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- #26 

## ✏️ 변경 사항
- GET /api/v1/new-messages API 구현
- SignalRoom, SignalMessage 관계 기반으로 새 메시지 존재 여부 확인 로직 추가

## 📋 상세 설명
- 사용자가 참여한 SignalRoom 중, 본인이 보낸 메시지를 제외하고 읽지 않은 메시지가 하나라도 존재하는지 확인하는 API입니다.
- SignalMessage의 senderUserId 필드가 User 타입이므로, existsBy 쿼리 메서드에서 User 엔티티를 직접 비교하도록 구현했습니다.

### 🔍 주요 흐름
1. 현재 로그인한 사용자의 `sentSignalRooms`와 `receivedSignalRooms`를 모두 가져와 병합
2. 해당 SignalRoom 리스트에 대해 `isRead = false` && `senderUser != 현재 유저` 조건을 만족하는 메시지 존재 여부 확인
3. 결과에 따라 다음 응답 반환:
    - NEW_MESSAGE / NO_ANY_NEW_MESSAGE

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 응답 예시
1. 새 메세지가 있을 경우
<img width="891" alt="스크린샷 2025-05-04 오후 4 09 02" src="https://github.com/user-attachments/assets/ca247501-652e-4e6f-822c-a25e8822a386" />

2. 새 메세지가 없을 경우
<img width="856" alt="스크린샷 2025-05-04 오후 4 09 18" src="https://github.com/user-attachments/assets/df8c64ef-d0ea-44b0-b2a3-c123c5c5fbe0" />
