### PR TITLE
[#58] Fix: 취향 등록 관련 데이터 누락 시 예외처리

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/interests/exception/InterestsExceptionHandler.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/interests/exception/InterestsExceptionHandler.java
@@ -1,6 +1,5 @@
 package com.hertz.hertz_be.domain.interests.exception;
 
-import com.hertz.hertz_be.domain.auth.exception.*;
 import com.hertz.hertz_be.global.common.ResponseDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,7 +13,7 @@ public class InterestsExceptionHandler {
             RegisterBadRequestException.class
     })
     public ResponseEntity<ResponseDto<Void>> handleInterestsBadRequestExceptions(RuntimeException ex) {
-        String code = ((BaseAuthException) ex).getCode();
+        String code = ((BaseInterestsException) ex).getCode();
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(new ResponseDto<>(code, ex.getMessage(), null));
@@ -24,7 +23,7 @@ public class InterestsExceptionHandler {
             DuplicateIdException.class
     })
     public ResponseEntity<ResponseDto<Void>> handleInterestsDuplicateExceptions(RuntimeException ex) {
-        String code = ((BaseAuthException) ex).getCode();
+        String code = ((BaseInterestsException) ex).getCode();
         return ResponseEntity
                 .status(HttpStatus.CONFLICT)
                 .body(new ResponseDto<>(code, ex.getMessage(), null));
@@ -34,10 +33,19 @@ public class InterestsExceptionHandler {
             SimilarityUpdateFailedException.class
     })
     public ResponseEntity<ResponseDto<Void>> handleInterestsUpdateFailExceptions(RuntimeException ex) {
-        String code = ((BaseAuthException) ex).getCode();
+        String code = ((BaseInterestsException) ex).getCode();
         return ResponseEntity
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(new ResponseDto<>(code, ex.getMessage(), null));
     }
 
+    @ExceptionHandler({
+            InvalidInterestsInputException.class
+    })
+    public ResponseEntity<ResponseDto<Void>> handleInterestsUnprocessableContentExceptions(RuntimeException ex) {
+        String code = ((BaseInterestsException) ex).getCode();
+        return ResponseEntity
+                .status(HttpStatus.UNPROCESSABLE_ENTITY)
+                .body(new ResponseDto<>(code, ex.getMessage(), null));
+    }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/interests/exception/InvalidInterestsInputException.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/interests/exception/InvalidInterestsInputException.java
@@ -1,0 +1,17 @@
+package com.hertz.hertz_be.domain.interests.exception;
+
+import com.hertz.hertz_be.global.common.ResponseCode;
+import lombok.Getter;
+
+@Getter
+public class InvalidInterestsInputException extends BaseInterestsException {
+
+  private static final String DEFAULT_MESSAGE = "하나 이상의 항목을 선택해야 합니다.";
+  private final String code;
+
+  public InvalidInterestsInputException() {
+    super(DEFAULT_MESSAGE);
+    this.code = ResponseCode.EMPTY_LIST_NOT_ALLOWED;
+  }
+
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- #58 

## ✏️ 변경 사항
- 누락되어있던 422 예외를 추가하였습니다.

## 📋 상세 설명
- 키워드 및 취향 정보에 대한 데이터 누락보다 사용자의 DB 저장 여부를 먼저 판단하고 있어 해당 로직을 추가/수정했습니다.
- 이에 대해 관련 예외를 추가하였습니다.

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 

## 📎 참고 자료 (선택)
- 
