### PR TITLE
[#199] Fix: 낙관적 락 적용 및 트랜잭션 충돌 재시도 처리

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/TuningResult.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/TuningResult.java
@@ -33,4 +33,8 @@ public class TuningResult {
 
     @Column(nullable = false)
     private int lineup;
+
+    @Version
+    @Column(name = "version")
+    private Long version;
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/interests/service/InterestsService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/interests/service/InterestsService.java
@@ -65,50 +65,55 @@ public class InterestsService {
 
     @Transactional
     public void saveUserInterests(UserInterestsRequestDto userInterestsRequestDto, Long userId) throws Exception {
-        log.debug("🔥 [saveUserInterests] 취향 저장 시작 - userId: {}", userId);
-        Map<String, String> keywordsMap = userInterestsRequestDto.getKeywords().toMap();
-        Map<String, List<String>> interestsMap = userInterestsRequestDto.getInterests().toMap();
-        validateUserInterestsInput(keywordsMap, interestsMap);
+        retryTemplate.execute(retryContext -> {
+            log.debug("🔥 [saveUserInterests] 취향 저장 시작 - userId: {}", userId);
+            Map<String, String> keywordsMap = userInterestsRequestDto.getKeywords().toMap();
+            Map<String, List<String>> interestsMap = userInterestsRequestDto.getInterests().toMap();
+            validateUserInterestsInput(keywordsMap, interestsMap);
 
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> {
-                    log.error("❌ [saveUserInterests] 유저 없음 - userId: {}", userId);
-                    return new UserException("사용자를 찾을 수 없습니다.", ResponseCode.BAD_REQUEST);
-                });
-        log.debug("✅ [saveUserInterests] 유저 조회 완료 - email: {}", user.getEmail());
-      
-        resetCachingTuningResult(user);
-        log.debug("🔄 [saveUserInterests] 캐싱 튜닝 결과 초기화");
-
-        Map<String, Object> aiRequestBody = buildRequestAiBody(user);
-        Map<String, String> aiKeywords = new HashMap<>();
-        Map<String, String[]> aiInterests = new HashMap<>();
-
-        try {
-            saveKeywordInterests(user, keywordsMap, aiKeywords);
-            saveInterestItems(user, interestsMap, aiInterests);
-        } catch (Exception e) {
-            log.error("❌ [saveUserInterests] 취향 저장 중 예외 발생", e);
-            throw new UserException("취향 등록 처리에 문제가 발생했습니다.", ResponseCode.BAD_REQUEST);
-        }
-
-
-        // 트랜잭션 커밋 이후 실행
-        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-            @Override
-            public void afterCommit() {
-                try {
-                    retryTemplate.execute(context -> {
-                        log.debug("🚀 [saveUserInterests - TransactionSynchronizationManager] AI 서버에 요청 시작");
-                        Map<String, Object> responseMap = saveInterestsToAiServer(aiRequestBody, aiKeywords, aiInterests);
-                        log.debug("📥 [saveUserInterests - TransactionSynchronizationManager] AI 응답: {}", responseMap);
-                        return null;
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> {
+                        log.error("❌ [saveUserInterests] 유저 없음 - userId: {}", userId);
+                        return new UserException("사용자를 찾을 수 없습니다.", ResponseCode.BAD_REQUEST);
                     });
-                } catch (Exception e) {
-                    log.error("❌ AI 서버 호출 실패", e);
-                }
+            log.debug("✅ [saveUserInterests] 유저 조회 완료 - email: {}", user.getEmail());
+
+            resetCachingTuningResult(user);
+            log.debug("🔄 [saveUserInterests] 캐싱 튜닝 결과 초기화");
+
+            Map<String, Object> aiRequestBody = buildRequestAiBody(user);
+            Map<String, String> aiKeywords = new HashMap<>();
+            Map<String, String[]> aiInterests = new HashMap<>();
+
+            try {
+                saveKeywordInterests(user, keywordsMap, aiKeywords);
+                saveInterestItems(user, interestsMap, aiInterests);
+            } catch (Exception e) {
+                log.error("❌ [saveUserInterests] 취향 저장 중 예외 발생", e);
+                throw new UserException("취향 등록 처리에 문제가 발생했습니다.", ResponseCode.BAD_REQUEST);
             }
+
+
+            // 트랜잭션 커밋 이후 실행
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    try {
+                        retryTemplate.execute(context -> {
+                            log.debug("🚀 [saveUserInterests - TransactionSynchronizationManager] AI 서버에 요청 시작");
+                            Map<String, Object> responseMap = saveInterestsToAiServer(aiRequestBody, aiKeywords, aiInterests);
+                            log.debug("📥 [saveUserInterests - TransactionSynchronizationManager] AI 응답: {}", responseMap);
+                            return null;
+                        });
+                    } catch (Exception e) {
+                        log.error("❌ AI 서버 호출 실패", e);
+                    }
+                }
+            });
+
+            return null;
         });
+
     }
 
     private Map<String, Object> buildRequestAiBody(User user) {


### PR DESCRIPTION
## 🔗 관련 이슈
- #199 

## ✏️ 변경 사항
- 트랜잭션 충돌로 인한 낙관적 락 적용 (`@Version` 어노테이션 및 DB 내 `version` 필드 추가)
- 관심사 저장 로직에 대해 `retryTemplate` 기반 재시도 로직 추가

## 📋 상세 설명
- `TuningResult` 엔티티 수정 도중, 동시에 여러 트랜잭션이 접근하며 낙관적 락 충돌 발생
  - 예상 오류 발생 시나리오 : 한 사용자가 관심사를 저장하는 동안, 동시에 다른 트랜잭션에서 같은 튜닝 결과를 갱신
- 이를 해결하기 위해 `@Version` 필드 추가 및 DB 테이블에 `version` 컬럼 반영
- 낙관적 락 예외(`ObjectOptimisticLockingFailureException`) 발생 시 최대 3회까지 재시도하도록 `retryTemplate` 적용
- 트랜잭션 커밋 이후에 실행되는 AI 서버 호출 로직(`afterCommit`)은 기존대로 유지하며, 별도로 재시도 처리도 포함
- version 컬럼은 `BIGINT DEFAULT 0`으로 DB에 추가되어야 함
<br>

> 오류 발생 트랜잭션
<img width="1094" alt="image" src="https://github.com/user-attachments/assets/d4db4c57-2764-48c0-bc34-f490b7202bfc" />

> 직전 발생한 트랜잭션
<img width="1103" alt="image" src="https://github.com/user-attachments/assets/56cb40f9-5117-4d38-9146-b00167e0518b" />


## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.
