### PR TITLE
Fix: 아직 등록된 취향이 없을 때 예외 처리 수정

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/ChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/ChannelService.java
@@ -124,6 +124,12 @@ public class ChannelService {
     @Transactional
     public TuningResponseDTO getTunedUser(Long userId) {
         User requester = getUserById(userId);
+
+        boolean isUserChooseInterests = userInterestsRepository.existsByUser(requester);
+        if (!isUserChooseInterests){
+            throw new InterestsNotSelectedException();
+        }
+
         Tuning tuning = getOrCreateTuning(requester);
 
         if (!tuningResultRepository.existsByTuning(tuning)) {

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/interests/repository/UserInterestsRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/interests/repository/UserInterestsRepository.java
@@ -14,6 +14,7 @@ import java.util.Optional;
 @Repository
 public interface UserInterestsRepository extends JpaRepository<UserInterests, Long> {
     boolean existsByUserAndCategoryItem(User user, InterestsCategoryItem item);
+    boolean existsByUser(User user);
 
     @Query("SELECT ui FROM UserInterests ui JOIN FETCH ui.categoryItem ci JOIN FETCH ci.category WHERE ui.user.id = :userId")
     List<UserInterests> findByUserId(@Param("userId") Long userId);


### PR DESCRIPTION
## 🔗 관련 이슈
- 없음

## ✏️ 변경 사항
- 특정 사용자가 아직 취향을 등록하지 않았는데, 튜닝 상대 API를 요청하면 예외 처리 로직 수정

## 📋 상세 설명
- 위와 같습니다.

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

