### PR TITLE
[#52] Fix: 특정 채널방 내 메세지 정렬 수정

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/ChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/ChannelService.java
@@ -324,7 +324,7 @@ public class ChannelService {
         User partner = userRepository.findByIdAndDeletedAtIsNull(partnerId)
                 .orElseThrow(() -> new UserException("USER_DEACTIVATED", "상대방이 탈퇴한 사용자입니다."));
 
-        PageRequest pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "sendAt"));
+        PageRequest pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "sendAt"));
         Page<SignalMessage> messagePage = signalMessageRepository.findBySignalRoom_Id(roomId, pageable);
 
         List<ChannelRoomResponseDto.MessageDto> messages = messagePage.getContent().stream()


### PR DESCRIPTION
## 🔗 관련 이슈
- #52 

## ✏️ 변경 사항
- 채널방 내에서 메세지의 정렬 순서가 내림차순으로 되어 있는 오류 수정

## 📋 상세 설명
- 메세지가 내림차순으로 되어있어 순서가 맞지 않음
- 정렬 변경

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 

## 📎 참고 자료 (선택)
- 
