### PR TITLE
Test: FE 측 로그인 테스트가 불편하여 임시 변경

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/request/UserInfoRequestDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/request/UserInfoRequestDto.java
@@ -1,5 +1,6 @@
 package com.hertz.hertz_be.domain.user.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.hertz.hertz_be.domain.user.entity.enums.AgeGroup;
 import com.hertz.hertz_be.domain.user.entity.enums.Gender;
 import lombok.Getter;
@@ -39,6 +40,11 @@ public class UserInfoRequestDto {
 
     @NotBlank
     private String oneLineIntroduction;
+
+
+    // Todo. FE 개발용 테스트 필드 (추후 삭제 필요)
+    @JsonProperty("isTest")
+    private boolean isTest;
 
 
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/service/UserService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/service/UserService.java
@@ -32,10 +32,7 @@ public class UserService {
 
 
     public UserInfoResponseDto createUser(UserInfoRequestDto userInfoRequestDto) {
-
-        // 랜덤 닉네임 반환 (무한루프)
         String redisValue = oauthRedisRepository.get(userInfoRequestDto.getProviderId());
-
         if (redisValue == null) {
             throw new UserException(ResponseCode.REFRESH_TOKEN_INVALID, "Refresh Token이 올바르지 않습니다.");
         }
@@ -47,11 +44,23 @@ public class UserService {
         long secondsUntilExpiry = Duration.between(LocalDateTime.now(), refreshTokenExpiredAt).getSeconds();
         int maxAge = (int) Math.max(0, secondsUntilExpiry);
 
+        // Todo. FE 개발용 테스트 로직 (추후 삭제 필요)
+        if(userInfoRequestDto.isTest()) {
+            Long fakeUserId = -1L;
+
+            return UserInfoResponseDto.builder()
+                    .userId(fakeUserId)
+                    .accessToken(jwtTokenProvider.createAccessToken(fakeUserId))
+                    .refreshToken(refreshTokenValue)
+                    .refreshSecondsUntilExpiry(maxAge)
+                    .build();
+        }
+
         User user = User.builder()
                 .ageGroup(userInfoRequestDto.getAgeGroup())
                 .profileImageUrl(userInfoRequestDto.getProfileImage())
                 .nickname(userInfoRequestDto.getNickname())
-                .email(userInfoRequestDto.getEmail())
+                .email(userInfoRequestDto.getProviderId() + "@kakaotech.com") //
                 .gender(userInfoRequestDto.getGender())
                 .oneLineIntroduction(userInfoRequestDto.getOneLineIntroduction())
                 .build();


### PR DESCRIPTION
## 🔗 관련 이슈
- .

## ✏️ 변경 사항
- FE 측 로그인 테스트를 용이하게 하기 위하여 임시 로직 수정

## 📋 상세 설명
- 개인정보 등록 API 요청 시 
   - `isTest = true` 일 경우 테스트용으로 인지하여 JPA save 하지 않도록 수정
   - `isTest = false` 일 경우 기존 로직 + email 관련 비즈니스 로직 내 처리 (`provider_id + @kakaotech.com`)

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 위 내용 관련하여 API 명세서 수정하였습니다.

## 📎 참고 자료 (선택)
- 
