### PR TITLE
[#56] Fix: 채널 보관함 목록 관련 컬럼 누락건 수정

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/SignalRoom.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/SignalRoom.java
@@ -35,6 +35,9 @@ public class SignalRoom {
     @Column(nullable = false, length = 10)
     private Category category;
 
+    @Column(name = "user_pair_signal", nullable = false, unique = true, length = 35)
+    private String userPairSignal;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "sender_matching_status", nullable = false, length = 15)
     private MatchingStatus senderMatchingStatus;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/exception/CannotSendSignalToSelfException.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/exception/CannotSendSignalToSelfException.java
@@ -1,0 +1,16 @@
+package com.hertz.hertz_be.domain.channel.exception;
+
+import com.hertz.hertz_be.global.common.ResponseCode;
+import lombok.Getter;
+
+@Getter
+public class CannotSendSignalToSelfException extends BaseChannelException{
+    private static final String DEFAULT_MESSAGE = "자기 자신에게는 시그널을 보낼 수 없습니다.";
+    private final String code;
+
+    public CannotSendSignalToSelfException() {
+        super(DEFAULT_MESSAGE);
+        this.code = ResponseCode.ALREADY_IN_CONVERSATION;
+    }
+
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/exception/ChannelExceptionHandler.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/exception/ChannelExceptionHandler.java
@@ -31,7 +31,8 @@ public class ChannelExceptionHandler {
     }
 
     @ExceptionHandler({
-            InterestsNotSelectedException.class
+            InterestsNotSelectedException.class,
+            CannotSendSignalToSelfException.class
     })
     public ResponseEntity<ResponseDto<Void>> badRequestException(RuntimeException ex) {
         String code = ((BaseChannelException) ex).getCode();

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/SignalRoomRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/SignalRoomRepository.java
@@ -7,7 +7,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface SignalRoomRepository extends JpaRepository<SignalRoom, Long> {
     boolean existsBySenderUserAndReceiverUser(User sender, User receiver);
-    Page<SignalMessage> findById(Long roomId, Pageable pageable);
+    Optional<SignalRoom> findByUserPairSignal(String userPairSignal);
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- #56 

## ✏️ 변경 사항
- `signal_room` 테이블 내 `user_pair_signal` 컬럼 추가
- 사용자의 시그널 상대가 본인일 경우에 대한 예외 처리 추가

## 📋 상세 설명
1. `signal_room` 테이블 내 `user_pair_signal` 컬럼이 누락되어 있어 추가하였습니다. (양방향 중복 방지용 컬럼)
   1. 테이블 정의서 상으로는 `user_pair_signal` 에 STORED GENERATED COLUMN 제약 조건을 부여하려 했으나, JPA 상에서 해당 제약 조건을 직접 매핑하거나 조작할 수 없어 entity 내에 아래와 같이 설정했습니다.
    ```
    @Column(name = "user_pair_signal", nullable = false, unique = true, length = 35)
    private String userPairSignal;
    ```
2. `user_pair_signal` 컬럼 추가로 인해 '시그널 보내기' 쪽 Serivce 로직을 수정했습니다.
     1. `ChannelService.java > sendSignal`
          ```
              @Transactional
              public SendSignalResponseDTO sendSignal(Long senderUserId, SendSignalRequestDTO dto) {
                  User sender = userRepository.findById(senderUserId)
                          .orElseThrow(InternalServerErrorException::new);
          
                  User receiver = userRepository.findById(dto.getReceiverUserId())
                          .orElseThrow(UserWithdrawnException::new);
          
                  // user_pair_signal 컬럼 누락으로 인한 수정 진행 
                  //        boolean alreadyExists = signalRoomRepository.existsBySenderUserAndReceiverUser(sender, receiver);
                  //        if (alreadyExists) {
                  //            throw new AlreadyInConversationException();
                  //        }
    
                  // ➕ 추가된 부분
                  String userPairSignal = generateUserPairSignal(sender.getId(), receiver.getId());
                  Optional<SignalRoom> existingRoom = signalRoomRepository.findByUserPairSignal(userPairSignal);
                  if (existingRoom.isPresent()) {
                      throw new AlreadyInConversationException();
                  } else if (Objects.equals(sender.getId(), receiver.getId())) {
                      throw new CannotSendSignalToSelfException();
                  }
          
                  SignalRoom signalRoom = SignalRoom.builder()
                          .senderUser(sender)
                          .receiverUser(receiver)
                          .category(Category.FRIEND)
                          .senderMatchingStatus(MatchingStatus.SIGNAL)
                          .receiverMatchingStatus(MatchingStatus.SIGNAL)
                          .userPairSignal(userPairSignal)
                          .build();
                  signalRoomRepository.save(signalRoom);

                  ...(생략)...
        
                  public static String generateUserPairSignal(Long userId1, Long userId2) {
                      Long min = Math.min(userId1, userId2);
                      Long max = Math.max(userId1, userId2);
                      return min + "_" + max;
                  }
          ```
     2. 해당 오류 확인하며, DB에 sender_user_id와 receiver_user_id가 동일한 경우도 보여 이에 대한 예외 처리도 추가하였습니다.

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- @kanado5385-k (alex)가 작성하신 부분을 수정했습니다. API 테스트 상 문제는 없었으나, 한 번 더 확인 부탁드립니다.

## 📎 참고 자료 (선택)
- [ERD Cloud](https://www.erdcloud.com/d/FHYJSh9Ack7XRzqFi) 에 user_pair_signal 컬럼이 없어서 업데이트 했습니다. 
