### PR TITLE
[#41] Feat: 취향 등록 API AI 연동

### DIFF
--- a/hertz-be/build.gradle
+++ b/hertz-be/build.gradle
@@ -31,8 +31,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'com.giffing.bucket4j.spring.boot.starter:bucket4j-spring-boot-starter:0.9.0'
-
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/interests/dto/request/UserAiInterestsRequestDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/interests/dto/request/UserAiInterestsRequestDto.java
@@ -1,0 +1,32 @@
+package com.hertz.hertz_be.domain.interests.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserAiInterestsRequestDto {
+    private Long userId;
+    private String emailDomain;
+    private String gender;
+    private String ageGroup;
+
+    // 키워드
+    @JsonProperty("MBTI")
+    private String MBTI;
+    private String religion;
+    private String smoking;
+    private String drinking;
+
+    // 관심사
+    private String[] personality;
+    private String[] preferredPeople;
+    private String[] currentInterests;
+    private String[] favoriteFoods;
+    private String[] likedSports;
+    private String[] pets;
+    private String[] selfDevelopment;
+    private String[] hobbies;
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/interests/dto/response/UserInterestsResponseDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/interests/dto/response/UserInterestsResponseDto.java
@@ -1,4 +1,17 @@
 package com.hertz.hertz_be.domain.interests.dto.response;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class UserInterestsResponseDto {
+    private String code;
+    private String accessToken;
+    private String refreshToken;
+    private int refreshSecondsUntilExpiry;
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/interests/exception/BaseInterestsException.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/interests/exception/BaseInterestsException.java
@@ -1,0 +1,8 @@
+package com.hertz.hertz_be.domain.interests.exception;
+
+public abstract class BaseInterestsException extends RuntimeException{
+    public abstract String getCode();
+    public BaseInterestsException(String message) {
+        super(message);
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/interests/exception/DuplicateIdException.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/interests/exception/DuplicateIdException.java
@@ -1,0 +1,15 @@
+package com.hertz.hertz_be.domain.interests.exception;
+
+import com.hertz.hertz_be.global.common.ResponseCode;
+import lombok.Getter;
+
+@Getter
+public class DuplicateIdException extends BaseInterestsException {
+    private static final String DEFAULT_MESSAGE = "중복된 사용자 아이디 입니다.";
+    private final String code;
+
+    public DuplicateIdException() {
+        super(DEFAULT_MESSAGE);
+        this.code = ResponseCode.REFRESH_TOKEN_INVALID;
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/interests/exception/InterestsExceptionHandler.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/interests/exception/InterestsExceptionHandler.java
@@ -1,0 +1,43 @@
+package com.hertz.hertz_be.domain.interests.exception;
+
+import com.hertz.hertz_be.domain.auth.exception.*;
+import com.hertz.hertz_be.global.common.ResponseDto;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(basePackages = "com.hertz.hertz_be.domain.interests")
+public class InterestsExceptionHandler {
+
+    @ExceptionHandler({
+            RegisterBadRequestException.class
+    })
+    public ResponseEntity<ResponseDto<Void>> handleInterestsBadRequestExceptions(RuntimeException ex) {
+        String code = ((BaseAuthException) ex).getCode();
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ResponseDto<>(code, ex.getMessage(), null));
+    }
+
+    @ExceptionHandler({
+            DuplicateIdException.class
+    })
+    public ResponseEntity<ResponseDto<Void>> handleInterestsDuplicateExceptions(RuntimeException ex) {
+        String code = ((BaseAuthException) ex).getCode();
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body(new ResponseDto<>(code, ex.getMessage(), null));
+    }
+
+    @ExceptionHandler({
+            SimilarityUpdateFailedException.class
+    })
+    public ResponseEntity<ResponseDto<Void>> handleInterestsUpdateFailExceptions(RuntimeException ex) {
+        String code = ((BaseAuthException) ex).getCode();
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new ResponseDto<>(code, ex.getMessage(), null));
+    }
+
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/interests/exception/InvalidException.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/interests/exception/InvalidException.java
@@ -1,0 +1,15 @@
+package com.hertz.hertz_be.domain.interests.exception;
+
+import com.hertz.hertz_be.global.common.ResponseCode;
+import lombok.Getter;
+
+@Getter
+public class InvalidException extends BaseInterestsException {
+    private static final String DEFAULT_MESSAGE = "필수 필드 누락 또는 형식 오류가 발생했습니다.";
+    private final String code;
+
+    public InvalidException() {
+        super(DEFAULT_MESSAGE);
+        this.code = ResponseCode.REFRESH_TOKEN_INVALID;
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/interests/exception/RegisterBadRequestException.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/interests/exception/RegisterBadRequestException.java
@@ -1,0 +1,16 @@
+package com.hertz.hertz_be.domain.interests.exception;
+
+import lombok.Getter;
+
+@Getter
+public class RegisterBadRequestException extends BaseInterestsException {
+
+    private static final String DEFAULT_MESSAGE = "AI 서버로 잘못된 요청을 보냈습니다.";
+    private final String code;
+
+    public RegisterBadRequestException(String code) {
+        super(DEFAULT_MESSAGE);
+        this.code = code;
+    }
+
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/interests/exception/SimilarityUpdateFailedException.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/interests/exception/SimilarityUpdateFailedException.java
@@ -1,0 +1,17 @@
+package com.hertz.hertz_be.domain.interests.exception;
+
+import com.hertz.hertz_be.global.common.ResponseCode;
+import lombok.Getter;
+
+@Getter
+public class SimilarityUpdateFailedException extends BaseInterestsException {
+
+    private static final String DEFAULT_MESSAGE = "AI 처리 과정에서 오류가 발생했습니다.";
+    private final String code;
+
+    public SimilarityUpdateFailedException() {
+        super(DEFAULT_MESSAGE);
+        this.code = ResponseCode.REFRESH_TOKEN_INVALID;
+    }
+
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/interests/service/InterestsService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/interests/service/InterestsService.java
@@ -7,6 +7,7 @@ import com.hertz.hertz_be.domain.interests.entity.InterestsCategoryItem;
 import com.hertz.hertz_be.domain.interests.entity.UserInterests;
 import com.hertz.hertz_be.domain.interests.entity.enums.InterestsCategoryType;
 import com.hertz.hertz_be.domain.interests.exception.DuplicateIdException;
+import com.hertz.hertz_be.domain.interests.exception.InvalidException;
 import com.hertz.hertz_be.domain.interests.exception.RegisterBadRequestException;
 import com.hertz.hertz_be.domain.interests.exception.SimilarityUpdateFailedException;
 import com.hertz.hertz_be.domain.interests.repository.InterestsCategoryItemRepository;
@@ -33,9 +34,6 @@ import java.util.Map;
 @Service
 @RequiredArgsConstructor
 public class InterestsService {
-
-    @Value("${ai.server.ip}")
-    private String AI_SERVER_IP;
 
     private final UserInterestsRepository userInterestsRepository;
     private final InterestsCategoryRepository interestsCategoryRepository;
@@ -98,23 +96,31 @@ public class InterestsService {
         String code = (String) responseMap.get("code");
 
         switch (code) {
-            case ResponseCode.EMBEDDING_REGISTER_SUCCESS -> { // 성공
+            case ResponseCode.EMBEDDING_REGISTER_SUCCESS -> { // 201
                 return;
             }
 
-            case ResponseCode.EMBEDDING_CONFLICT_DUPLICATE_ID -> {
+            case ResponseCode.EMBEDDING_REGISTER_BAD_REQUEST -> { // 400
+                throw new RegisterBadRequestException(code);
+            }
+
+            case ResponseCode.EMBEDDING_CONFLICT_DUPLICATE_ID -> { // 409
                 throw new DuplicateIdException();
             }
 
-            case ResponseCode.EMBEDDING_REGISTER_SIMILARITY_UPDATE_FAILED -> {
+            case ResponseCode.BAD_REQUEST_VALIDATION_ERROR -> { // 422
+                throw new InvalidException();
+            }
+
+            case ResponseCode.EMBEDDING_REGISTER_SIMILARITY_UPDATE_FAILED -> { // 500
                 throw new SimilarityUpdateFailedException();
             }
 
-            case ResponseCode.EMBEDDING_REGISTER_SERVER_ERROR -> {
+            case ResponseCode.EMBEDDING_REGISTER_SERVER_ERROR -> { // 500
                 throw new AiServerErrorException();
             }
 
-            default -> { // EMBEDDING_REGISTER_BAD_REQUEST, BAD_REQUEST_VALIDATION_ERROR
+            default -> {
                 throw new RegisterBadRequestException(code);
             }
         }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/interests/service/InterestsService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/interests/service/InterestsService.java
@@ -1,10 +1,14 @@
 package com.hertz.hertz_be.domain.interests.service;
 
+import com.hertz.hertz_be.domain.interests.dto.request.UserAiInterestsRequestDto;
 import com.hertz.hertz_be.domain.interests.dto.request.UserInterestsRequestDto;
 import com.hertz.hertz_be.domain.interests.entity.InterestsCategory;
 import com.hertz.hertz_be.domain.interests.entity.InterestsCategoryItem;
 import com.hertz.hertz_be.domain.interests.entity.UserInterests;
 import com.hertz.hertz_be.domain.interests.entity.enums.InterestsCategoryType;
+import com.hertz.hertz_be.domain.interests.exception.DuplicateIdException;
+import com.hertz.hertz_be.domain.interests.exception.RegisterBadRequestException;
+import com.hertz.hertz_be.domain.interests.exception.SimilarityUpdateFailedException;
 import com.hertz.hertz_be.domain.interests.repository.InterestsCategoryItemRepository;
 import com.hertz.hertz_be.domain.interests.repository.InterestsCategoryRepository;
 import com.hertz.hertz_be.domain.interests.repository.UserInterestsRepository;
@@ -12,10 +16,17 @@ import com.hertz.hertz_be.domain.user.entity.User;
 import com.hertz.hertz_be.domain.user.exception.UserException;
 import com.hertz.hertz_be.domain.user.repository.UserRepository;
 import com.hertz.hertz_be.global.common.ResponseCode;
+import com.hertz.hertz_be.global.exception.AiServerErrorException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -23,27 +34,50 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class InterestsService {
 
+    @Value("${ai.server.ip}")
+    private String AI_SERVER_IP;
+
     private final UserInterestsRepository userInterestsRepository;
     private final InterestsCategoryRepository interestsCategoryRepository;
     private final InterestsCategoryItemRepository interestsCategoryItemRepository;
     private final UserRepository userRepository;
-    //private final WebClient.Builder webClientBuilder;
+    private final WebClient webClient;
 
-    //@Value("${ai.server.ip}")
-    //private String AI_SERVER_IP;
+    @Autowired
+    public InterestsService(UserRepository userRepository,
+                            InterestsCategoryRepository interestsCategoryRepository,
+                            InterestsCategoryItemRepository interestsCategoryItemRepository,
+                            UserInterestsRepository userInterestsRepository,
+                            @Value("${ai.server.ip}") String aiServerIp) {
+        this.userInterestsRepository = userInterestsRepository;
+        this.interestsCategoryRepository = interestsCategoryRepository;
+        this.interestsCategoryItemRepository = interestsCategoryItemRepository;
+        this.userRepository = userRepository;
+        this.webClient = WebClient.builder().baseUrl(aiServerIp).build();
+    }
+
+    private Map<String, Object> requestAiBody = new HashMap<>();
 
     @Transactional
-    public void saveUserInterests(UserInterestsRequestDto userInterestsRequestDto, Long userId) {
+    public void saveUserInterests(UserInterestsRequestDto userInterestsRequestDto, Long userId) throws Exception {
 
         Map<String, String> keywordsMap = userInterestsRequestDto.getKeywords().toMap();
         Map<String, List<String>> interestsMap = userInterestsRequestDto.getInterests().toMap();
+        Map<String, String> requestAiKeywordsBody = new HashMap<>(); // 키워드 담을 Map
+        Map<String, String[]> requestAiInterestsBody = new HashMap<>(); // 관심사 담을 Map
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserException("사용자를 찾을 수 없습니다.", ResponseCode.BAD_REQUEST));
+
+        requestAiBody.put("userId", user.getId());
+        requestAiBody.put("emailDomain", user.getEmail().split("@")[1]);
+        requestAiBody.put("gender", user.getGender());
+        requestAiBody.put("ageGroup", user.getAgeGroup());
 
         try {
             // 키워드 처리
             keywordsMap.forEach((categoryName, itemName) -> {
                 saveSingleUserInterest(user, InterestsCategoryType.KEYWORD, categoryName, itemName);
+                requestAiKeywordsBody.put(categoryName, itemName);
             });
 
             // 관심사 처리
@@ -53,33 +87,38 @@ public class InterestsService {
                 }
                 itemNames.forEach(itemName -> {
                     saveSingleUserInterest(user, InterestsCategoryType.INTEREST, categoryName, itemName);
+                    requestAiInterestsBody.put(categoryName, itemNames.toArray(new String[0]));
                 });
             });
         } catch (Exception e) {
             throw new UserException("취향 등록 처리에 문제가 발생했습니다.", ResponseCode.BAD_REQUEST);
         }
 
+        Map<String, Object> responseMap = saveInterestsToAiServer(requestAiKeywordsBody, requestAiInterestsBody);
+        String code = (String) responseMap.get("code");
 
-        // AI - 데이터 합치는 과정
-//        EmbeddingRequestDto dto = EmbeddingRequestMapper.toDto(
-//                user.getId(),
-//                user.getEmail().split("@")[1],
-//                user.getGender().name(),
-//                user.getAgeGroup().name(),
-//                keywordsMap.
-//        );
-//
-//        // AI - 임베딩(회원 등록) API 연동
-//        String aiResponse = webClientBuilder.build()
-//                .post()
-//                .uri(AI_SERVER_IP)
-//                .bodyValue(dto)
-//                .retrieve()
-//                .bodyToMono(String.class)
-//                .block();
-//
-//        // 응답값 활용할 필요 있으면 여기에 처리
-//        System.out.println("AI 응답: " + aiResponse);
+        switch (code) {
+            case ResponseCode.EMBEDDING_REGISTER_SUCCESS -> { // 성공
+                return;
+            }
+
+            case ResponseCode.EMBEDDING_CONFLICT_DUPLICATE_ID -> {
+                throw new DuplicateIdException();
+            }
+
+            case ResponseCode.EMBEDDING_REGISTER_SIMILARITY_UPDATE_FAILED -> {
+                throw new SimilarityUpdateFailedException();
+            }
+
+            case ResponseCode.EMBEDDING_REGISTER_SERVER_ERROR -> {
+                throw new AiServerErrorException();
+            }
+
+            default -> { // EMBEDDING_REGISTER_BAD_REQUEST, BAD_REQUEST_VALIDATION_ERROR
+                throw new RegisterBadRequestException(code);
+            }
+        }
+
     }
 
     private void saveSingleUserInterest(User user, InterestsCategoryType categoryType, String categoryName, String itemName) {
@@ -112,5 +151,40 @@ public class InterestsService {
             throw new UserException("단일 취향 아이템 저장에 문제가 발생했습니다.", ResponseCode.BAD_REQUEST);
         }
 
+    }
+
+    private Map<String, Object> saveInterestsToAiServer(Map<String, String> keywordMap, Map<String, String[]> interestsMap) {
+        String uri = "/api/v1/users";
+        UserAiInterestsRequestDto aiRequest = UserAiInterestsRequestDto.builder()
+                .userId((Long) requestAiBody.get("userId"))
+                .emailDomain((String) requestAiBody.get("emailDomain"))
+                .gender(String.valueOf(requestAiBody.get("gender")))
+                .ageGroup(String.valueOf(requestAiBody.get("ageGroup")))
+                .MBTI(keywordMap.get("mbti"))
+                .religion(keywordMap.get("religion"))
+                .smoking(keywordMap.get("smoking"))
+                .drinking(keywordMap.get("drinking"))
+                .personality(interestsMap.get("personality"))
+                .preferredPeople(interestsMap.get("preferredPeople"))
+                .currentInterests(interestsMap.get("currentInterests"))
+                .favoriteFoods(interestsMap.get("favoriteFoods"))
+                .likedSports(interestsMap.get("likedSports"))
+                .pets(interestsMap.get("pets"))
+                .selfDevelopment(interestsMap.get("selfDevelopment"))
+                .hobbies(interestsMap.get("hobbies"))
+                .build();
+
+        Map<String, Object> responseMap = webClient.post()
+                .uri(uri)
+                .contentType(MediaType.APPLICATION_JSON) // JSON 형식으로 보내겠다고 명시
+                .bodyValue(aiRequest) // requestBody를 POST 요청 본문에 담음
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
+                .block();
+
+        if (responseMap == null || !responseMap.containsKey("code")) {
+            throw new AiServerErrorException();
+        }
+        return responseMap;
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseCode.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseCode.java
@@ -30,7 +30,6 @@ public class ResponseCode {
     public static final String NICKNAME_API_FAILED = "NICKNAME_API_FAILED";
     public static final String NICKNAME_GENERATION_TIMEOUT = "NICKNAME_GENERATION_TIMEOUT";
     public static final String USER_NOT_FOUND = "USER_NOT_FOUND";
-    public static final String EMBEDDING_REGISTER_SUCCESS = "EMBEDDING_REGISTER_SUCCESS"; // AI API 연동 (사용자 취향 등록)
 
 
     // 취향 선택 응답 code
@@ -55,6 +54,14 @@ public class ResponseCode {
     public static final String NO_CHANNEL_ROOM = "NO_CHANNEL_ROOM";
     public static final String MESSAGE_CREATED = "MESSAGE_CREATED";
 
+
+    /* AI Response */
+    public static final String EMBEDDING_REGISTER_SUCCESS = "EMBEDDING_REGISTER_SUCCESS";
+    public static final String EMBEDDING_REGISTER_BAD_REQUEST = "EMBEDDING_REGISTER_BAD_REQUEST";
+    public static final String EMBEDDING_CONFLICT_DUPLICATE_ID = "EMBEDDING_CONFLICT_DUPLICATE_ID";
+    public static final String BAD_REQUEST_VALIDATION_ERROR = "BAD_REQUEST_VALIDATION_ERROR";
+    public static final String EMBEDDING_REGISTER_SIMILARITY_UPDATE_FAILED = "EMBEDDING_REGISTER_SIMILARITY_UPDATE_FAILED";
+    public static final String EMBEDDING_REGISTER_SERVER_ERROR = "EMBEDDING_REGISTER_SERVER_ERROR";
 
 
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/config/WebClientConfig.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/config/WebClientConfig.java
@@ -1,0 +1,13 @@
+package com.hertz.hertz_be.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+    @Bean
+    public WebClient.Builder webClientBuilder() {
+        return WebClient.builder();
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- #41 

## ✏️ 변경 사항
- 취향등록 시 사용자 정보를 AI 벡터 DB에 저장할 수 있도록 API 연동

## 📋 상세 설명
- 사용자의 개인정보, 취향정보(키워드, 관심사)를 AI API를 통해 전달
- 각 예외에 대한 예외처리 추가

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 

## 📎 참고 자료 (선택)
- 
