### PR TITLE
[#84] Chore: Shenandoah GC 설정 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 *.env
+logs/*

--- a/hertz-be/.gitignore
+++ b/hertz-be/.gitignore
@@ -37,3 +37,6 @@ out/
 .vscode/
 
 *.env
+
+### Shenandoah GC logs ###
+logs/*


### PR DESCRIPTION
## 🔗 관련 이슈
- #84 

## ✏️ 변경 사항
- Shenandoah GC 설정 추가로 인해 .gitignore 수정
- 로컬 및 개발/운영 VM Options 설정 필요 (개발/운영의 경우 @DDongu 작업 완료)

## 📋 상세 설명
- 로컬 IntelliJ 내 Shenandoah GC 관련 VM Options 추가
   - `-XX:+UseShenandoahGC -Xms512m -Xmx1024m -Xlog:gc*:file=logs/gc.log:time,uptime,level,tags:filecount=5,filesize=20m`
   - 이전 이력 쌓이는 파일 개수 : 5개
   - 파일 하나당 최대 용량 20MB
- DEV : -XX:+UseShenandoahGC -Xms1g -Xmx2g
- PROD : -XX:+UseShenandoahGC -Xms2g -Xmx2g

### 추가 설명
- DEV에서 `-Xms < -Xmx` 로 설정하는 이유
   - 메모리 부담을 줄이되 최대 상황도에 대한 대비를 위해
   - GC 튜닝이나 메모리 누수 탐지 등과 같은 모니터링에 적절
- PROD 에서 `-Xms = -Xmx` 로 설정하는 이유
   - JVM 힙 사이즈가 변하지 않도록 고정하기 위해
   - 힙 사이즈가 변하지 않으면 GC가 힙을 확장/축소하지 않기 때문에 GC pause가 더 안정적이고 예측하기 좋음
   - CPU spike나 성능 튐 방지

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 

## 📎 참고 자료 (선택)
- 
