### PR TITLE
[#195] Fix: 취향 등록 시 동시성 문제 수정

### DIFF
--- a/hertz-be/build.gradle
+++ b/hertz-be/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	implementation 'com.giffing.bucket4j.spring.boot.starter:bucket4j-spring-boot-starter:0.9.0'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+	implementation 'org.springframework.retry:spring-retry'
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/config/RetryConfig.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/config/RetryConfig.java
@@ -1,0 +1,17 @@
+package com.hertz.hertz_be.global.config;
+
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RetryConfig {
+    @Bean
+    public RetryTemplate retryTemplate() {
+        return RetryTemplate.builder()
+                .maxAttempts(3)
+                .fixedBackoff(1000)
+                .retryOn(Exception.class)
+                .build();
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- #195 

## ✏️ 변경 사항
- AI SERVER Response `409` - AI SERVER에 이미 등록된 사용자인 경우, 예외처리로 throw 하지 않고 200으로 처리하여 다음 과정으로 넘어갈 수 있도록 함
- AI SERVER Responce `404` - AI SERVER에 등록되지 않은 사용자를 튜닝페이지에서 조회하려 하는 오류, BE DB와 AI DB에 정상적으로 저장되지 않은 상태로 다음 기능으로 넘어감 -> AI SERVER 호출 전에 BE DB에 저장하는 트랜잭션이 커밋된 후 실행되도록 함 (TransactionSynchronizationManager)
- AI SERVER 데이터 저장 시 비정상적인 동작에 대비하여 RetryTemplate 추가 (총 3번 시도, 1초 지연)
- 취향 등록 관련 로직 가독성 향상

## 📋 상세 설명
- 

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.
