### PR TITLE
fix: backend cicd 스크립트 중 배포환경 구분이 안되는 오류 해결

### DIFF
--- a/.github/workflows/cicd-backend.yml
+++ b/.github/workflows/cicd-backend.yml
@@ -59,16 +59,8 @@ jobs:
             echo "$VALUE" > "$2"
           }
 
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            if [[ "${{ github.event.inputs.env }}" == "PROD" ]]; then
-              echo "BRANCH=main" >> $GITHUB_ENV
-            else
-              echo "BRANCH=develop" >> $GITHUB_ENV
-            fi
-          else
-            echo "BRANCH=${{ github.ref_name }}" >> $GITHUB_ENV
-          fi
-
+          BRANCH="${{ github.ref_name }}"
+          echo "BRANCH=$BRANCH" >> $GITHUB_ENV
           if [[ "$BRANCH" == "main" ]]; then
             echo "ENV=PROD" >> $GITHUB_ENV
             load_param "/global/gcp/PROD_GCP_HOST" HOST
@@ -224,7 +216,6 @@ jobs:
 
           BRANCH="${{ github.ref_name }}"
           echo "BRANCH=$BRANCH" >> $GITHUB_ENV
-
           if [[ "$BRANCH" == "main" ]]; then
             echo "ENV=PROD" >> $GITHUB_ENV
             load_param "/global/gcp/PROD_GCP_HOST" HOST


### PR DESCRIPTION
## 🔗 관련 이슈
- 이 PR이 연결된 이슈 번호를 작성해 주세요. (예: `#123`)

## ✏️ 변경 사항
- backend cicd 스크립트 중 배포환경 구분이 안되는 오류 해결

## 📋 상세 설명
- 조건문에서 branch를 바로 읽어오도록 변경

## ✅ 체크리스트
- [x] 로컬에서 테스트 완료
- [ ] 현재 PR을 병합하여 테스트 시도

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.
