### PR TITLE
[#30][#31] Feat: 채널방 메세지 전송 및 특정 채널방 반환 API 구현

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/ChannelController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/ChannelController.java
@@ -2,6 +2,7 @@ package com.hertz.hertz_be.domain.channel.controller;
 
 import com.hertz.hertz_be.domain.channel.dto.request.SendSignalRequestDTO;
 import com.hertz.hertz_be.domain.channel.dto.response.ChannelListResponseDto;
+import com.hertz.hertz_be.domain.channel.dto.response.ChannelRoomResponseDto;
 import com.hertz.hertz_be.domain.channel.dto.response.SendSignalResponseDTO;
 import com.hertz.hertz_be.domain.channel.dto.response.TuningResponseDTO;
 import com.hertz.hertz_be.domain.channel.service.ChannelService;
@@ -9,6 +10,7 @@ import com.hertz.hertz_be.global.common.ResponseCode;
 import com.hertz.hertz_be.global.common.ResponseDto;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -67,5 +69,25 @@ public class ChannelController {
         return ResponseEntity.ok(new ResponseDto<>(ResponseCode.CHANNEL_ROOM_LIST_FETCHED, "채널방 목록이 정상적으로 조회되었습니다.", response));
     }
 
+    @GetMapping("/v1/channel-rooms/{channelRoomId}")
+    public ResponseEntity<ResponseDto<ChannelRoomResponseDto>> getChannelRoomMessages(@PathVariable Long channelRoomId,
+                                                                                      @AuthenticationPrincipal Long userId,
+                                                                                      @RequestParam(defaultValue = "0") int page,
+                                                                                      @RequestParam(defaultValue = "20") int size) {
 
+        ChannelRoomResponseDto response = channelService.getChannelRoomMessages(channelRoomId, userId, page, size);
+        return ResponseEntity.ok(new ResponseDto<>("CHANNEL_ROOM_SUCCESS", "채널방이 정상적으로 조회되었습니다.", response));
+    }
+
+    @PostMapping("/v1/channel-rooms/{channelRoomId}/messages")
+    public ResponseEntity<ResponseDto<ChannelRoomResponseDto>> sendChannelMessage(@PathVariable Long channelRoomId,
+                                                                                  @AuthenticationPrincipal Long userId,
+                                                                                  @RequestBody SendSignalRequestDTO response) {
+
+        channelService.sendChannelMessage(channelRoomId, userId, response);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(new ResponseDto<>(ResponseCode.MESSAGE_CREATED, "메세지가 성공적으로 전송되었습니다.", null)
+        );
+    }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/request/SignalMessageRequestDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/request/SignalMessageRequestDto.java
@@ -1,0 +1,10 @@
+package com.hertz.hertz_be.domain.channel.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class SignalMessageRequestDto {
+    @NotBlank(message = "메세지를 입력해주세요.")
+    private String message;
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/ChannelRoomResponseDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/ChannelRoomResponseDto.java
@@ -1,0 +1,82 @@
+package com.hertz.hertz_be.domain.channel.dto.response;
+
+import com.hertz.hertz_be.domain.channel.entity.SignalMessage;
+import com.hertz.hertz_be.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ChannelRoomResponseDto {
+
+    private Long channelRoomId;
+    private Long partnerId;
+    private String partnerProfileImage;
+    private String partnerNickname;
+    private String relationType;
+    private MessagePage messages;
+
+    public static ChannelRoomResponseDto of(Long roomId, User partner, String relationType,
+                                         List<MessageDto> messages, Page<SignalMessage> page) {
+        return ChannelRoomResponseDto.builder()
+                .channelRoomId(roomId)
+                .partnerId(partner.getId())
+                .partnerProfileImage(partner.getProfileImageUrl())
+                .partnerNickname(partner.getNickname())
+                .relationType(relationType)
+                .messages(new MessagePage(messages, page))
+                .build();
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class MessageDto {
+        private Long messageId;
+        private Long messageSenderId;
+        private String messageContents;
+        private String messageSendAt;
+
+        public static MessageDto from(SignalMessage msg) {
+            return new MessageDto(
+                    msg.getId(),
+                    msg.getSenderUser().getId(),
+                    msg.getMessage(),
+                    msg.getSendAt().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+            );
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class MessagePage {
+        private List<MessageDto> list;
+        private PageableInfo pageable;
+
+        public MessagePage(List<MessageDto> list, Page<?> page) {
+            this.list = list;
+            this.pageable = new PageableInfo(page);
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class PageableInfo {
+        private int pageNumber;
+        private int pageSize;
+        private boolean isLast;
+
+        public PageableInfo(Page<?> page) {
+            this.pageNumber = page.getNumber();
+            this.pageSize = page.getSize();
+            this.isLast = page.isLast();
+        }
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/SignalMessage.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/SignalMessage.java
@@ -21,17 +21,18 @@ public class SignalMessage {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "signal_room_id", nullable = false)
-    private SignalRoom signalRoomId;
+    private SignalRoom signalRoom;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sender_user_id", nullable = false)
-    private User senderUserId;
+    private User senderUser;
 
     @Column(nullable = false, length = 300)
     private String message;
 
     @Column(name = "is_read", nullable = false)
-    private Boolean isRead;
+    @Builder.Default
+    private Boolean isRead = false;
 
     @CreationTimestamp
     @Column(name = "send_at", nullable = false)

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/SignalRoom.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/SignalRoom.java
@@ -47,7 +47,32 @@ public class SignalRoom {
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
-    @OneToMany(mappedBy = "signalRoomId")
+    @OneToMany(mappedBy = "signalRoom")
     private List<SignalMessage> messages = new ArrayList<>();
+
+    /**
+     * 현재 유저 기준으로 상대방을 반환
+     */
+    public User getPartnerUser(Long currentUserId) {
+        if (senderUser.getId().equals(currentUserId)) return receiverUser;
+        if (receiverUser.getId().equals(currentUserId)) return senderUser;
+        throw new IllegalArgumentException("해당 유저는 이 방의 참가자가 아닙니다.");
+    }
+
+    /**
+     * 현재 유저가 이 방에 참가 중인지 여부
+     */
+    public boolean isParticipant(Long userId) {
+        return senderUser.getId().equals(userId) || receiverUser.getId().equals(userId);
+    }
+
+    /**
+     * RelationType을 반환하는 유틸
+     */
+    public String getRelationType() {
+        // 상황에 따라 ENUM으로 바꿔도 됨
+        return "SIGNAL";
+    }
+
 }
 

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/exception/ChannelNotFoundException.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/exception/ChannelNotFoundException.java
@@ -1,0 +1,15 @@
+package com.hertz.hertz_be.domain.channel.exception;
+
+import com.hertz.hertz_be.global.common.ResponseCode;
+import lombok.Getter;
+
+@Getter
+public class ChannelNotFoundException extends BaseChannelException{
+    private static final String DEFAULT_MESSAGE = "해당 채널방을 찾을 수 없습니다.";
+    private final String code;
+
+    public ChannelNotFoundException() {
+        super(DEFAULT_MESSAGE);
+        this.code = ResponseCode.USER_DEACTIVATED;
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/exception/UnauthorizedAccessException.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/exception/UnauthorizedAccessException.java
@@ -1,0 +1,16 @@
+package com.hertz.hertz_be.domain.channel.exception;
+
+import com.hertz.hertz_be.global.common.ResponseCode;
+import lombok.Getter;
+
+@Getter
+public class UnauthorizedAccessException extends BaseChannelException{
+    private static final String DEFAULT_MESSAGE = "해당 채널방에 접근 권한이 없습니다.";
+    private final String code;
+
+    public UnauthorizedAccessException() {
+        super(DEFAULT_MESSAGE);
+        this.code = ResponseCode.ALREADY_IN_CONVERSATION;
+    }
+
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/SignalMessageRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/SignalMessageRepository.java
@@ -3,11 +3,13 @@ package com.hertz.hertz_be.domain.channel.repository;
 import com.hertz.hertz_be.domain.channel.entity.SignalMessage;
 import com.hertz.hertz_be.domain.channel.entity.SignalRoom;
 import com.hertz.hertz_be.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface SignalMessageRepository extends JpaRepository<SignalMessage, Long> {
     boolean existsBySignalRoomIdInAndSenderUserIdNotAndIsReadFalse(List<SignalRoom> signalRooms, User senderUser);
-
+    Page<SignalMessage> findBySignalRoom_Id(Long roomId, Pageable pageable);
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/SignalRoomRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/SignalRoomRepository.java
@@ -1,9 +1,13 @@
 package com.hertz.hertz_be.domain.channel.repository;
 
+import com.hertz.hertz_be.domain.channel.entity.SignalMessage;
 import com.hertz.hertz_be.domain.channel.entity.SignalRoom;
 import com.hertz.hertz_be.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SignalRoomRepository extends JpaRepository<SignalRoom, Long> {
     boolean existsBySenderUserAndReceiverUser(User sender, User receiver);
+    Page<SignalMessage> findById(Long roomId, Pageable pageable);
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/entity/User.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/entity/User.java
@@ -84,6 +84,7 @@ public class User {
     @OneToMany(mappedBy = "receiverUser")
     private List<SignalRoom> receivedSignalRooms = new ArrayList<>();
 
-    @OneToMany(mappedBy = "senderUserId")
+    @OneToMany(mappedBy = "senderUser")
     private List<SignalMessage> sendMessages = new ArrayList<>();
+
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/repository/UserRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/repository/UserRepository.java
@@ -1,10 +1,16 @@
 package com.hertz.hertz_be.domain.user.repository;
 
+import com.hertz.hertz_be.domain.channel.entity.SignalMessage;
 import com.hertz.hertz_be.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByNickname(String nickname);
+    Optional<User> findByIdAndDeletedAtIsNull(Long id);
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseCode.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseCode.java
@@ -27,6 +27,7 @@ public class ResponseCode {
     public static final String NICKNAME_CREATED = "NICKNAME_CREATED";
     public static final String NICKNAME_API_FAILED = "NICKNAME_API_FAILED";
     public static final String NICKNAME_GENERATION_TIMEOUT = "NICKNAME_GENERATION_TIMEOUT";
+    public static final String USER_NOT_FOUND = "USER_NOT_FOUND";
 
     // 취향 선택 응답 code
     public static final String INTERESTS_SAVED_SUCCESSFULLY = "INTERESTS_SAVED_SUCCESSFULLY";
@@ -43,5 +44,6 @@ public class ResponseCode {
     // 채널 정보 관련 응답 code
     public static final String CHANNEL_ROOM_LIST_FETCHED = "CHANNEL_ROOM_LIST_FETCHED";
     public static final String NO_CHANNEL_ROOM = "NO_CHANNEL_ROOM";
+    public static final String MESSAGE_CREATED = "MESSAGE_CREATED";
 
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- #30 
- #31 

## ✏️ 변경 사항
- 채널방 메세지 전송 API 구현
- 특정 채널방 반환 API 구현

## 📋 상세 설명
- 사용자가 특정 채널방(`/api/v1/channel-rooms/{channelRoomId}`)을 선택하면 해당 채널방의 메시지 목록을 최신순으로 최대 20개까지 페이징하여 조회할 수 있도록 구현했습니다.  
- 응답에는 상대방의 정보(`partnerId`, `partnerNickname`, `partnerProfileImage`)와 관계 유형(`relationType`: `SIGNAL` 또는 `MATCHING`)이 포함됩니다.  
- 메시지는 `messageSendAt` 기준으로 최신순으로 정렬되어 반환됩니다.  
- 프론트에서 무한 스크롤 형태로 사용할 수 있도록 페이지네이션 정보(`pageNumber`, `pageSize`, `isLast`)를 함께 제공합니다.  
- 상대방이 탈퇴한 경우에는 `410 USER_DEACTIVATED` 응답을 반환하도록 예외처리를 추가했습니다.  

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 

## 📎 참고 자료 (선택)
- 
