### PR TITLE
[#37] Feat: AI 서버 연동을 통한 튜닝된 상대 추천 API 구현

### DIFF
--- a/hertz-be/build.gradle
+++ b/hertz-be/build.gradle
@@ -24,6 +24,7 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springframework.boot:spring-boot-starter-cache'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/ChannelController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/ChannelController.java
@@ -35,6 +35,9 @@ public class ChannelController {
     @GetMapping("/v1/tuning")
     public ResponseEntity<ResponseDto<TuningResponseDTO>> getTunedUser(@AuthenticationPrincipal Long userId) {
         TuningResponseDTO response = channelService.getTunedUser(userId);
+        if (response == null) {
+            return ResponseEntity.ok(new ResponseDto<>(ResponseCode.NO_TUNING_CANDIDATE, "추천 가능한 상대가 현재 없습니다.", null));
+        }
         return ResponseEntity.ok(
                 new ResponseDto<>(ResponseCode.TUNING_SUCCESS, "튜닝된 사용자가 정상적으로 조회되었습니다.", response)
         );

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/TuningResponseDTO.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/TuningResponseDTO.java
@@ -1,5 +1,6 @@
 package com.hertz.hertz_be.domain.channel.dto.response;
 
+import com.hertz.hertz_be.domain.user.entity.enums.Gender;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -12,7 +13,7 @@ public class TuningResponseDTO {
     private Long userId;
     private String profileImage;
     private String nickname;
-    private String gender;
+    private Gender gender;
     private String oneLineIntroduction;
     private Map<String, String> keywords;
     private Map<String, List<String>> sameInterests;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/Tuning.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/Tuning.java
@@ -1,0 +1,41 @@
+package com.hertz.hertz_be.domain.channel.entity;
+
+import com.hertz.hertz_be.domain.channel.entity.enums.Category;
+import com.hertz.hertz_be.domain.user.entity.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class Tuning {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 15)
+    private Category category;
+
+    @CreationTimestamp
+    @Column(nullable = false)
+    private LocalDateTime created_at;
+
+    @OneToOne(mappedBy = "tuning")
+    private TuningResult tuningResult;
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/Tuning.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/Tuning.java
@@ -13,6 +13,8 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Builder
@@ -36,6 +38,6 @@ public class Tuning {
     @Column(nullable = false)
     private LocalDateTime created_at;
 
-    @OneToOne(mappedBy = "tuning")
-    private TuningResult tuningResult;
+    @OneToMany(mappedBy = "tuning", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<TuningResult> tuningResults = new ArrayList<>();
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/TuningResult.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/TuningResult.java
@@ -23,8 +23,8 @@ public class TuningResult {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "tuning_id", nullable = false, unique = true)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tuning_id", nullable = false)
     private Tuning tuning;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -32,5 +32,5 @@ public class TuningResult {
     private User matchedUser;
 
     @Column(nullable = false)
-    private Long lineup;
+    private int lineup;
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/TuningResult.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/TuningResult.java
@@ -1,0 +1,36 @@
+package com.hertz.hertz_be.domain.channel.entity;
+
+import com.hertz.hertz_be.domain.user.entity.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Table;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "tuning_result")
+public class TuningResult {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tuning_id", nullable = false, unique = true)
+    private Tuning tuning;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "matched_user_id", nullable = false)
+    private User matchedUser;
+
+    @Column(nullable = false)
+    private Long lineup;
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/exception/ChannelExceptionHandler.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/exception/ChannelExceptionHandler.java
@@ -13,7 +13,7 @@ public class ChannelExceptionHandler {
     @ExceptionHandler({
             AlreadyInConversationException.class
     })
-    public ResponseEntity<ResponseDto<Void>> handleAlreadyInConversationException(RuntimeException ex) {
+    public ResponseEntity<ResponseDto<Void>> conflictException(RuntimeException ex) {
         String code = ((BaseChannelException) ex).getCode();
         return ResponseEntity
                 .status(HttpStatus.CONFLICT)
@@ -23,10 +23,20 @@ public class ChannelExceptionHandler {
     @ExceptionHandler({
             UserWithdrawnException.class
     })
-    public ResponseEntity<ResponseDto<Void>> handleUserWithdrawnException(RuntimeException ex) {
+    public ResponseEntity<ResponseDto<Void>> goneException(RuntimeException ex) {
         String code = ((BaseChannelException) ex).getCode();
         return ResponseEntity
                 .status(HttpStatus.GONE)
+                .body(new ResponseDto<>(code, ex.getMessage(), null));
+    }
+
+    @ExceptionHandler({
+            InterestsNotSelectedException.class
+    })
+    public ResponseEntity<ResponseDto<Void>> badRequestException(RuntimeException ex) {
+        String code = ((BaseChannelException) ex).getCode();
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
                 .body(new ResponseDto<>(code, ex.getMessage(), null));
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/exception/InterestsNotSelectedException.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/exception/InterestsNotSelectedException.java
@@ -1,0 +1,16 @@
+package com.hertz.hertz_be.domain.channel.exception;
+
+import com.hertz.hertz_be.global.common.ResponseCode;
+import lombok.Getter;
+
+@Getter
+public class InterestsNotSelectedException extends BaseChannelException{
+    private static final String DEFAULT_MESSAGE = "사용자가 아직 취향 선택을 완료하지 않았습니다.";
+    private final String code;
+
+    public InterestsNotSelectedException() {
+        super(DEFAULT_MESSAGE);
+        this.code = ResponseCode.USER_INTERESTS_NOT_SELECTED;
+    }
+
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/TuningRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/TuningRepository.java
@@ -1,0 +1,16 @@
+package com.hertz.hertz_be.domain.channel.repository;
+
+import com.hertz.hertz_be.domain.channel.entity.Tuning;
+import com.hertz.hertz_be.domain.channel.entity.enums.Category;
+import com.hertz.hertz_be.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface TuningRepository extends JpaRepository<Tuning, Long> {
+    List<Tuning> findByUser(User user);
+    Optional<Tuning> findByUserAndCategory(User user, Category category);
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/TuningResultRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/TuningResultRepository.java
@@ -1,0 +1,23 @@
+package com.hertz.hertz_be.domain.channel.repository;
+
+import com.hertz.hertz_be.domain.channel.entity.Tuning;
+import com.hertz.hertz_be.domain.channel.entity.TuningResult;
+import com.hertz.hertz_be.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface TuningResultRepository extends JpaRepository<TuningResult, Long> {
+    List<TuningResult> findByTuning(Tuning tuning);
+
+    Optional<TuningResult> findByTuningAndLineup(Tuning tuning, int lineup);
+
+    boolean existsByTuningAndMatchedUser(Tuning tuning, User matchedUser);
+
+    Optional<TuningResult> findFirstByTuningOrderByLineupAsc(Tuning tuning);
+
+    boolean existsByTuning(Tuning tuning);
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/interests/repository/UserInterestsRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/interests/repository/UserInterestsRepository.java
@@ -3,10 +3,18 @@ package com.hertz.hertz_be.domain.interests.repository;
 import com.hertz.hertz_be.domain.interests.entity.InterestsCategoryItem;
 import com.hertz.hertz_be.domain.interests.entity.UserInterests;
 import com.hertz.hertz_be.domain.user.entity.User;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface UserInterestsRepository extends JpaRepository<UserInterests, Long> {
     boolean existsByUserAndCategoryItem(User user, InterestsCategoryItem item);
+
+    @Query("SELECT ui FROM UserInterests ui JOIN FETCH ui.categoryItem ci JOIN FETCH ci.category WHERE ui.user.id = :userId")
+    List<UserInterests> findByUserId(@Param("userId") Long userId);
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/entity/User.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/entity/User.java
@@ -2,6 +2,8 @@ package com.hertz.hertz_be.domain.user.entity;
 
 import com.hertz.hertz_be.domain.channel.entity.SignalMessage;
 import com.hertz.hertz_be.domain.channel.entity.SignalRoom;
+import com.hertz.hertz_be.domain.channel.entity.Tuning;
+import com.hertz.hertz_be.domain.channel.entity.TuningResult;
 import com.hertz.hertz_be.domain.user.entity.enums.AgeGroup;
 import com.hertz.hertz_be.domain.user.entity.enums.Gender;
 import com.hertz.hertz_be.domain.user.entity.enums.MembershipType;
@@ -87,4 +89,6 @@ public class User {
     @OneToMany(mappedBy = "senderUser")
     private List<SignalMessage> sendMessages = new ArrayList<>();
 
+    @OneToMany(mappedBy = "user")
+    private List<Tuning> recommendListByCategory = new ArrayList<>();
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseCode.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseCode.java
@@ -9,6 +9,7 @@ public class ResponseCode {
     public static final String INTERNAL_ERROR = "INTERNAL_SERVER_ERROR";
     public static final String NOT_IMPLEMENTED = "NOT_IMPLEMENTED";
     public static final String INTERNAL_SERVER_ERROR = "INTERNAL_SERVER_ERROR";
+    public static final String AI_SERVER_ERROR = "AI_SERVER_ERROR";
 
     // OAuth 관련 응답 code
     public static final String UNSUPPORTED_PROVIDER = "UNSUPPORTED_PROVIDER";
@@ -43,6 +44,11 @@ public class ResponseCode {
     public static final String TUNING_SUCCESS = "TUNING_SUCCESS";
     public static final String NEW_MESSAGE = "NEW_MESSAGE";
     public static final String NO_ANY_NEW_MESSAGE = "NO_ANY_NEW_MESSAGE";
+
+    // 튜닝 추천 상대 반환 로직 관련 응답 code
+    public static final String USER_INTERESTS_NOT_SELECTED = "USER_INTERESTS_NOT_SELECTED";
+    public static final String NO_TUNING_CANDIDATE = "NO_TUNING_CANDIDATE";
+
 
     // 채널 정보 관련 응답 code
     public static final String CHANNEL_ROOM_LIST_FETCHED = "CHANNEL_ROOM_LIST_FETCHED";

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/exception/AiServerErrorException.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/exception/AiServerErrorException.java
@@ -1,0 +1,17 @@
+package com.hertz.hertz_be.global.exception;
+
+import com.hertz.hertz_be.global.common.ResponseCode;
+import lombok.Getter;
+
+@Getter
+public class AiServerErrorException extends RuntimeException {
+    private static final String DEFAULT_MESSAGE = "AI 서버 문제로 요청을 처리할 수 없습니다.";
+    private final String code;
+
+    public AiServerErrorException() {
+        super(DEFAULT_MESSAGE);
+        this.code = ResponseCode.AI_SERVER_ERROR;
+    }
+
+}
+

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/exception/GlobalExceptionHandler.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/exception/GlobalExceptionHandler.java
@@ -56,4 +56,15 @@ public class GlobalExceptionHandler {
                         null
                 ));
     }
+
+    @ExceptionHandler(AiServerErrorException.class)
+    public ResponseEntity<ResponseDto<Void>> handleAiServerError(AiServerErrorException ex) {
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ResponseDto<>(
+                        ex.getCode(),
+                        ex.getMessage(),
+                        null
+                ));
+    }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- #37 

## ✏️ 변경 사항
- 기존 더미 데이터를 반환하던 튜닝 API를 AI 서버 연동 방식으로 변경
- 중복 대화 상대 필터링 로직 추가
- AI 서버 호출 및 결과 저장 로직 리팩토링 (메서드 분리)

## 📋 상세 설명
- 기존에는 AI 서버가 구현되지 않아 `getTunedUser()`에서 더미 데이터를 사용하였습니다.
- 이제 AI 서버가 완성됨에 따라 실제 추천 유저 목록을 받아와 DB에 저장하고, 
  이미 대화방이 존재하지 않는 유저를 찾아 반환하는 로직을 구현했습니다.
- `fetchAndSaveTuningResultsFromAiServer()`로 분리하여 중복 제거 및 재사용성을 높였습니다.
- `TuningResult`가 소진되거나 유효하지 않은 경우, 반복적으로 AI 서버를 호출하여 새로 추천을 받습니다.

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)
