### PR TITLE
[#92] Fix: 메세지 읽음 처리 관련 오류 수정 및 리팩토링

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/exception/ChannelExceptionHandler.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/exception/ChannelExceptionHandler.java
@@ -1,7 +1,5 @@
 package com.hertz.hertz_be.domain.channel.exception;
 
-import com.hertz.hertz_be.domain.auth.exception.BaseAuthException;
-import com.hertz.hertz_be.domain.auth.exception.RateLimitException;
 import com.hertz.hertz_be.global.common.ResponseDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -38,6 +36,26 @@ public class ChannelExceptionHandler {
         String code = ((BaseChannelException) ex).getCode();
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
+                .body(new ResponseDto<>(code, ex.getMessage(), null));
+    }
+
+    @ExceptionHandler({
+            UserNotFoundException.class
+    })
+    public ResponseEntity<ResponseDto<Void>> notFoundException(RuntimeException ex) {
+        String code = ((BaseChannelException) ex).getCode();
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(new ResponseDto<>(code, ex.getMessage(), null));
+    }
+
+    @ExceptionHandler({
+            ForbiddenChannelException.class
+    })
+    public ResponseEntity<ResponseDto<Void>> forbiddenException(RuntimeException ex) {
+        String code = ((BaseChannelException) ex).getCode();
+        return ResponseEntity
+                .status(HttpStatus.FORBIDDEN)
                 .body(new ResponseDto<>(code, ex.getMessage(), null));
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/exception/ForbiddenChannelException.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/exception/ForbiddenChannelException.java
@@ -4,11 +4,11 @@ import com.hertz.hertz_be.global.common.ResponseCode;
 import lombok.Getter;
 
 @Getter
-public class UnauthorizedAccessException extends BaseChannelException{
+public class ForbiddenChannelException extends BaseChannelException{
     private static final String DEFAULT_MESSAGE = "해당 채널방에 접근 권한이 없습니다.";
     private final String code;
 
-    public UnauthorizedAccessException() {
+    public ForbiddenChannelException() {
         super(DEFAULT_MESSAGE);
         this.code = ResponseCode.ALREADY_IN_CONVERSATION;
     }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/exception/UserNotFoundException.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/exception/UserNotFoundException.java
@@ -1,0 +1,15 @@
+package com.hertz.hertz_be.domain.channel.exception;
+
+import com.hertz.hertz_be.global.common.ResponseCode;
+import lombok.Getter;
+
+@Getter
+public class UserNotFoundException extends BaseChannelException{
+    private static final String DEFAULT_MESSAGE = "사용자가 존재하지 않습니다.";
+    private final String code;
+
+    public UserNotFoundException() {
+        super(DEFAULT_MESSAGE);
+        this.code = ResponseCode.USER_NOT_FOUND;
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- #92 

## ✏️ 변경 사항
- 사용자에 따른 `is_read` 값 반환 변경
- 메세지 읽음 처리 update 쿼리 추가
- 시그널 관련 예외처리 추가

## 📋 상세 설명
- 기존에는 is_read 필드의 값을 그대로 조회하고 있었는데, 같은 채널방에 대해 is_read를 다르게 보여줘야 하기 때문에 CASE 쿼리문 추가
- '특정 채널방 반환 API' 호출 시 해당 채널방의 메세지를 모두 읽음 처리할 수 있도록 update 쿼리 및 비즈니스 로직 수정
- 채널 도메인 내 예외처리 세분화
   - 사용자 : `UserNotFoundException`, `UserWithdrawnException`
   - 채널 : `ForbiddenChannelException`

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 

## 📎 참고 자료 (선택)
- 
