### PR TITLE
[#94] Feat: RT를 httpOnly 쿠키에 담을 때 FE 클라이언트 서브 도메인 지정

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/AuthController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/AuthController.java
@@ -46,12 +46,12 @@ public class AuthController {
                 .maxAge(1209600)
                 .path("/")
                 .httpOnly(true)
-                .sameSite("None")
-                .domain("dev.hertz-tuning.com");
+                .sameSite("None");
 
         if (isLocal) {
             cookieBuilder
-                    .secure(true);// Dev과 Prod 환경의 클라이언트 도메인
+                    .secure(true)
+                    .domain(".hertz-tuning.com");
         }
 
         ResponseCookie responseCookie = cookieBuilder.build();

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/AuthController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/AuthController.java
@@ -46,12 +46,12 @@ public class AuthController {
                 .maxAge(1209600)
                 .path("/")
                 .httpOnly(true)
+                .domain("dev.hertz-tuning.com")
                 .sameSite("None");
 
         if (!isLocal) {
             cookieBuilder
-                    .secure(true)
-                    .domain("dev.hertz-tuning.com");
+                    .secure(true);
         }
 
         ResponseCookie responseCookie = cookieBuilder.build();

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/AuthController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/AuthController.java
@@ -40,16 +40,21 @@ public class AuthController {
         ReissueAccessTokenResponseDTO accessTokenResponse = result.getKey();
         String newRefreshToken = result.getValue();
 
-        //ResponseCookie 설정 (환경에 따라 분기)
-        ResponseCookie responseCookie = ResponseCookie.from("refreshToken", newRefreshToken)
+        // 환경에 따라 domain, secure 조건 분기
+        ResponseCookie.ResponseCookieBuilder cookieBuilder = ResponseCookie
+                .from("refreshToken", newRefreshToken)
                 .maxAge(1209600)
                 .path("/")
-                .domain(".hertz-tuning.com")   // 클라이언트 도메인 지정
                 .httpOnly(true)
-                .sameSite("None")
-                .secure(true)
-                .build();
+                .sameSite("None");
 
+        if (!isLocal) {
+            cookieBuilder
+                    .secure(true)
+                    .domain(".hertz-tuning.com"); //모든 서브도메인에서 공유 가능
+        }
+
+        ResponseCookie responseCookie = cookieBuilder.build();
         response.setHeader("Set-Cookie", responseCookie.toString());
 
         return ResponseEntity.ok(

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/AuthController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/AuthController.java
@@ -41,16 +41,15 @@ public class AuthController {
         String newRefreshToken = result.getValue();
 
         //ResponseCookie 설정 (환경에 따라 분기)
-        ResponseCookie.ResponseCookieBuilder cookieBuilder = ResponseCookie
-                .from("refreshToken", newRefreshToken)
+        ResponseCookie responseCookie = ResponseCookie.from("refreshToken", newRefreshToken)
                 .maxAge(1209600)
                 .path("/")
+                .domain("dev.hertz-tuning.com")   // 클라이언트 도메인 지정
                 .httpOnly(true)
-                .domain("dev.hertz-tuning.com")
                 .sameSite("None")
-                .secure(true);
+                .secure(true)
+                .build();
 
-        ResponseCookie responseCookie = cookieBuilder.build();
         response.setHeader("Set-Cookie", responseCookie.toString());
 
         return ResponseEntity.ok(

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/AuthController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/AuthController.java
@@ -44,7 +44,7 @@ public class AuthController {
         ResponseCookie responseCookie = ResponseCookie.from("refreshToken", newRefreshToken)
                 .maxAge(1209600)
                 .path("/")
-                .domain("dev.hertz-tuning.com")   // 클라이언트 도메인 지정
+                .domain(".hertz-tuning.com")   // 클라이언트 도메인 지정
                 .httpOnly(true)
                 .sameSite("None")
                 .secure(true)

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/AuthController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/AuthController.java
@@ -49,7 +49,7 @@ public class AuthController {
                 .sameSite("None")
                 .domain("dev.hertz-tuning.com");
 
-        if (!isLocal) {
+        if (isLocal) {
             cookieBuilder
                     .secure(true);// Dev과 Prod 환경의 클라이언트 도메인
         }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/AuthController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/AuthController.java
@@ -46,12 +46,12 @@ public class AuthController {
                 .maxAge(1209600)
                 .path("/")
                 .httpOnly(true)
-                .sameSite("None");
+                .sameSite("None")
+                .domain("dev.hertz-tuning.com");
 
         if (!isLocal) {
             cookieBuilder
-                    .secure(true)
-                    .domain("dev.hertz-tuning.com"); // Dev과 Prod 환경의 클라이언트 도메인
+                    .secure(true);// Dev과 Prod 환경의 클라이언트 도메인
         }
 
         ResponseCookie responseCookie = cookieBuilder.build();

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/AuthController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/AuthController.java
@@ -46,12 +46,12 @@ public class AuthController {
                 .maxAge(1209600)
                 .path("/")
                 .httpOnly(true)
-                .domain(".hertz-tuning.com")
                 .sameSite("None");
 
         if (!isLocal) {
             cookieBuilder
-                    .secure(true);
+                    .secure(true)
+                    .domain("dev.hertz-tuning.com");
         }
 
         ResponseCookie responseCookie = cookieBuilder.build();

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/AuthController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/AuthController.java
@@ -48,7 +48,7 @@ public class AuthController {
                 .httpOnly(true)
                 .sameSite("None");
 
-        if (isLocal) {
+        if (!isLocal) {
             cookieBuilder
                     .secure(true)
                     .domain(".hertz-tuning.com");

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/AuthController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/AuthController.java
@@ -46,12 +46,12 @@ public class AuthController {
                 .maxAge(1209600)
                 .path("/")
                 .httpOnly(true)
+                .domain(".hertz-tuning.com")
                 .sameSite("None");
 
         if (!isLocal) {
             cookieBuilder
-                    .secure(true)
-                    .domain(".hertz-tuning.com");
+                    .secure(true);
         }
 
         ResponseCookie responseCookie = cookieBuilder.build();

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/AuthController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/AuthController.java
@@ -47,12 +47,8 @@ public class AuthController {
                 .path("/")
                 .httpOnly(true)
                 .domain("dev.hertz-tuning.com")
-                .sameSite("None");
-
-        if (!isLocal) {
-            cookieBuilder
-                    .secure(true);
-        }
+                .sameSite("None")
+                .secure(true);
 
         ResponseCookie responseCookie = cookieBuilder.build();
         response.setHeader("Set-Cookie", responseCookie.toString());

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/OAuthController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/OAuthController.java
@@ -44,16 +44,15 @@ public class OAuthController {
             String newRefreshToken = result.getRefreshToken();
 
             //ResponseCookie 설정 (환경에 따라 분기)
-            ResponseCookie.ResponseCookieBuilder cookieBuilder = ResponseCookie
-                    .from("refreshToken", newRefreshToken)
+            ResponseCookie responseCookie = ResponseCookie.from("refreshToken", newRefreshToken)
                     .maxAge(1209600)
                     .path("/")
+                    .domain("dev.hertz-tuning.com")   // 클라이언트 도메인 지정
                     .httpOnly(true)
-                    .domain("dev.hertz-tuning.com")
                     .sameSite("None")
-                    .secure(true);
+                    .secure(true)
+                    .build();
 
-            ResponseCookie responseCookie = cookieBuilder.build();
             response.setHeader("Set-Cookie", responseCookie.toString());
 
             OAuthLoginResponseDTO dto = new OAuthLoginResponseDTO(result.getUserId(), result.getAccessToken());

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/OAuthController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/OAuthController.java
@@ -49,12 +49,12 @@ public class OAuthController {
                     .maxAge(1209600)
                     .path("/")
                     .httpOnly(true)
-                    .sameSite("None");
+                    .sameSite("None")
+                    .domain("dev.hertz-tuning.com");
 
             if (!isLocal) {
                 cookieBuilder
-                        .secure(true)
-                        .domain("dev.hertz-tuning.com"); // Dev과 Prod 환경의 클라이언트 도메인
+                        .secure(true);
             }
 
             ResponseCookie responseCookie = cookieBuilder.build();

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/OAuthController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/OAuthController.java
@@ -49,12 +49,12 @@ public class OAuthController {
                     .maxAge(1209600)
                     .path("/")
                     .httpOnly(true)
-                    .sameSite("None")
-                    .domain("dev.hertz-tuning.com");
+                    .sameSite("None");
 
             if (isLocal) {
                 cookieBuilder
-                        .secure(true);
+                        .secure(true)
+                        .domain(".hertz-tuning.com");
             }
 
             ResponseCookie responseCookie = cookieBuilder.build();

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/OAuthController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/OAuthController.java
@@ -43,16 +43,21 @@ public class OAuthController {
         if (result.isRegistered()) {
             String newRefreshToken = result.getRefreshToken();
 
-            //ResponseCookie 설정 (환경에 따라 분기)
-            ResponseCookie responseCookie = ResponseCookie.from("refreshToken", newRefreshToken)
+            // ✅ 환경에 따라 domain, secure 조건 분기
+            ResponseCookie.ResponseCookieBuilder cookieBuilder = ResponseCookie
+                    .from("refreshToken", newRefreshToken)
                     .maxAge(1209600)
                     .path("/")
-                    .domain(".hertz-tuning.com")   // 클라이언트 도메인 지정
                     .httpOnly(true)
-                    .sameSite("None")
-                    .secure(true)
-                    .build();
+                    .sameSite("None");
 
+            if (!isLocal) {
+                cookieBuilder
+                        .secure(true)
+                        .domain(".hertz-tuning.com"); // ✅ 모든 서브도메인에서 공유 가능
+            }
+
+            ResponseCookie responseCookie = cookieBuilder.build();
             response.setHeader("Set-Cookie", responseCookie.toString());
 
             OAuthLoginResponseDTO dto = new OAuthLoginResponseDTO(result.getUserId(), result.getAccessToken());

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/OAuthController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/OAuthController.java
@@ -52,7 +52,7 @@ public class OAuthController {
                     .sameSite("None")
                     .domain("dev.hertz-tuning.com");
 
-            if (!isLocal) {
+            if (isLocal) {
                 cookieBuilder
                         .secure(true);
             }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/OAuthController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/OAuthController.java
@@ -47,7 +47,7 @@ public class OAuthController {
             ResponseCookie responseCookie = ResponseCookie.from("refreshToken", newRefreshToken)
                     .maxAge(1209600)
                     .path("/")
-                    .domain("dev.hertz-tuning.com")   // 클라이언트 도메인 지정
+                    .domain(".hertz-tuning.com")   // 클라이언트 도메인 지정
                     .httpOnly(true)
                     .sameSite("None")
                     .secure(true)

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/OAuthController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/OAuthController.java
@@ -49,12 +49,12 @@ public class OAuthController {
                     .maxAge(1209600)
                     .path("/")
                     .httpOnly(true)
-                    .domain(".hertz-tuning.com")
                     .sameSite("None");
 
             if (!isLocal) {
                 cookieBuilder
-                        .secure(true);
+                        .secure(true)
+                        .domain("dev.hertz-tuning.com");
             }
 
             ResponseCookie responseCookie = cookieBuilder.build();

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/OAuthController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/OAuthController.java
@@ -50,12 +50,8 @@ public class OAuthController {
                     .path("/")
                     .httpOnly(true)
                     .domain("dev.hertz-tuning.com")
-                    .sameSite("None");
-
-            if (!isLocal) {
-                cookieBuilder
-                        .secure(true);
-            }
+                    .sameSite("None")
+                    .secure(true);
 
             ResponseCookie responseCookie = cookieBuilder.build();
             response.setHeader("Set-Cookie", responseCookie.toString());

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/OAuthController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/OAuthController.java
@@ -51,7 +51,7 @@ public class OAuthController {
                     .httpOnly(true)
                     .sameSite("None");
 
-            if (isLocal) {
+            if (!isLocal) {
                 cookieBuilder
                         .secure(true)
                         .domain(".hertz-tuning.com");

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/OAuthController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/OAuthController.java
@@ -49,12 +49,12 @@ public class OAuthController {
                     .maxAge(1209600)
                     .path("/")
                     .httpOnly(true)
+                    .domain(".hertz-tuning.com")
                     .sameSite("None");
 
             if (!isLocal) {
                 cookieBuilder
-                        .secure(true)
-                        .domain(".hertz-tuning.com");
+                        .secure(true);
             }
 
             ResponseCookie responseCookie = cookieBuilder.build();

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/OAuthController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/OAuthController.java
@@ -49,12 +49,12 @@ public class OAuthController {
                     .maxAge(1209600)
                     .path("/")
                     .httpOnly(true)
+                    .domain("dev.hertz-tuning.com")
                     .sameSite("None");
 
             if (!isLocal) {
                 cookieBuilder
-                        .secure(true)
-                        .domain("dev.hertz-tuning.com");
+                        .secure(true);
             }
 
             ResponseCookie responseCookie = cookieBuilder.build();

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/UserController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/UserController.java
@@ -43,12 +43,12 @@ public class UserController {
                 .maxAge(userInfoResponseDto.getRefreshSecondsUntilExpiry())
                 .path("/")
                 .httpOnly(true)
+                .domain("dev.hertz-tuning.com")
                 .sameSite("None");
 
         if (!isLocal) {
             cookieBuilder
-                    .secure(true)
-                    .domain("dev.hertz-tuning.com");
+                    .secure(true);
         }
 
         ResponseCookie responseCookie = cookieBuilder.build();

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/UserController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/UserController.java
@@ -45,7 +45,7 @@ public class UserController {
                 .httpOnly(true)
                 .sameSite("None");
 
-        if (isLocal) {
+        if (!isLocal) {
             cookieBuilder
                     .secure(true)
                     .domain(".hertz-tuning.com");

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/UserController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/UserController.java
@@ -43,12 +43,12 @@ public class UserController {
                 .maxAge(userInfoResponseDto.getRefreshSecondsUntilExpiry())
                 .path("/")
                 .httpOnly(true)
-                .sameSite("None")
-                .domain("dev.hertz-tuning.com");
+                .sameSite("None");
 
         if (isLocal) {
             cookieBuilder
-                    .secure(true);
+                    .secure(true)
+                    .domain(".hertz-tuning.com");
         }
 
         ResponseCookie responseCookie = cookieBuilder.build();

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/UserController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/UserController.java
@@ -43,12 +43,12 @@ public class UserController {
                 .maxAge(userInfoResponseDto.getRefreshSecondsUntilExpiry())
                 .path("/")
                 .httpOnly(true)
-                .sameSite("None");
+                .sameSite("None")
+                .domain("dev.hertz-tuning.com");
 
         if (!isLocal) {
             cookieBuilder
-                    .secure(true)
-                    .domain("dev.hertz-tuning.com"); // Dev과 Prod 환경의 클라이언트 도메인
+                    .secure(true);
         }
 
         ResponseCookie responseCookie = cookieBuilder.build();

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/UserController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/UserController.java
@@ -46,7 +46,7 @@ public class UserController {
                 .sameSite("None")
                 .domain("dev.hertz-tuning.com");
 
-        if (!isLocal) {
+        if (isLocal) {
             cookieBuilder
                     .secure(true);
         }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/UserController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/UserController.java
@@ -43,12 +43,12 @@ public class UserController {
                 .maxAge(userInfoResponseDto.getRefreshSecondsUntilExpiry())
                 .path("/")
                 .httpOnly(true)
-                .domain(".hertz-tuning.com")
                 .sameSite("None");
 
         if (!isLocal) {
             cookieBuilder
-                    .secure(true);
+                    .secure(true)
+                    .domain("dev.hertz-tuning.com");
         }
 
         ResponseCookie responseCookie = cookieBuilder.build();

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/UserController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/UserController.java
@@ -37,17 +37,21 @@ public class UserController {
 
         UserInfoResponseDto userInfoResponseDto = userService.createUser(userInfoRequestDto);
 
-        ResponseCookie responseCookie;
-
-        responseCookie = ResponseCookie.from("refreshToken", userInfoResponseDto.getRefreshToken())
+        // 환경에 따라 secure/domain 설정 분기
+        ResponseCookie.ResponseCookieBuilder cookieBuilder = ResponseCookie
+                .from("refreshToken", userInfoResponseDto.getRefreshToken())
                 .maxAge(userInfoResponseDto.getRefreshSecondsUntilExpiry())
                 .path("/")
-                .domain(".hertz-tuning.com")
                 .httpOnly(true)
-                .sameSite("None")
-                .secure(true)
-                .build();
+                .sameSite("None");
 
+        if (!isLocal) {
+            cookieBuilder
+                    .secure(true)
+                    .domain(".hertz-tuning.com"); // 모든 서브도메인에서 사용 가능
+        }
+
+        ResponseCookie responseCookie = cookieBuilder.build();
         response.setHeader("Set-Cookie", responseCookie.toString());
 
         // ✅ 응답 바디 구성

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/UserController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/UserController.java
@@ -43,12 +43,12 @@ public class UserController {
                 .maxAge(userInfoResponseDto.getRefreshSecondsUntilExpiry())
                 .path("/")
                 .httpOnly(true)
+                .domain(".hertz-tuning.com")
                 .sameSite("None");
 
         if (!isLocal) {
             cookieBuilder
-                    .secure(true)
-                    .domain(".hertz-tuning.com");
+                    .secure(true);
         }
 
         ResponseCookie responseCookie = cookieBuilder.build();

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/UserController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/UserController.java
@@ -37,17 +37,17 @@ public class UserController {
 
         UserInfoResponseDto userInfoResponseDto = userService.createUser(userInfoRequestDto);
 
-        //ResponseCookie 설정 (환경에 따라 분기)
-        ResponseCookie.ResponseCookieBuilder cookieBuilder = ResponseCookie
-                .from("refreshToken", userInfoResponseDto.getRefreshToken())
+        ResponseCookie responseCookie;
+
+        responseCookie = ResponseCookie.from("refreshToken", userInfoResponseDto.getRefreshToken())
                 .maxAge(userInfoResponseDto.getRefreshSecondsUntilExpiry())
                 .path("/")
+                .domain(".hertz-tuning.com")
                 .httpOnly(true)
-                .domain("dev.hertz-tuning.com")
                 .sameSite("None")
-                .secure(true);
+                .secure(true)
+                .build();
 
-        ResponseCookie responseCookie = cookieBuilder.build();
         response.setHeader("Set-Cookie", responseCookie.toString());
 
         // ✅ 응답 바디 구성

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/UserController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/UserController.java
@@ -44,12 +44,8 @@ public class UserController {
                 .path("/")
                 .httpOnly(true)
                 .domain("dev.hertz-tuning.com")
-                .sameSite("None");
-
-        if (!isLocal) {
-            cookieBuilder
-                    .secure(true);
-        }
+                .sameSite("None")
+                .secure(true);
 
         ResponseCookie responseCookie = cookieBuilder.build();
         response.setHeader("Set-Cookie", responseCookie.toString());

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/config/SecurityConfig.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/config/SecurityConfig.java
@@ -20,9 +20,6 @@ import java.util.List;
 @Configuration
 @RequiredArgsConstructor
 public class SecurityConfig {
-
-    @Value("${backend.url}")
-    private String backendUrl;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/config/SecurityConfig.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/config/SecurityConfig.java
@@ -60,7 +60,6 @@ public class SecurityConfig {
         CorsConfiguration corsConfiguration = new CorsConfiguration();
         corsConfiguration.setAllowedOrigins(List.of(
                 "http://localhost:3000",
-                backendUrl,      // 테스트용 추가
                 "https://hertz-tuning.com",
                 "https://dev.hertz-tuning.com"
         ));


### PR DESCRIPTION
## 🔗 관련 이슈  
- #94 

---

## ✏️ 변경 사항  
- `refreshToken` 쿠키 설정 로직을 환경 변수 `is.local`에 따라 분기하도록 수정  
- 로컬 환경에서는 `secure`, `domain` 미설정  
- 운영 환경에서는 `.secure(true)`, `.domain(".hertz-tuning.com")` 설정

---

## 📋 상세 설명  
기존에는 쿠키 설정이 운영 도메인에 고정되어 있어, 로컬 환경(`localhost`)에서는 쿠키가 저장되지 않는 문제가 있었습니다.  
이를 해결하기 위해 `is.local` 값을 기준으로 `ResponseCookie` 설정을 조건부로 처리하도록 리팩토링했습니다.

- **로컬 (`is.local=true`)**  
  - `secure`, `domain` 생략 → `localhost`에서 쿠키 저장 가능  

- **운영 (`is.local=false`)**  
  - `secure=true`, `domain=.hertz-tuning.com` → `dev.hertz-tuning.com`, `hertz-tuning.com`에서 쿠키 공유 가능

📌 적용된 위치:
- `OAuthController`
- `AuthController`
- `UserController`

---

## ✅ 체크리스트  
- [x] 기능이 정상적으로 동작하는지 확인했습니다.  
- [x] 로컬/운영 환경 모두에서 쿠키 수신 확인했습니다.  
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.  
- [x] 환경 분기를 위한 프로퍼티(`is.local`) 설정도 확인했습니다.

---

## 👀 리뷰 요청 사항  
- 혹시 더 명확하게 설정 분리할 수 있는 구조가 있다면 피드백 환영입니다.

---

## 📎 참고 자료  
- 없음

