### PR TITLE
fix: cd 실패 시 rollback으로 넘어가지 않는 오류 수정

### DIFF
--- a/.github/workflows/cicd-backend.yml
+++ b/.github/workflows/cicd-backend.yml
@@ -23,9 +23,6 @@ jobs:
   backend-cd:
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
-    outputs:
-      deploy_status: ${{ steps.set-result.outputs.status }}
-      target_branch: ${{ steps.set-result.outputs.branch }}
     steps:
       # # ✅ act 테스트용 필요 패키지 설치 (명령어: act workflow_dispatch -W .github/workflows/cicd-backend.yml -P ubuntu-latest=ghcr.io/catthehacker/ubuntu:act-latest)
       # - name: Install required tools
@@ -133,10 +130,11 @@ jobs:
             ./be_deploy.sh
 
       - name: Wait for Spring Boot to start
-        run: sleep 15
+        run: |
+          echo "🕒 Spring Boot 서버 기동 대기 중..."
+          sleep 15
 
       - name: Health check with retries
-        id: set-result
         run: |
           echo "🔍 헬스체크 시작"
           if [[ "${{ env.BRANCH }}" == "main" ]]; then
@@ -149,7 +147,6 @@ jobs:
             echo "⏱️ 시도 $i: $CHECK_URL"
             if curl -sf "$CHECK_URL"; then
               echo "✅ 헬스체크 성공"
-              echo "status=success" >> $GITHUB_OUTPUT
               exit 0
             else
               echo "::error::헬스체크 시도 $i 실패"
@@ -158,11 +155,10 @@ jobs:
           done
 
           echo "::error::❌ 3회 헬스체크 실패"
-          echo "status=failure" >> $GITHUB_OUTPUT
-          exit 0
+          exit 1
 
       - name: Send failure notification
-        if: failure() || steps.set-result.outputs.status == 'failure'
+        if: failure()
         run: |
           WORKFLOW_URL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           curl -H "Content-Type: application/json" \
@@ -171,7 +167,7 @@ jobs:
             ${{ secrets.DISCORD_WEBHOOK_CICD_URL }}
 
       - name: Send success notification
-        if: steps.set-result.outputs.status == 'success'
+        if: success()
         run: |
           curl -H "Content-Type: application/json" \
             -X POST \
@@ -180,7 +176,7 @@ jobs:
 
   backend-rollback:
     needs: backend-cd
-    if: needs.backend-cd.outputs.deploy_status == 'failure'
+    if: always() && needs.backend-cd.result != 'success'
     runs-on: ubuntu-latest
     steps:
       # # ✅ act 테스트용 필요 패키지 설치
@@ -264,6 +260,11 @@ jobs:
           script: |
             cd /home/deploy
             ./be_deploy.sh --rollback || exit 1
+
+      - name: Wait for Spring Boot to start
+        run: |
+          echo "🕒 Spring Boot 서버 기동 대기 중..."
+          sleep 15
 
       - name: Health check with retries
         run: |


### PR DESCRIPTION
## 🔗 관련 이슈
- x

## ✏️ 변경 사항
- cd 실패 시 rollback으로 넘어가지 않는 오류 수정

## 📋 상세 설명
- cd 실패 exit 1로 종료되는 트리거를 rollback job에서 인식하지 못해 문제가 생김
- rollback job의 트리거에 `if: always() && needs.frontend-cd.result != 'success'`를 설정
- cd job에서 exit 1을 뱉고 끝내더라도, rollback job에 `always()`를 넣어 해당 job을 인식하게 설정하고, `&& needs.frontend-cd.result != 'success'` 조건을 추가로 걸어 cd job이 실패했을 때만 수행됨

## ✅ 체크리스트
- [x] 로컬에서 act로 스크립트가 정상동작 하는걸 확임

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.