### PR TITLE
Fix: 개인정보 등록 재시도 시 예외 처리

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/request/UserInfoRequestDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/request/UserInfoRequestDto.java
@@ -26,7 +26,6 @@ public class UserInfoRequestDto {
     @NotBlank
     private String profileImage;
 
-    @NotBlank
     private String email;
 
     @NotBlank

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/repository/UserOauthRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/repository/UserOauthRepository.java
@@ -10,4 +10,5 @@ public interface UserOauthRepository extends JpaRepository<UserOauth, Long> {
 
     Optional<UserOauth> findByProviderIdAndProvider(String providerId, String provider);
     boolean existsByProviderIdAndProvider(String providerId, String provider);
+
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/service/UserService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/service/UserService.java
@@ -6,6 +6,7 @@ import com.hertz.hertz_be.domain.user.dto.response.UserInfoResponseDto;
 import com.hertz.hertz_be.domain.user.entity.User;
 import com.hertz.hertz_be.domain.user.entity.UserOauth;
 import com.hertz.hertz_be.domain.user.exception.UserException;
+import com.hertz.hertz_be.domain.user.repository.UserOauthRepository;
 import com.hertz.hertz_be.domain.user.repository.UserRepository;
 import com.hertz.hertz_be.global.auth.token.JwtTokenProvider;
 import com.hertz.hertz_be.global.common.ResponseCode;
@@ -22,6 +23,7 @@ import java.time.LocalDateTime;
 @RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
+    private final UserOauthRepository userOauthRepository;
     private final OAuthRedisRepository oauthRedisRepository;
     private final JwtTokenProvider jwtTokenProvider;
     private final RestTemplate restTemplate = new RestTemplate();
@@ -35,6 +37,10 @@ public class UserService {
         String redisValue = oauthRedisRepository.get(userInfoRequestDto.getProviderId());
         if (redisValue == null) {
             throw new UserException(ResponseCode.REFRESH_TOKEN_INVALID, "Refresh Token이 올바르지 않습니다.");
+        }
+
+        if (userOauthRepository.existsByProviderIdAndProvider(userInfoRequestDto.getProviderId(), userInfoRequestDto.getProvider())) {
+            throw new UserException(ResponseCode.DUPLICATE_USER, "이미 등록된 사용자입니다.");
         }
 
         String refreshTokenValue = redisValue.split(",")[0];


### PR DESCRIPTION
## 🔗 관련 이슈
- 

## ✏️ 변경 사항
- 같은 사용자 계정으로 개인정보 등록 API 호출이 2회 이상 실행될 경우의 예외 처리 추가

## 📋 상세 설명
- 

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 개인정보 등록 (최초 요청)
<img width="730" alt="image" src="https://github.com/user-attachments/assets/dec359ae-9197-4e52-922f-8a3f1870ff70" />

- 개인정보 등록 (2회 이상 요청)
<img width="814" alt="image" src="https://github.com/user-attachments/assets/16de85f9-0114-42ce-9edc-2a237aeb332f" />
