### PR TITLE
[#92] Fix: 시그널 메세지 읽음 처리 오류 수정

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/SignalMessage.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/SignalMessage.java
@@ -8,11 +8,16 @@ import org.hibernate.annotations.CreationTimestamp;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "signal_message")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Table(
+        name = "signal_message",
+        indexes = {
+                @Index(name = "idx_signal_message_room_sendat", columnList = "signal_room_id, send_at DESC")
+        }
+)
 public class SignalMessage {
 
     @Id

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/enums/MatchingStatus.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/enums/MatchingStatus.java
@@ -7,8 +7,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum MatchingStatus {
     SIGNAL("시그널"),
-    MATCHING_ACCEPT("매칭 수락"),
-    MATCHING_REFUSE("매칭 거절");
+    MATCHED("매칭 수락"),
+    UNMATCHED("매칭 거절");
 
     private final String label;
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/ChannelRoomRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/ChannelRoomRepository.java
@@ -1,107 +1,11 @@
 package com.hertz.hertz_be.domain.channel.repository;
 
 import com.hertz.hertz_be.domain.channel.entity.ChannelRoom;
-import com.hertz.hertz_be.domain.channel.repository.projection.ChannelRoomProjection;
-import io.lettuce.core.dynamic.annotation.Param;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ChannelRoomRepository extends JpaRepository<ChannelRoom, Long> {
-
-// Todo: 웹소켓 도입 전 임시 사용 (v1), 추후 삭제 필요
-    @Query(value = """
-        SELECT 
-            sr.id AS channelRoomId,
-            u.profile_image_url AS partnerProfileImage,
-            u.nickname AS partnerNickname,
-            sm.message AS lastMessage,
-            sm.send_at AS lastMessageTime,
-            CASE
-                WHEN sm.sender_user_id = :userId THEN 'true'
-                WHEN sm.sender_user_id != :userId AND sm.is_read = true THEN 'true'
-                ELSE 'false'
-            END AS isRead,
-            CASE
-                WHEN sr.receiver_matching_status = 'MATCHED' AND sr.sender_matching_status = 'MATCHED'
-                THEN 'MATCHING'
-                ELSE 'SIGNAL'
-            END AS relationType
-        FROM signal_room sr
-        JOIN user u ON 
-            (CASE 
-                WHEN sr.sender_user_id = :userId THEN sr.receiver_user_id 
-                ELSE sr.sender_user_id 
-             END) = u.id
-        LEFT JOIN signal_message sm ON sm.id = (
-            SELECT sm2.id
-            FROM signal_message sm2
-            WHERE sm2.signal_room_id = sr.id
-            ORDER BY sm2.send_at DESC
-            LIMIT 1
-        )
-        WHERE :userId IN (sr.sender_user_id, sr.receiver_user_id)
-        ORDER BY sm.send_at DESC
-        """,
-            countQuery = """
-        SELECT COUNT(*)
-        FROM signal_room sr
-        WHERE :userId IN (sr.sender_user_id, sr.receiver_user_id)
-        """,
-            nativeQuery = true)
-    Page<ChannelRoomProjection> findChannelRoomsWithPartnerAndLastMessage(
-            @Param("userId") Long userId,
-            Pageable pageable
-    );
-
-    @Modifying(clearAutomatically = true)
-    @Query("UPDATE SignalMessage sm SET sm.isRead = true WHERE sm.signalRoom.id = :roomId")
-    int markAllMessagesAsReadByRoomId(@Param("roomId") Long roomId);
-
-// Todo: 추후 웹소켓 도입 시 쿼리 변경 필요 (v2)
-
-//    @Query(value = """
-//    SELECT
-//        cr.id AS channelRoomId,
-//        u.profile_image_url AS partnerProfileImage,
-//        u.nickname AS partnerNickname,
-//        cm.message AS lastMessage,
-//        cm.send_at AS lastMessageTime,
-//        CASE
-//            WHEN cm.id <= COALESCE(cmlr.last_message_read_id, 0) THEN true
-//            ELSE false
-//        END AS isRead,
-//        cr.category AS relationType
-//    FROM channel_room cr
-//    JOIN channel_join cj1 ON cj1.channel_room_id = cr.id
-//    JOIN channel_join cj2 ON cj2.channel_room_id = cr.id AND cj2.user_id != :userId
-//    JOIN user u ON u.id = cj2.user_id
-//    LEFT JOIN channel_message cm ON cm.id = (
-//        SELECT cm2.id FROM channel_message cm2
-//        WHERE cm2.channel_room_id = cr.id
-//        ORDER BY cm2.send_at DESC LIMIT 1
-//    )
-//    LEFT JOIN channel_message_last_read cmlr
-//        ON cmlr.channel_id = cr.id AND cmlr.user_id = :userId
-//    WHERE cr.current_user_count = 2
-//      AND cj1.user_id = :userId
-//    ORDER BY cm.send_at DESC
-//    """,
-//            countQuery = """
-//    SELECT COUNT(*)
-//    FROM channel_room cr
-//    JOIN channel_join cj1 ON cj1.channel_room_id = cr.id
-//    WHERE cr.current_user_count = 2
-//      AND cj1.user_id = :userId
-//    """,
-//            nativeQuery = true)
-//    Page<ChannelRoomProjection> findChannelRoomsWithPartnerAndLastMessage(
-//            @Param("userId") Long userId,
-//            Pageable pageable);
 
 
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/SignalMessageRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/SignalMessageRepository.java
@@ -2,14 +2,40 @@ package com.hertz.hertz_be.domain.channel.repository;
 
 import com.hertz.hertz_be.domain.channel.entity.SignalMessage;
 import com.hertz.hertz_be.domain.channel.entity.SignalRoom;
+import com.hertz.hertz_be.domain.channel.repository.projection.RoomWithLastSenderProjection;
 import com.hertz.hertz_be.domain.user.entity.User;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface SignalMessageRepository extends JpaRepository<SignalMessage, Long> {
     boolean existsBySignalRoomInAndSenderUserNotAndIsReadFalse(List<SignalRoom> signalRooms, User senderUser);
     Page<SignalMessage> findBySignalRoom_Id(Long roomId, Pageable pageable);
+
+    @Query(value = """
+    SELECT
+        sm.sender_user_id AS lastSenderId
+    FROM signal_room sr
+    LEFT JOIN signal_message sm ON sm.id = (
+        SELECT sm2.id
+        FROM signal_message sm2
+        WHERE sm2.signal_room_id = sr.id
+        ORDER BY sm2.send_at DESC
+        LIMIT 1
+    )
+    LEFT JOIN user u ON sm.sender_user_id = u.id
+    WHERE sr.id = :roomId
+    """, nativeQuery = true)
+    Optional<RoomWithLastSenderProjection> findRoomsWithLastSender(@Param("roomId") Long roomId);
+
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE SignalMessage sm SET sm.isRead = true WHERE sm.signalRoom.id = :roomId")
+    int markAllMessagesAsReadByRoomId(@Param("roomId") Long roomId);
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/SignalRoomRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/SignalRoomRepository.java
@@ -1,15 +1,63 @@
 package com.hertz.hertz_be.domain.channel.repository;
 
-import com.hertz.hertz_be.domain.channel.entity.SignalMessage;
 import com.hertz.hertz_be.domain.channel.entity.SignalRoom;
+import com.hertz.hertz_be.domain.channel.repository.projection.ChannelRoomProjection;
 import com.hertz.hertz_be.domain.user.entity.User;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 
 public interface SignalRoomRepository extends JpaRepository<SignalRoom, Long> {
     boolean existsBySenderUserAndReceiverUser(User sender, User receiver);
     Optional<SignalRoom> findByUserPairSignal(String userPairSignal);
+
+    // Todo: 웹소켓 도입 전 임시 사용 (v1), 추후 삭제 필요
+    @Query(value = """
+        SELECT 
+            sr.id AS channelRoomId,
+            u.profile_image_url AS partnerProfileImage,
+            u.nickname AS partnerNickname,
+            sm.message AS lastMessage,
+            sm.send_at AS lastMessageTime,
+            CASE
+                WHEN sm.sender_user_id = :userId THEN 'true'
+                WHEN sm.sender_user_id != :userId AND sm.is_read = true THEN 'true'
+                ELSE 'false'
+            END AS isRead,
+            CASE
+                WHEN sr.receiver_matching_status = 'MATCHED' AND sr.sender_matching_status = 'MATCHED'
+                THEN 'MATCHING'
+                ELSE 'SIGNAL'
+            END AS relationType
+        FROM signal_room sr
+        JOIN user u ON 
+            (CASE 
+                WHEN sr.sender_user_id = :userId THEN sr.receiver_user_id 
+                ELSE sr.sender_user_id 
+             END) = u.id
+        LEFT JOIN signal_message sm ON sm.id = (
+            SELECT sm2.id
+            FROM signal_message sm2
+            WHERE sm2.signal_room_id = sr.id
+            ORDER BY sm2.send_at DESC
+            LIMIT 1
+        )
+        WHERE :userId IN (sr.sender_user_id, sr.receiver_user_id)
+        ORDER BY sm.send_at DESC
+        """,
+            countQuery = """
+        SELECT COUNT(*)
+        FROM signal_room sr
+        WHERE :userId IN (sr.sender_user_id, sr.receiver_user_id)
+        """,
+            nativeQuery = true)
+    Page<ChannelRoomProjection> findChannelRoomsWithPartnerAndLastMessage(
+            @Param("userId") Long userId,
+            Pageable pageable
+    );
+
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/projection/ChannelRoomProjection.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/projection/ChannelRoomProjection.java
@@ -4,10 +4,10 @@ import java.time.LocalDateTime;
 
 public interface ChannelRoomProjection {
     Long getChannelRoomId();
-    String getPartnerNickname();
-    String getPartnerProfileImage();
+    Boolean getIsRead();
     String getLastMessage();
     LocalDateTime getLastMessageTime();
-    Boolean getIsRead();
     String getRelationType();
+    String getPartnerNickname();
+    String getPartnerProfileImage();
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/projection/RoomWithLastSenderProjection.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/projection/RoomWithLastSenderProjection.java
@@ -1,0 +1,5 @@
+package com.hertz.hertz_be.domain.channel.repository.projection;
+
+public interface RoomWithLastSenderProjection {
+    Long getLastSenderId();           // 마지막 메시지 보낸 유저 ID
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- #92 

## ✏️ 변경 사항
- 메세지 읽음 처리 수정
- MatchingStatus ENUM 통일화
- signal_message 테이블 내 인덱스 설정 추가 (읽음 처리 관련)
- 시그널/채널 관련 쿼리 수정 및 이동

## 📋 상세 설명
1. 메세지 읽음 처리 수정
   1. 특정 채널방 반환 API 호출 시 마지막으로 메세지를 보낸 사용자 아이디를 체크하여 currentUser와 다를 경우에만 is_read = true로 update하도록 수정했습니다.
2. signal_message 테이블 내 인덱스 설정 추가 (읽음 처리 관련)
   1. 채널보관함 목록 조회 시마다 signal_room_id별 send_at DESC를 자주 조회하기 때문에 인덱스 설정을 추가하였습니다. (JPA)
3. 시그널/채널 관련 쿼리 수정 및 이동
   1. 기존 로직에서 시그널과 채널을 혼동하여 Repository를 사용하였습니다. 현재 '채널' 도메인은 사용하지 않기 때문에 채널의 쿼리를 모두 시그널로 옮겼습니다.
   2. 시그널 중에서도 Message/Room 으로 나뉘었는데, 비즈니스 로직 상에서 사용되는 쿼리가 어디에 더 적합한지 판단하여 옮기는 작업을 진행하였습니다.
 

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 

## 📎 참고 자료 (선택)
- 
