### PR TITLE
[#88] Feat: 사용자 정보 조회 기능 구현

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/ChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/ChannelService.java
@@ -282,7 +282,7 @@ public class ChannelService {
         }
     }
 
-    private TuningResponseDTO buildTuningResponseDTO(Long requesterId, User target) {
+    private TuningResponseDto buildTuningResponseDTO(Long requesterId, User target) {
         Map<String, String> keywords = interestsService.getUserKeywords(target.getId());
         Map<String, List<String>> requesterInterests = interestsService.getUserInterests(requesterId);
         Map<String, List<String>> targetInterests = interestsService.getUserInterests(target.getId());
@@ -298,9 +298,6 @@ public class ChannelService {
                 sameInterests
         );
     }
-
-
-
 
     @Transactional(readOnly = true)
     public boolean hasNewMessages(Long userId) {

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/UserController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/UserController.java
@@ -2,6 +2,7 @@ package com.hertz.hertz_be.domain.user.controller;
 
 import com.hertz.hertz_be.domain.user.dto.request.UserInfoRequestDto;
 import com.hertz.hertz_be.domain.user.dto.response.UserInfoResponseDto;
+import com.hertz.hertz_be.domain.user.dto.response.UserProfileDTO;
 import com.hertz.hertz_be.domain.user.service.UserService;
 import com.hertz.hertz_be.global.common.ResponseCode;
 import com.hertz.hertz_be.global.common.ResponseDto;
@@ -12,13 +13,14 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
 import java.util.Map;
 
 @RestController
-@RequestMapping("/api/v1")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 @Tag(name = "사용자 관련 API")
 public class UserController {
@@ -33,7 +35,7 @@ public class UserController {
      * @param userInfoRequestDto
      * @author daisy.lee
      */
-    @PostMapping("/users")
+    @PostMapping("/v1/users")
     @Operation(summary = "개인정보 등록 API")
     public ResponseEntity<ResponseDto<Map<String, Object>>> createUser(
             @RequestBody UserInfoRequestDto userInfoRequestDto,
@@ -72,7 +74,7 @@ public class UserController {
      * 랜덤 닉네임 반환
      * @author daisy.lee
      */
-    @GetMapping("/nickname")
+    @GetMapping("/v1/nickname")
     @Operation(summary = "랜덤 닉네임 반환 API")
     public ResponseEntity<ResponseDto<Map<String, String>>> generateNickname() {
         String nickname = userService.fetchRandomNickname();
@@ -80,5 +82,27 @@ public class UserController {
         return ResponseEntity.ok(
                 new ResponseDto<>(ResponseCode.NICKNAME_CREATED, "닉네임이 성공적으로 생성되었습니다.", data)
         );
+    }
+
+
+    /**
+     * 사용자 정보 조회 (마이페이지, 상대방 상세 조회 페이지)
+     * @author daisy.lee
+     */
+    @GetMapping("/v2/users/{userId}")
+    @Operation(summary = "사용자 정보 조회")
+    public ResponseEntity<ResponseDto<UserProfileDTO>> getUserProfile(@PathVariable Long userId,
+                                                                      @AuthenticationPrincipal Long id) {
+        UserProfileDTO response = userService.getUserProfile(userId, id);
+
+        if(response.getRelationType().equals("ME")) {
+            return ResponseEntity.ok(
+                    new ResponseDto<>(ResponseCode.USER_INFO_FETCH_SUCCESS, "사용자의 정보가 정상적으로 조회되었습니다.", response)
+            );
+        } else {
+            return ResponseEntity.ok(
+                    new ResponseDto<>(ResponseCode.OTHER_USER_INFO_FETCH_SUCCESS, "상대방의 정보가 정상적으로 조회되었습니다.", response)
+            );
+        }
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/response/InterestsDTO.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/response/InterestsDTO.java
@@ -1,0 +1,23 @@
+package com.hertz.hertz_be.domain.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InterestsDTO {
+    private List<String> personality;
+    private List<String> preferredPeople;
+    private List<String> currentInterests;
+    private List<String> favoriteFoods;
+    private List<String> likedSports;
+    private List<String> pets;
+    private List<String> selfDevelopment;
+    private List<String> hobbies;
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/response/KeywordsDTO.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/response/KeywordsDTO.java
@@ -1,0 +1,17 @@
+package com.hertz.hertz_be.domain.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class KeywordsDTO {
+    private String mbti;
+    private String religion;
+    private String smoking;
+    private String drinking;
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/response/UserProfileDTO.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/response/UserProfileDTO.java
@@ -1,0 +1,24 @@
+package com.hertz.hertz_be.domain.user.dto.response;
+
+import com.hertz.hertz_be.domain.user.entity.enums.Gender;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserProfileDTO {
+    private String profileImage;
+    private String nickname;
+    private Gender gender;
+    private String oneLineIntroduction;
+    private String relationType;
+
+    private KeywordsDTO keywords;
+    private InterestsDTO interests;
+    private InterestsDTO sameInterests;
+
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/response/UserProfileDTO.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/response/UserProfileDTO.java
@@ -1,5 +1,6 @@
 package com.hertz.hertz_be.domain.user.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.hertz.hertz_be.domain.user.entity.enums.Gender;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -10,6 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class UserProfileDTO {
     private String profileImage;
     private String nickname;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/repository/UserRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/repository/UserRepository.java
@@ -1,10 +1,7 @@
 package com.hertz.hertz_be.domain.user.repository;
 
-import com.hertz.hertz_be.domain.channel.entity.SignalMessage;
 import com.hertz.hertz_be.domain.user.entity.User;
 import io.lettuce.core.dynamic.annotation.Param;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -19,4 +16,19 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("SELECT u FROM User u WHERE u.email LIKE %:domain AND u.deletedAt IS NULL")
     List<User> findAllByEmailDomain(@Param("domain") String domain);
+
+    @Query("""
+    SELECT
+        CASE
+            WHEN sr.senderMatchingStatus = com.hertz.hertz_be.domain.channel.entity.enums.MatchingStatus.MATCHED
+             AND sr.receiverMatchingStatus = com.hertz.hertz_be.domain.channel.entity.enums.MatchingStatus.MATCHED
+            THEN 'MATCHING'
+            ELSE 'SIGNAL'
+        END
+    FROM SignalRoom sr
+    WHERE (sr.senderUser.id = :currentUserId AND sr.receiverUser.id = :targetUserId)
+       OR (sr.senderUser.id = :targetUserId AND sr.receiverUser.id = :currentUserId)
+    """)
+    String findRelationTypeBetweenUsers(@Param("currentUserId") Long currentUserId,
+                                          @Param("targetUserId") Long targetUserId);
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/repository/UserRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/repository/UserRepository.java
@@ -32,4 +32,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     String findRelationTypeBetweenUsers(@Param("currentUserId") Long currentUserId,
                                           @Param("targetUserId") Long targetUserId);
 
+    @Query("SELECT u FROM User u LEFT JOIN FETCH u.sentSignalRooms WHERE u.id = :userId")
+    Optional<User> findByIdWithSentSignalRooms(@Param("userId") Long userId);
+
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/service/UserService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/service/UserService.java
@@ -23,7 +23,6 @@ import com.hertz.hertz_be.global.auth.token.JwtTokenProvider;
 import com.hertz.hertz_be.global.common.ResponseCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.crossstore.ChangeSetPersister;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -47,7 +46,6 @@ public class UserService {
     private final SignalRoomRepository signalRoomRepository;
     private final SignalMessageRepository signalMessageRepository;
     private final TuningResultRepository tuningResultRepository;
-    private final UserInterestsRepository userInterestsRepository;
     private final RestTemplate restTemplate = new RestTemplate();
     private final long TIMEOUT_NANOS = 5_000_000_000L; // // 5초 = 5_000_000_000 나노초
 

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/service/UserService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/service/UserService.java
@@ -1,9 +1,15 @@
 package com.hertz.hertz_be.domain.user.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hertz.hertz_be.domain.auth.repository.OAuthRedisRepository;
 import com.hertz.hertz_be.domain.auth.repository.RefreshTokenRepository;
+import com.hertz.hertz_be.domain.interests.repository.UserInterestsRepository;
+import com.hertz.hertz_be.domain.interests.service.InterestsService;
 import com.hertz.hertz_be.domain.user.dto.request.UserInfoRequestDto;
+import com.hertz.hertz_be.domain.user.dto.response.InterestsDTO;
+import com.hertz.hertz_be.domain.user.dto.response.KeywordsDTO;
 import com.hertz.hertz_be.domain.user.dto.response.UserInfoResponseDto;
+import com.hertz.hertz_be.domain.user.dto.response.UserProfileDTO;
 import com.hertz.hertz_be.domain.user.entity.User;
 import com.hertz.hertz_be.domain.user.entity.UserOauth;
 import com.hertz.hertz_be.domain.user.exception.UserException;
@@ -19,14 +25,18 @@ import org.springframework.web.client.RestTemplate;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.*;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
     private final UserOauthRepository userOauthRepository;
+    private final UserInterestsRepository userInterestsRepository;
     private final OAuthRedisRepository oauthRedisRepository;
-    private final RefreshTokenRepository refreshTokenService;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    private final InterestsService interestsService;
     private final JwtTokenProvider jwtTokenProvider;
     private final RestTemplate restTemplate = new RestTemplate();
     private final long TIMEOUT_NANOS = 5_000_000_000L; // // 5초 = 5_000_000_000 나노초
@@ -88,7 +98,7 @@ public class UserService {
         User savedUser = userRepository.save(user);
 
         String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
-        refreshTokenService.saveRefreshToken(user.getId(), refreshToken, maxAgeSeconds);
+        refreshTokenRepository.saveRefreshToken(user.getId(), refreshToken, maxAgeSeconds);
 
         return UserInfoResponseDto.builder()
                 .userId(savedUser.getId())
@@ -126,6 +136,52 @@ public class UserService {
             return response.getBody().trim();
         }
         throw new UserException(ResponseCode.NICKNAME_API_FAILED, "닉네임 생성 API 응답 실패");
+    }
+
+    public UserProfileDTO getUserProfile(Long targetUserId, Long userId) {
+        User targetUser = userRepository.findByIdAndDeletedAtIsNull(targetUserId)
+                .orElseThrow(() -> new UserException(ResponseCode.USER_DEACTIVATED, "상대방이 탈퇴한 사용자입니다."));
+
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        Map<String, String> keywordsMap = interestsService.getUserKeywords(targetUser.getId());
+        Map<String, List<String>> currentUserInterestsMap = interestsService.getUserInterests(userId);
+
+        KeywordsDTO keywordsDto = objectMapper.convertValue(keywordsMap, KeywordsDTO.class);
+        InterestsDTO currentUserDto = objectMapper.convertValue(currentUserInterestsMap, InterestsDTO.class);
+
+
+        if(Objects.equals(targetUser.getId(), userId)) { // 마이페이지 조회
+            return new UserProfileDTO(
+                    targetUser.getProfileImageUrl(),
+                    targetUser.getNickname(),
+                    targetUser.getGender(),
+                    targetUser.getOneLineIntroduction(),
+                    "ME",
+                    keywordsDto,
+                    currentUserDto,
+                    null
+            );
+        } else { // 상대방 페이지 조회
+            String relationType = userRepository.findRelationTypeBetweenUsers(userId, targetUser.getId());
+
+            Map<String, List<String>> targetInterestsMap = interestsService.getUserInterests(targetUser.getId());
+            Map<String, List<String>> sameInterestsMap = interestsService.extractSameInterests(targetInterestsMap, currentUserInterestsMap);
+            InterestsDTO sameInterestsDto = objectMapper.convertValue(sameInterestsMap, InterestsDTO.class);
+
+            return new UserProfileDTO(
+                    targetUser.getProfileImageUrl(),
+                    targetUser.getNickname(),
+                    targetUser.getGender(),
+                    targetUser.getOneLineIntroduction(),
+                    relationType,
+                    keywordsDto,
+                    currentUserDto,
+                    sameInterestsDto
+            );
+        }
+
+
     }
 }
 

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseCode.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseCode.java
@@ -77,4 +77,8 @@ public class ResponseCode {
     public static final String TUNING_NOT_FOUND_DATA = "TUNING_NOT_FOUND_DATA";
     public static final String TUNING_NOT_FOUND_LIST = "TUNING_NOT_FOUND_LIST";
 
+    /* 마이페이지, 상대방 상세 페이지 조회 */
+    public static final String USER_INFO_FETCH_SUCCESS = "USER_INFO_FETCH_SUCCESS";
+    public static final String OTHER_USER_INFO_FETCH_SUCCESS = "OTHER_USER_INFO_FETCH_SUCCESS";
+
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- #88 

## ✏️ 변경 사항
- 마이페이지 정보 조회 가능
- 상대방 상세 페이지 정보 조회 가능
- 관심사 매핑 관련 기능을 공통 메서드로 처리

## 📋 상세 설명
- 마이페이지 내 사용자의 개인정보, 취향정보 조회 가능 (keywords, interests)
- 상대방 상세 페이지 내 상대방의 개인정보, 취향정보 조회 가능 (keywords, interests, sameInterests)
   - 시그널 상태 : keywords, sameInterests 까지만 공개 (프론트에서 interests는 블러처리)
   - 매칭 상태 : keywords, sameInterests, interests 모두 공개
- 기존에 채널 도메인에서만 사용하던 관심사 매핑 관련 함수를 공통 메서드로 처리하여 사용자 도메인에서도 사용할 수 있도록 함

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 큰 기능은 없지만 리뷰해주실 부분이 있다면 코멘트 부탁드립니다!

## 📎 참고 자료 (선택)
- 시그널/매칭 상태에 따른 code, message 분리가 불필요한 것 같아 통일하였습니다. [API 명세서 참고](https://docs.google.com/spreadsheets/d/19OiUmoIrlbFr20BKg5lpO1wkBBeqZ8rd7ZEcPmRCkho/edit?gid=1448614724#gid=1448614724&range=A13:H16)
