### PR TITLE
[#29] Feat: 개인 채널보관함 목록 반환 API

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/ChannelController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/ChannelController.java
@@ -2,6 +2,7 @@ package com.hertz.hertz_be.domain.channel.controller;
 
 
 import com.hertz.hertz_be.domain.channel.dto.request.SendSignalRequestDTO;
+import com.hertz.hertz_be.domain.channel.dto.response.ChannelListResponseDto;
 import com.hertz.hertz_be.domain.channel.dto.response.SendSignalResponseDTO;
 import com.hertz.hertz_be.domain.channel.dto.response.TuningResponseDTO;
 import com.hertz.hertz_be.domain.channel.service.ChannelService;
@@ -52,5 +53,25 @@ public class ChannelController {
                     new ResponseDto<>(ResponseCode.NO_ANY_NEW_MESSAGE, "새 메시지가 없습니다.", null)
             );
         }
+    }
+
+    @GetMapping("/v1/channel")
+    public ResponseEntity<ResponseDto<ChannelListResponseDto>> getPersonalChannelList(@AuthenticationPrincipal Long userId,
+                                                                                      @RequestParam(defaultValue = "0") int page,
+                                                                                      @RequestParam(defaultValue = "10") int size) {
+        ChannelListResponseDto response = channelService.getPersonalChannelList(userId, page, size);
+
+        if(response == null) {
+            return ResponseEntity.ok(
+                    new ResponseDto<>(ResponseCode.CHANNEL_ROOM_LIST_FETCHED, "채널방 목록이 정상적으로 조회되었습니다.", response)
+            );
+        } else {
+            return ResponseEntity.ok(
+                    new ResponseDto<>(ResponseCode.NO_CHANNEL_ROOM, "참여 중인 채널이 없습니다.", response)
+            );
+        }
+
+
+
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/ChannelListResponseDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/ChannelListResponseDto.java
@@ -1,0 +1,15 @@
+package com.hertz.hertz_be.domain.channel.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ChannelListResponseDto {
+    private List<ChannelSummaryDto> list;
+    private int pageNumber;
+    private int pageSize;
+    private boolean isLast;
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/ChannelSummaryDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/ChannelSummaryDto.java
@@ -1,0 +1,31 @@
+package com.hertz.hertz_be.domain.channel.dto.response;
+
+import com.hertz.hertz_be.domain.channel.repository.projection.ChannelRoomProjection;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class ChannelSummaryDto {
+    private Long channelRoomId;
+    private String partnerProfileImage;
+    private String partnerNickname;
+    private String lastMessage;
+    private LocalDateTime lastMessageTime;
+    private boolean isRead;
+    private String relationType;
+
+    public static ChannelSummaryDto fromProjection(ChannelRoomProjection p) {
+        return new ChannelSummaryDto(
+                p.getChannelRoomId(),
+                p.getPartnerProfileImage(),
+                p.getPartnerNickname(),
+                p.getLastMessage(),
+                p.getLastMessageTime(),
+                p.getIsRead(),
+                p.getRelationType()
+        );
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/ChannelJoin.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/ChannelJoin.java
@@ -1,0 +1,23 @@
+package com.hertz.hertz_be.domain.channel.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "channel_join")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChannelJoin {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "channel_room_id", nullable = false)
+    private Long channelRoomId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/ChannelMessage.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/ChannelMessage.java
@@ -1,0 +1,31 @@
+package com.hertz.hertz_be.domain.channel.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "channel_message")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChannelMessage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "channel_room_id", nullable = false)
+    private Long channelRoomId;
+
+    @Column(name = "sender_user_id", nullable = false)
+    private Long senderUserId;
+
+    @Column(name = "message", nullable = false, length = 300)
+    private String message;
+
+    @Column(name = "send_at", nullable = false)
+    private LocalDateTime sendAt;
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/ChannelMessageLastRead.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/ChannelMessageLastRead.java
@@ -1,0 +1,31 @@
+package com.hertz.hertz_be.domain.channel.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "channel_message_last_read")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChannelMessageLastRead {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "channel_id", nullable = false)
+    private Long channelId;
+
+    @Column(name = "last_message_read_id", nullable = false)
+    private Long lastMessageReadId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "last_read_at", nullable = false)
+    private LocalDateTime lastReadAt;
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/ChannelRoom.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/ChannelRoom.java
@@ -1,0 +1,43 @@
+package com.hertz.hertz_be.domain.channel.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "channel_room")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChannelRoom {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 10)
+    private String category;
+
+    @Column(name = "channel_name", length = 20)
+    private String channelName;
+
+    @Column(name = "channel_content", length = 100)
+    private String channelContent;
+
+    @Column(name = "current_user_count", nullable = false)
+    private int currentUserCount;
+
+    @Column(name = "max_user_count", nullable = false)
+    private int maxUserCount;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "modified_at", nullable = false)
+    private LocalDateTime modifiedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/projection/ChannelRoomProjection.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/projection/ChannelRoomProjection.java
@@ -1,0 +1,13 @@
+package com.hertz.hertz_be.domain.channel.repository.projection;
+
+import java.time.LocalDateTime;
+
+public interface ChannelRoomProjection {
+    Long getChannelRoomId();
+    String getPartnerNickname();
+    String getPartnerProfileImage();
+    String getLastMessage();
+    LocalDateTime getLastMessageTime();
+    Boolean getIsRead();
+    String getRelationType();
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseCode.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseCode.java
@@ -40,4 +40,8 @@ public class ResponseCode {
     public static final String NEW_MESSAGE = "NEW_MESSAGE";
     public static final String NO_ANY_NEW_MESSAGE = "NO_ANY_NEW_MESSAGE";
 
+    // 채널 정보 관련 응답 code
+    public static final String CHANNEL_ROOM_LIST_FETCHED = "CHANNEL_ROOM_LIST_FETCHED";
+    public static final String NO_CHANNEL_ROOM = "NO_CHANNEL_ROOM";
+
 }


### PR DESCRIPTION
## 🔗 관련 이슈  
- #29

## ✏️ 변경 사항  
- `ChannelRoomProjection` 인터페이스 기반 Projection 적용  
- `ChannelSummaryDto.fromProjection()` 메서드 구현  
- `User` 엔티티에서 `@Setter` 제거, 대신 연관관계 설정용 메서드(`registerUserOauth`) 추가  

## 📋 상세 설명  
- 개인 채널보관함 목록을 효율적으로 조회하기 위해 **interface 기반 Projection**을 적용했습니다.  
- 엔티티 전체가 아닌 필요한 필드만 조회하도록 하여 성능을 최적화했습니다.  
- `ChannelSummaryDto`에서 `ChannelRoomProjection`을 활용한 `fromProjection()` 메서드를 통해 Projection → DTO 매핑을 처리했습니다.  
- `User` 엔티티의 `userOauth` 필드에 대해 setter를 제거하면서, 연관관계를 안전하게 맺기 위한 `registerUserOauth()` 메서드를 추가했습니다.

## ✅ 체크리스트  
- [x] 기능이 정상적으로 동작하는지 확인했습니다.  
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.  
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항  
- Projection 방식이 적절하게 사용되었는지 확인해주시면 감사하겠습니다.
- `User`와 `UserOauth` 간 연관관계 설정 방식이 객체지향적으로 잘 정리되었는지 검토 부탁드립니다.

## 📎 참고 자료 (선택)  
- 