### PR TITLE
Fix: email 필드 NotBlank 어노테이션 삭제

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/request/UserInfoRequestDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/request/UserInfoRequestDto.java
@@ -26,7 +26,6 @@ public class UserInfoRequestDto {
     @NotBlank
     private String profileImage;
 
-    @NotBlank
     private String email;
 
     @NotBlank


### PR DESCRIPTION
## 🔗 관련 이슈
- 

## ✏️ 변경 사항
- user 관련 DTO에서 email 필드의 `@NotBlank` annotation을 삭제함

## 📋 상세 설명
- email 입력 여부에 따라 사용자를 다르게 판단하기 때문에 `@NotBlank` 를 할 수 없음

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 

## 📎 참고 자료 (선택)
- 
