### PR TITLE
[#87] Feat: 채널방 나가기 API 구현

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/ChannelController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/ChannelController.java
@@ -111,7 +111,7 @@ public class ChannelController {
     @PostMapping("/v2/matching/acceptances")
     @Operation(summary = "채널방 매칭 수락 API")
     public ResponseEntity<ResponseDto<Void>> channelMatchingAccept(@AuthenticationPrincipal Long userId,
-                                                                                     @RequestBody SignalMatchingRequestDTO response) {
+                                                                   @RequestBody SignalMatchingRequestDTO response) {
 
         String matchingResult = channelService.channelMatchingStatusUpdate(userId, response, MatchingStatus.MATCHED);
 
@@ -146,5 +146,18 @@ public class ChannelController {
                             channelService.channelMatchingStatusUpdate(userId, response, MatchingStatus.UNMATCHED)
                             , "매칭 거절이 완료되었습니다."
                             , null));
+    }
+
+    @DeleteMapping("/v2/channel-rooms/{channelRoomId}")
+    @Operation(summary = "채널방 나가기 API")
+    public ResponseEntity<ResponseDto<Void>> leaveChannelRoom(@PathVariable Long channelRoomId,
+                                                                                     @AuthenticationPrincipal Long userId) {
+
+        channelService.leaveChannelRoom(channelRoomId, userId);
+
+        return ResponseEntity
+                    .status(HttpStatus.CREATED)
+                    .body(new ResponseDto<>(ResponseCode.MESSAGE_CREATED, "채널방에서 정상적으로 나갔습니다.", null)
+                );
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/ChannelJoinRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/ChannelJoinRepository.java
@@ -1,0 +1,15 @@
+package com.hertz.hertz_be.domain.channel.repository;
+
+import com.hertz.hertz_be.domain.channel.entity.ChannelJoin;
+import com.hertz.hertz_be.domain.channel.entity.ChannelRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ChannelJoinRepository extends JpaRepository<ChannelRoom, Long> {
+    Optional<ChannelJoin> findByChannelRoomIdAndUserId(Long channelRoomId, Long userId);
+
+    void delete(ChannelJoin channelJoin);
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/ChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/ChannelService.java
@@ -49,7 +49,7 @@ public class ChannelService {
     private final UserInterestsRepository userInterestsRepository;
     private final SignalRoomRepository signalRoomRepository;
     private final SignalMessageRepository signalMessageRepository;
-    private final ChannelRoomRepository channelRoomRepository;
+    private final ChannelJoinRepository channelJoinRepository;
     private final WebClient webClient;
     private final AESUtil aesUtil;
 
@@ -60,7 +60,7 @@ public class ChannelService {
                           UserInterestsRepository userInterestsRepository,
                           SignalRoomRepository signalRoomRepository,
                           SignalMessageRepository signalMessageRepository,
-                          ChannelRoomRepository channelRoomRepository,
+                          ChannelJoinRepository channelJoinRepository,
                           AESUtil aesUtil,
                           @Value("${ai.server.ip}") String aiServerIp) {
         this.userRepository = userRepository;
@@ -69,7 +69,7 @@ public class ChannelService {
         this.userInterestsRepository = userInterestsRepository;
         this.signalMessageRepository = signalMessageRepository;
         this.signalRoomRepository = signalRoomRepository;
-        this.channelRoomRepository = channelRoomRepository;
+        this.channelJoinRepository = channelJoinRepository;
         this.aesUtil = aesUtil;
         this.webClient = WebClient.builder().baseUrl(aiServerIp).build();
     }
@@ -429,4 +429,14 @@ public class ChannelService {
             return ResponseCode.MATCH_REJECTION_SUCCESS;
         }
     }
+
+    @Transactional
+    public void leaveChannelRoom(Long channelRoomId, Long userId) {
+        ChannelJoin channelJoin = channelJoinRepository.findByChannelRoomIdAndUserId(channelRoomId, userId)
+                .orElseThrow(ChannelNotFoundException::new);
+
+        channelJoinRepository.delete(channelJoin);
+    }
+
+
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- #87 

## ✏️ 변경 사항
- 채널 도메인일 경우 채널방 내 '나가기' 버튼 활성화, 
- 사용자가 해당 버튼 클릭 시 채널방 나가기 처리 기능 추가

## 📋 상세 설명
- 기존에는 채널방 내 사용자가 임의로 나갈 수 있는 기능이 없었음
- 이번 변경을 통해 채널 도메인에서만 ‘나가기’ 버튼이 표시되며,
해당 버튼 클릭 시 channel_join 테이블에서 해당 사용자와 방의 관계가 삭제됨
- 채널방에 남은 사용자가 없을 경우, 채널방 자체 삭제 로직은 추후 처리 예정

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.
