### PR TITLE
[#34] 개인 채널보관함 목록 반환 API 리팩터링

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/ChannelController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/ChannelController.java
@@ -2,6 +2,7 @@ package com.hertz.hertz_be.domain.channel.controller;
 
 
 import com.hertz.hertz_be.domain.channel.dto.request.SendSignalRequestDTO;
+import com.hertz.hertz_be.domain.channel.dto.response.ChannelListResponseDto;
 import com.hertz.hertz_be.domain.channel.dto.response.SendSignalResponseDTO;
 import com.hertz.hertz_be.domain.channel.dto.response.TuningResponseDTO;
 import com.hertz.hertz_be.domain.channel.service.ChannelService;
@@ -52,5 +53,25 @@ public class ChannelController {
                     new ResponseDto<>(ResponseCode.NO_ANY_NEW_MESSAGE, "새 메시지가 없습니다.", null)
             );
         }
+    }
+
+    @GetMapping("/v1/channel")
+    public ResponseEntity<ResponseDto<ChannelListResponseDto>> getPersonalChannelList(@AuthenticationPrincipal Long userId,
+                                                                                      @RequestParam(defaultValue = "0") int page,
+                                                                                      @RequestParam(defaultValue = "10") int size) {
+        ChannelListResponseDto response = channelService.getPersonalChannelList(userId, page, size);
+
+        if(response == null) {
+            return ResponseEntity.ok(
+                    new ResponseDto<>(ResponseCode.CHANNEL_ROOM_LIST_FETCHED, "채널방 목록이 정상적으로 조회되었습니다.", response)
+            );
+        } else {
+            return ResponseEntity.ok(
+                    new ResponseDto<>(ResponseCode.NO_CHANNEL_ROOM, "참여 중인 채널이 없습니다.", response)
+            );
+        }
+
+
+
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/ChannelController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/ChannelController.java
@@ -1,15 +1,12 @@
 package com.hertz.hertz_be.domain.channel.controller;
 
-
 import com.hertz.hertz_be.domain.channel.dto.request.SendSignalRequestDTO;
 import com.hertz.hertz_be.domain.channel.dto.response.ChannelListResponseDto;
 import com.hertz.hertz_be.domain.channel.dto.response.SendSignalResponseDTO;
 import com.hertz.hertz_be.domain.channel.dto.response.TuningResponseDTO;
 import com.hertz.hertz_be.domain.channel.service.ChannelService;
-import com.hertz.hertz_be.global.auth.token.JwtTokenProvider;
 import com.hertz.hertz_be.global.common.ResponseCode;
 import com.hertz.hertz_be.global.common.ResponseDto;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -30,6 +27,7 @@ public class ChannelController {
         return ResponseEntity.status(201).body(
                 new ResponseDto<>(ResponseCode.SIGNAL_ROOM_CREATED, "시그널 룸이 성공적으로 생성되었습니다.", response)
         );
+
     }
 
     @GetMapping("/v1/tuning")
@@ -56,22 +54,17 @@ public class ChannelController {
     }
 
     @GetMapping("/v1/channel")
-    public ResponseEntity<ResponseDto<ChannelListResponseDto>> getPersonalChannelList(@AuthenticationPrincipal Long userId,
-                                                                                      @RequestParam(defaultValue = "0") int page,
-                                                                                      @RequestParam(defaultValue = "10") int size) {
-        ChannelListResponseDto response = channelService.getPersonalChannelList(userId, page, size);
+    public ResponseEntity<ResponseDto<ChannelListResponseDto>> getPersonalSignalRoomList(@AuthenticationPrincipal Long userId,
+                                                                                         @RequestParam(defaultValue = "0") int page,
+                                                                                         @RequestParam(defaultValue = "10") int size) {
 
-        if(response == null) {
-            return ResponseEntity.ok(
-                    new ResponseDto<>(ResponseCode.CHANNEL_ROOM_LIST_FETCHED, "채널방 목록이 정상적으로 조회되었습니다.", response)
-            );
-        } else {
-            return ResponseEntity.ok(
-                    new ResponseDto<>(ResponseCode.NO_CHANNEL_ROOM, "참여 중인 채널이 없습니다.", response)
-            );
+        // Todo: 추후 시그널 -> 채널로 마이그레이션 시 메소드명 변경 필요 (getPersonalSignalRoomList -> getPersonalChannelList)
+        ChannelListResponseDto response = channelService.getPersonalSignalRoomList(userId, page, size);
+
+        if (response == null) {
+            return ResponseEntity.ok(new ResponseDto<>(ResponseCode.NO_CHANNEL_ROOM, "참여 중인 채널이 없습니다.", null));
         }
-
-
-
+        return ResponseEntity.ok(new ResponseDto<>(ResponseCode.CHANNEL_ROOM_LIST_FETCHED, "채널방 목록이 정상적으로 조회되었습니다.", response));
     }
+
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/ChannelListResponseDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/ChannelListResponseDto.java
@@ -1,0 +1,15 @@
+package com.hertz.hertz_be.domain.channel.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ChannelListResponseDto {
+    private List<ChannelSummaryDto> list;
+    private int pageNumber;
+    private int pageSize;
+    private boolean isLast;
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/ChannelSummaryDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/ChannelSummaryDto.java
@@ -1,0 +1,31 @@
+package com.hertz.hertz_be.domain.channel.dto.response;
+
+import com.hertz.hertz_be.domain.channel.repository.projection.ChannelRoomProjection;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class ChannelSummaryDto {
+    private Long channelRoomId;
+    private String partnerProfileImage;
+    private String partnerNickname;
+    private String lastMessage;
+    private LocalDateTime lastMessageTime;
+    private boolean isRead;
+    private String relationType;
+
+    public static ChannelSummaryDto fromProjection(ChannelRoomProjection p) {
+        return new ChannelSummaryDto(
+                p.getChannelRoomId(),
+                p.getPartnerProfileImage(),
+                p.getPartnerNickname(),
+                p.getLastMessage(),
+                p.getLastMessageTime(),
+                p.getIsRead(),
+                p.getRelationType()
+        );
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/ChannelJoin.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/ChannelJoin.java
@@ -1,0 +1,23 @@
+package com.hertz.hertz_be.domain.channel.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "channel_join")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChannelJoin {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "channel_room_id", nullable = false)
+    private Long channelRoomId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/ChannelMessage.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/ChannelMessage.java
@@ -1,0 +1,31 @@
+package com.hertz.hertz_be.domain.channel.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "channel_message")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChannelMessage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "channel_room_id", nullable = false)
+    private Long channelRoomId;
+
+    @Column(name = "sender_user_id", nullable = false)
+    private Long senderUserId;
+
+    @Column(name = "message", nullable = false, length = 300)
+    private String message;
+
+    @Column(name = "send_at", nullable = false)
+    private LocalDateTime sendAt;
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/ChannelMessageLastRead.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/ChannelMessageLastRead.java
@@ -1,0 +1,31 @@
+package com.hertz.hertz_be.domain.channel.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "channel_message_last_read")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChannelMessageLastRead {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "channel_id", nullable = false)
+    private Long channelId;
+
+    @Column(name = "last_message_read_id", nullable = false)
+    private Long lastMessageReadId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "last_read_at", nullable = false)
+    private LocalDateTime lastReadAt;
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/ChannelRoom.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/ChannelRoom.java
@@ -1,0 +1,43 @@
+package com.hertz.hertz_be.domain.channel.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "channel_room")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChannelRoom {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 10)
+    private String category;
+
+    @Column(name = "channel_name", length = 20)
+    private String channelName;
+
+    @Column(name = "channel_content", length = 100)
+    private String channelContent;
+
+    @Column(name = "current_user_count", nullable = false)
+    private int currentUserCount;
+
+    @Column(name = "max_user_count", nullable = false)
+    private int maxUserCount;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "modified_at", nullable = false)
+    private LocalDateTime modifiedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/ChannelRoomRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/ChannelRoomRepository.java
@@ -11,43 +11,84 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ChannelRoomRepository extends JpaRepository<ChannelRoom, Long> {
+
+// Todo: 웹소켓 도입 전 임시 사용 (v1), 추후 삭제 필요
     @Query(value = """
-    SELECT 
-        cr.id AS channelRoomId,
-        u.profile_image_url AS partnerProfileImage,
-        u.nickname AS partnerNickname,
-        cm.message AS lastMessage,
-        cm.send_at AS lastMessageTime,
-        CASE 
-            WHEN cm.id <= COALESCE(cmlr.last_message_read_id, 0) THEN true
-            ELSE false
-        END AS isRead,
-        cr.category AS relationType
-    FROM channel_room cr
-    JOIN channel_join cj1 ON cj1.channel_room_id = cr.id
-    JOIN channel_join cj2 ON cj2.channel_room_id = cr.id AND cj2.user_id != :userId
-    JOIN user u ON u.id = cj2.user_id
-    LEFT JOIN channel_message cm ON cm.id = (
-        SELECT cm2.id FROM channel_message cm2 
-        WHERE cm2.channel_room_id = cr.id 
-        ORDER BY cm2.send_at DESC LIMIT 1
-    )
-    LEFT JOIN channel_message_last_read cmlr 
-        ON cmlr.channel_id = cr.id AND cmlr.user_id = :userId
-    WHERE cr.current_user_count = 2
-      AND cj1.user_id = :userId
-    ORDER BY cm.send_at DESC
-    """,
+        SELECT 
+            sr.id AS channelRoomId,
+            u.profile_image_url AS partnerProfileImage,
+            u.nickname AS partnerNickname,
+            sm.message AS lastMessage,
+            sm.send_at AS lastMessageTime,
+            sm.is_read AS isRead,
+            sr.category AS relationType
+        FROM signal_room sr
+        JOIN user u ON 
+            (CASE 
+                WHEN sr.sender_user_id = :userId THEN sr.receiver_user_id 
+                ELSE sr.sender_user_id 
+             END) = u.id
+        LEFT JOIN signal_message sm ON sm.id = (
+            SELECT sm2.id
+            FROM signal_message sm2
+            WHERE sm2.signal_room_id = sr.id
+            ORDER BY sm2.send_at DESC
+            LIMIT 1
+        )
+        WHERE :userId IN (sr.sender_user_id, sr.receiver_user_id)
+        ORDER BY sm.send_at DESC
+        """,
             countQuery = """
-    SELECT COUNT(*)
-    FROM channel_room cr
-    JOIN channel_join cj1 ON cj1.channel_room_id = cr.id
-    WHERE cr.current_user_count = 2
-      AND cj1.user_id = :userId
-    """,
+        SELECT COUNT(*)
+        FROM signal_room sr
+        WHERE :userId IN (sr.sender_user_id, sr.receiver_user_id)
+        """,
             nativeQuery = true)
     Page<ChannelRoomProjection> findChannelRoomsWithPartnerAndLastMessage(
             @Param("userId") Long userId,
-            Pageable pageable);
+            Pageable pageable
+    );
+
+
+// Todo: 추후 웹소켓 도입 시 쿼리 변경 필요 (v2)
+
+//    @Query(value = """
+//    SELECT
+//        cr.id AS channelRoomId,
+//        u.profile_image_url AS partnerProfileImage,
+//        u.nickname AS partnerNickname,
+//        cm.message AS lastMessage,
+//        cm.send_at AS lastMessageTime,
+//        CASE
+//            WHEN cm.id <= COALESCE(cmlr.last_message_read_id, 0) THEN true
+//            ELSE false
+//        END AS isRead,
+//        cr.category AS relationType
+//    FROM channel_room cr
+//    JOIN channel_join cj1 ON cj1.channel_room_id = cr.id
+//    JOIN channel_join cj2 ON cj2.channel_room_id = cr.id AND cj2.user_id != :userId
+//    JOIN user u ON u.id = cj2.user_id
+//    LEFT JOIN channel_message cm ON cm.id = (
+//        SELECT cm2.id FROM channel_message cm2
+//        WHERE cm2.channel_room_id = cr.id
+//        ORDER BY cm2.send_at DESC LIMIT 1
+//    )
+//    LEFT JOIN channel_message_last_read cmlr
+//        ON cmlr.channel_id = cr.id AND cmlr.user_id = :userId
+//    WHERE cr.current_user_count = 2
+//      AND cj1.user_id = :userId
+//    ORDER BY cm.send_at DESC
+//    """,
+//            countQuery = """
+//    SELECT COUNT(*)
+//    FROM channel_room cr
+//    JOIN channel_join cj1 ON cj1.channel_room_id = cr.id
+//    WHERE cr.current_user_count = 2
+//      AND cj1.user_id = :userId
+//    """,
+//            nativeQuery = true)
+//    Page<ChannelRoomProjection> findChannelRoomsWithPartnerAndLastMessage(
+//            @Param("userId") Long userId,
+//            Pageable pageable);
 
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/projection/ChannelRoomProjection.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/projection/ChannelRoomProjection.java
@@ -1,0 +1,13 @@
+package com.hertz.hertz_be.domain.channel.repository.projection;
+
+import java.time.LocalDateTime;
+
+public interface ChannelRoomProjection {
+    Long getChannelRoomId();
+    String getPartnerNickname();
+    String getPartnerProfileImage();
+    String getLastMessage();
+    LocalDateTime getLastMessageTime();
+    Boolean getIsRead();
+    String getRelationType();
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/ChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/ChannelService.java
@@ -113,9 +113,12 @@ public class ChannelService {
         return signalMessageRepository.existsBySignalRoomIdInAndSenderUserIdNotAndIsReadFalse(allRooms, user);
     }
 
-    public ChannelListResponseDto getPersonalChannelList(Long userId, int page, int size) {
+
+    // Todo: 추후 시그널 -> 채널로 마이그레이션 시 메소드명 변경 필요 (getPersonalSignalRoomList -> getPersonalChannelList)
+    public ChannelListResponseDto getPersonalSignalRoomList(Long userId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         Page<ChannelRoomProjection> result = channelRoomRepository.findChannelRoomsWithPartnerAndLastMessage(userId, pageable);
+
         if (result.isEmpty()) {
             return null;
         }
@@ -126,4 +129,5 @@ public class ChannelService {
 
         return new ChannelListResponseDto(list, result.getNumber(), result.getSize(), result.isLast());
     }
+
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseCode.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseCode.java
@@ -40,4 +40,8 @@ public class ResponseCode {
     public static final String NEW_MESSAGE = "NEW_MESSAGE";
     public static final String NO_ANY_NEW_MESSAGE = "NO_ANY_NEW_MESSAGE";
 
+    // 채널 정보 관련 응답 code
+    public static final String CHANNEL_ROOM_LIST_FETCHED = "CHANNEL_ROOM_LIST_FETCHED";
+    public static final String NO_CHANNEL_ROOM = "NO_CHANNEL_ROOM";
+
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- #34 

## ✏️ 변경 사항
- v1 기준 signal_message, signal_room 테이블을 사용하도록 리팩토링 하였습니다.

## 📋 상세 설명
- 채널 -> 시그널 테이블로 사용하도록 비즈니스 로직 수정하였습니다.

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 

## 📎 참고 자료 (선택)
- 
