### PR TITLE
Fix: accessToken 만료일 임시 연장 (테스트)

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/auth/token/JwtTokenProvider.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/auth/token/JwtTokenProvider.java
@@ -28,7 +28,7 @@ public class JwtTokenProvider {
 
     public String createAccessToken(Long userId) {
         Date now = new Date();
-        Date expiryDate = Date.from(Instant.now().plus(1, ChronoUnit.HOURS));
+        Date expiryDate = Date.from(Instant.now().plus(30, ChronoUnit.DAYS));
 
         return Jwts.builder()
                 .setSubject(userId.toString())


### PR DESCRIPTION
## 🔗 관련 이슈
- 

## ✏️ 변경 사항
- accessToken 만료 기간 연장

## 📋 상세 설명
- 테스트 용이성을 위하여 accessToken 만료 기간을 임시로 연장하였습니다. 

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 

## 📎 참고 자료 (선택)
- 
