### PR TITLE
[#132] Feat: 프로파일 기반 properties 분리 및 JWT AT 유효시간 환경변수화

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/auth/token/JwtTokenProvider.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/auth/token/JwtTokenProvider.java
@@ -14,6 +14,8 @@ import java.util.Date;
 
 @Component
 public class JwtTokenProvider {
+    @Value("${jwt.at.expiration-minutes}")
+    private long accessTokenExpirationMinutes;
 
     @Value("${jwt.secret}")
     private String secretKeyBase64;
@@ -28,7 +30,7 @@ public class JwtTokenProvider {
 
     public String createAccessToken(Long userId) {
         Date now = new Date();
-        Date expiryDate = Date.from(Instant.now().plus(30, ChronoUnit.MINUTES));
+        Date expiryDate = Date.from(Instant.now().plus(accessTokenExpirationMinutes, ChronoUnit.MINUTES));
 
         return Jwts.builder()
                 .setSubject(userId.toString())

--- a/hertz-be/src/main/resources/application-dev.properties
+++ b/hertz-be/src/main/resources/application-dev.properties
@@ -1,0 +1,9 @@
+# JPA
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.show-sql=false
+
+# JWT AT expiration time
+jwt.at.expiration-minutes=180
+

--- a/hertz-be/src/main/resources/application-local.properties
+++ b/hertz-be/src/main/resources/application-local.properties
@@ -1,0 +1,9 @@
+# JPA
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.show-sql=true
+
+# JWT AT expiration time
+jwt.at.expiration-minutes=300
+

--- a/hertz-be/src/main/resources/application-prod.properties
+++ b/hertz-be/src/main/resources/application-prod.properties
@@ -1,0 +1,8 @@
+# JPA
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.show-sql=false
+
+# JWT AT expiration time
+jwt.at.expiration-minutes=30

--- a/hertz-be/src/main/resources/application.properties
+++ b/hertz-be/src/main/resources/application.properties
@@ -1,3 +1,4 @@
+spring.profiles.active=${ACTIVE}
 spring.application.name=hertz-be
 spring.mvc.throw-exception-if-no-handler-found=true
 spring.web.resources.add-mappings=false
@@ -7,12 +8,6 @@ spring.datasource.url=jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?serverTimezo
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-
-# JPA
-spring.jpa.hibernate.ddl-auto=update
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
-spring.jpa.properties.hibernate.format_sql=true
-spring.jpa.show-sql=true
 
 # Swagger
 springdoc.api-docs.enabled=${SWAGGER_ENABLED:false}


### PR DESCRIPTION
## 🔗 관련 이슈
- #132 

### ✅ 작업 내용 요약
- `application.properties` → 공통 설정으로 유지
- `application-dev.properties`, `application-prod.properties`로 환경별 설정 분리
- `spring.profiles.active` 설정에 따라 실행 환경 분기 적용
- JWT Access Token 유효시간을 properties에서 설정 가능하도록 변경
  - dev 환경: 180분 (3시간)
  - prod 환경: 30분 (기본값)

---

### 🔧 주요 변경 파일
- `src/main/resources/application.properties`
- `src/main/resources/application-dev.properties`
- `src/main/resources/application-prod.properties`
- src/main/resources/application-local.properties`

---

### 🧪 테스트 방법
1. env 파일에서 ACTIVE=(dev,prod,local 중 하나) 추가

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

