### PR TITLE
Feat: 매칭 수락/거절 API 구현

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/request/SignalMatchingRequestDTO.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/request/SignalMatchingRequestDTO.java
@@ -1,0 +1,11 @@
+package com.hertz.hertz_be.domain.channel.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class SignalMatchingRequestDTO {
+
+    @NotBlank
+    private Long channelRoomId;
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/SignalRoomRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/SignalRoomRepository.java
@@ -1,12 +1,15 @@
 package com.hertz.hertz_be.domain.channel.repository;
 
 import com.hertz.hertz_be.domain.channel.entity.SignalRoom;
+import com.hertz.hertz_be.domain.channel.entity.enums.MatchingStatus;
 import com.hertz.hertz_be.domain.channel.repository.projection.ChannelRoomProjection;
 import com.hertz.hertz_be.domain.user.entity.User;
 import io.lettuce.core.dynamic.annotation.Param;
+import jakarta.transaction.Transactional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
@@ -60,4 +63,50 @@ public interface SignalRoomRepository extends JpaRepository<SignalRoom, Long> {
             Pageable pageable
     );
 
+    @Modifying
+    @Transactional
+    @Query("""
+        UPDATE SignalRoom sr
+        SET sr.senderMatchingStatus = :status
+        WHERE sr.id = :roomId AND (sr.senderUser.id = :userId)
+    """)
+    int updateSenderMatchingStatus(@Param("roomId") Long roomId,
+                                   @Param("userId") Long userId,
+                                   @Param("status") MatchingStatus status);
+
+    @Modifying
+    @Transactional
+    @Query("""
+        UPDATE SignalRoom sr
+        SET sr.receiverMatchingStatus = :status
+        WHERE sr.id = :roomId AND (sr.receiverUser.id = :userId)
+    """)
+    int updateReceiverMatchingStatus(@Param("roomId") Long roomId,
+                                     @Param("userId") Long userId,
+                                     @Param("status") MatchingStatus status);
+
+
+    @Query("""
+    SELECT 
+        CASE
+            WHEN (u.deletedAt IS NOT NULL) THEN 'USER_DEACTIVATED'
+            WHEN (:userId = sr.senderUser.id AND sr.senderMatchingStatus = 'UNMATCHED')
+              OR (:userId = sr.receiverUser.id AND sr.receiverMatchingStatus = 'UNMATCHED')
+              THEN 'MATCH_FAILED'
+            WHEN (sr.senderMatchingStatus = 'MATCHED' AND sr.receiverMatchingStatus = 'MATCHED')
+              THEN 'MATCH_SUCCESS'
+            WHEN (:userId = sr.senderUser.id AND sr.senderMatchingStatus = 'MATCHED' AND sr.receiverMatchingStatus = 'SIGNAL')
+              OR (:userId = sr.receiverUser.id AND sr.receiverMatchingStatus = 'MATCHED' AND sr.senderMatchingStatus = 'SIGNAL')
+              THEN 'MATCH_PENDING'
+            ELSE 'MATCH_FAILED'
+        END
+    FROM SignalRoom sr
+    JOIN User u ON 
+        CASE 
+            WHEN sr.senderUser.id = :userId THEN sr.receiverUser.id
+            ELSE sr.senderUser.id
+        END = u.id
+    WHERE sr.id = :roomId
+""")
+    String findMatchResultByUser(@Param("userId") Long userId, @Param("roomId") Long roomId);
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseCode.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseCode.java
@@ -53,6 +53,12 @@ public class ResponseCode {
     public static final String NO_CHANNEL_ROOM = "NO_CHANNEL_ROOM";
     public static final String MESSAGE_CREATED = "MESSAGE_CREATED";
 
+    // 매칭 관련 응답
+    public static final String MATCH_SUCCESS = "MATCH_SUCCESS";
+    public static final String MATCH_FAILED = "MATCH_FAILED";
+    public static final String MATCH_PENDING = "MATCH_PENDING";
+    public static final String MATCH_REJECTION_SUCCESS = "MATCH_REJECTION_SUCCESS";
+
 
     /* AI Response */
     public static final String EMBEDDING_REGISTER_SUCCESS = "EMBEDDING_REGISTER_SUCCESS";


### PR DESCRIPTION
## 🔗 관련 이슈
- #85 
- #86 

## ✏️ 변경 사항
- 시그널 보내기 후 매칭 수락/거절 API 추가

## 📋 상세 설명
- 시그널 전송 후 24시간 동안 대화 가능, 이후에는 매칭 여부에 따라 대화방 유지 여부가 달라짐
- 개인 채널인 경우에만 해당함 (그룹 채널 x)
- 2명 모두 매칭 수락을 해야만 시그널 -> 매칭으로 성사됨
- 1명이라도 매칭 거절을 할 경우 매칭 성사되지 않음

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.
