### PR TITLE
Feat: 소셜 API 로그인시, 이미 회원가입된 사용자인데 취향선택하지 않았음 예외 처리 추가

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/OAuthController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/OAuthController.java
@@ -5,11 +5,13 @@ import com.hertz.hertz_be.domain.auth.dto.response.OAuthLoginResponseDTO;
 import com.hertz.hertz_be.domain.auth.dto.response.OAuthLoginResult;
 import com.hertz.hertz_be.domain.auth.dto.response.OAuthSignupResponseDTO;
 import com.hertz.hertz_be.domain.auth.service.OAuthService;
+import com.hertz.hertz_be.domain.channel.service.ChannelService;
 import com.hertz.hertz_be.global.common.ResponseCode;
 import com.hertz.hertz_be.global.common.ResponseDto;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -20,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 public class OAuthController {
 
     private final OAuthService oAuthService;
+    private final ChannelService channelService;
 
     @Value("${is.local}")
     private boolean isLocal;
@@ -55,6 +58,13 @@ public class OAuthController {
             response.setHeader("Set-Cookie", responseCookie.toString());
 
             OAuthLoginResponseDTO dto = new OAuthLoginResponseDTO(result.getUserId(), result.getAccessToken());
+
+            boolean hasSelectedInterests = channelService.hasSelectedInterests(channelService.getUserById(result.getUserId()));
+            if (!hasSelectedInterests) {
+                return ResponseEntity
+                        .status(HttpStatus.BAD_REQUEST)
+                        .body(new ResponseDto<>(ResponseCode.USER_INTERESTS_NOT_SELECTED, "사용자가 아직 취향 선택을 완료하지 않았습니다.", dto));
+            }
             return ResponseEntity.ok(new ResponseDto<>(ResponseCode.USER_ALREADY_REGISTERED, "로그인에 성공했습니다.", dto));
 
         } else {

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/ChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/ChannelService.java
@@ -110,18 +110,20 @@ public class ChannelService {
         return min + "_" + max;
     }
 
-    private User getUserById(Long userId) {
+    public User getUserById(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
     }
 
+    public boolean hasSelectedInterests(User user) {
+        return userInterestsRepository.existsByUser(user);
+    }
 
     @Transactional
     public TuningResponseDTO getTunedUser(Long userId) {
         User requester = getUserById(userId);
 
-        boolean isUserChooseInterests = userInterestsRepository.existsByUser(requester);
-        if (!isUserChooseInterests){
+        if (!hasSelectedInterests(requester)) {
             throw new InterestsNotSelectedException();
         }
 


### PR DESCRIPTION
## ✏️ 변경 사항
- 소셜 로그인 API 예외 추가 

## 📋 상세 설명
- 소셜 로그인 시, 이미 회원가입된 사용자이고 취향을 선택하지 않았다면 예외처리

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)
