### PR TITLE
[#82] Feat: 대화내용 암/복호화 처리

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/ChannelRoomResponseDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/ChannelRoomResponseDto.java
@@ -3,6 +3,7 @@ package com.hertz.hertz_be.domain.channel.dto.response;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.hertz.hertz_be.domain.channel.entity.SignalMessage;
 import com.hertz.hertz_be.domain.user.entity.User;
+import com.hertz.hertz_be.global.common.AESUtil;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -45,11 +46,18 @@ public class ChannelRoomResponseDto {
         private String messageContents;
         private String messageSendAt;
 
-        public static MessageDto from(SignalMessage msg) {
+        public static MessageDto fromProjectionWithDecrypt(SignalMessage msg, AESUtil aesUtil) {
+            String decryptedMessage;
+            try {
+                decryptedMessage = aesUtil.decrypt(msg.getMessage());
+            } catch (Exception e) {
+                decryptedMessage = "메세지를 표시할 수 없습니다.";
+            }
+
             return new MessageDto(
                     msg.getId(),
                     msg.getSenderUser().getId(),
-                    msg.getMessage(),
+                    decryptedMessage,
                     msg.getSendAt().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
             );
         }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/ChannelSummaryDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/ChannelSummaryDto.java
@@ -2,6 +2,7 @@ package com.hertz.hertz_be.domain.channel.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.hertz.hertz_be.domain.channel.repository.projection.ChannelRoomProjection;
+import com.hertz.hertz_be.global.common.AESUtil;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -19,12 +20,19 @@ public class ChannelSummaryDto {
     private boolean isRead;
     private String relationType;
 
-    public static ChannelSummaryDto fromProjection(ChannelRoomProjection p) {
+    public static ChannelSummaryDto fromProjectionWithDecrypt(ChannelRoomProjection p, AESUtil aesUtil) {
+        String decryptedMessage;
+        try {
+            decryptedMessage = aesUtil.decrypt(p.getLastMessage());
+        } catch (Exception e) {
+            decryptedMessage = "메세지를 표시할 수 없습니다.";
+        }
+
         return new ChannelSummaryDto(
                 p.getChannelRoomId(),
                 p.getPartnerProfileImage(),
                 p.getPartnerNickname(),
-                p.getLastMessage(),
+                decryptedMessage,
                 p.getLastMessageTime(),
                 p.getIsRead(),
                 p.getRelationType()

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/DecryptedChannelSummaryConverter.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/DecryptedChannelSummaryConverter.java
@@ -1,0 +1,31 @@
+package com.hertz.hertz_be.domain.channel.dto.response;
+
+import com.hertz.hertz_be.global.common.AESUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DecryptedChannelSummaryConverter {
+
+    private final AESUtil aesUtil;
+
+    public ChannelSummaryDto from(ChannelSummaryDto encryptedDto) {
+        String decryptedMessage;
+        try {
+            decryptedMessage = aesUtil.decrypt(encryptedDto.getLastMessage());
+        } catch (RuntimeException e) {
+            decryptedMessage = "메세지를 표시할 수 없습니다.";
+        }
+
+        return new ChannelSummaryDto(
+                encryptedDto.getChannelRoomId(),
+                encryptedDto.getPartnerProfileImage(),
+                encryptedDto.getPartnerNickname(),
+                decryptedMessage,
+                encryptedDto.getLastMessageTime(),
+                encryptedDto.isRead(),
+                encryptedDto.getRelationType()
+        );
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/common/AESUtil.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/common/AESUtil.java
@@ -1,0 +1,47 @@
+package com.hertz.hertz_be.global.common;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.SecretKeySpec;
+import java.util.Base64;
+
+@Component
+public class AESUtil {
+
+    private final String secretKey;
+    private static final String ALGORITHM = "AES";
+
+    public AESUtil(@Value("${aes.secret}") String secretKey) {
+        this.secretKey = secretKey;
+    }
+
+    public String encrypt(String plainText) {
+        try {
+            byte[] decodedKey = Base64.getDecoder().decode(secretKey);
+            SecretKeySpec keySpec = new SecretKeySpec(decodedKey, ALGORITHM);
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.ENCRYPT_MODE, keySpec);
+            byte[] encrypted = cipher.doFinal(plainText.getBytes());
+            return Base64.getEncoder().encodeToString(encrypted);
+        } catch (Exception e) {
+            throw new RuntimeException("암호화 중 오류 발생", e);
+        }
+
+    }
+
+    public String decrypt(String encryptedText) {
+        try {
+            byte[] decodedKey = Base64.getDecoder().decode(secretKey);
+            SecretKeySpec keySpec = new SecretKeySpec(decodedKey, ALGORITHM);
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.DECRYPT_MODE, keySpec);
+            byte[] decoded = Base64.getDecoder().decode(encryptedText);
+            return new String(cipher.doFinal(decoded));
+        } catch (Exception e) {
+            throw new RuntimeException("복호화 중 오류 발생", e);
+        }
+
+    }
+}

--- a/hertz-be/src/main/resources/application.properties
+++ b/hertz-be/src/main/resources/application.properties
@@ -28,6 +28,7 @@ logging.level.com.hertz=DEBUG
 
 # JWT secret key
 jwt.secret=${JWT_SECRET}
+aes.secret=${AES_SECRET}
 
 # AI server IP address
 ai.server.ip=${AI_SERVER_IP}


### PR DESCRIPTION
## 🔗 관련 이슈
- #82 

## ✏️ 변경 사항
- 채널 관련 데이터 암호화 저장 및 화면 표시 시에는 복호화 처리

## 📋 상세 설명
- 양방향 대칭키 암호화 (AES)
  - `AESUtil` 생성 후 암복호화 전용 secret key 적용
  - 저장할 때 : 암호화 → DB 저장
  - 꺼낼 때 : DB 조회 → 복호화 → 클라이언트에 전달
- 적용 기능
  - 암호화 : 시그널 보내기, 채팅방 내 새 메세지 전송
  - 복호화 : 채팅방 목록, 채팅방 내 메세지 표시

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 📎 참고 자료 (선택)
- AES 관련 secretKey 가 추가되며 `.env`, `application.properties` 파일이 수정되었습니다. 