### PR TITLE
[#215] Refactor: 새 메세지 여부 API 삭제

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/ChannelController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/ChannelController.java
@@ -52,22 +52,6 @@ public class ChannelController {
         );
     }
 
-    @GetMapping("/v1/new-messages")
-    @Operation(summary = "새 메세지 여부 체크 API")
-    public ResponseEntity<ResponseDto<Void>> checkNewMessages(@AuthenticationPrincipal Long userId) {
-        boolean hasNewMessage = channelService.hasNewMessages(userId);
-
-        if (hasNewMessage) {
-            return ResponseEntity.ok(
-                    new ResponseDto<>(ResponseCode.NEW_MESSAGE, "새 메시지가 정상적으로 조회되었습니다.", null)
-            );
-        } else {
-            return ResponseEntity.ok(
-                    new ResponseDto<>(ResponseCode.NO_ANY_NEW_MESSAGE, "새 메시지가 없습니다.", null)
-            );
-        }
-    }
-
     @GetMapping("/v1/channel")
     @Operation(summary = "개인 채널보관함 목록 반환 API")
     public ResponseEntity<ResponseDto<ChannelListResponseDto>> getPersonalSignalRoomList(@AuthenticationPrincipal Long userId,

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/ChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/ChannelService.java
@@ -342,21 +342,6 @@ public class ChannelService {
         return sameInterests;
     }
 
-    @Transactional(readOnly = true)
-    public boolean hasNewMessages(Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(UserNotFoundException::new);
-
-        List<SignalRoom> allRooms = Stream.concat(
-                user.getSentSignalRooms().stream(),
-                user.getReceivedSignalRooms().stream()
-        ).collect(Collectors.toList());
-
-        if (allRooms.isEmpty()) return false;
-
-        return signalMessageRepository.existsBySignalRoomInAndSenderUserNotAndIsReadFalse(allRooms, user);
-    }
-
     // Todo: 추후 시그널 -> 채널로 마이그레이션 시 메소드명 변경 필요 (getPersonalSignalRoomList -> getPersonalChannelList)
     public ChannelListResponseDto getPersonalSignalRoomList(Long userId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);


### PR DESCRIPTION
## 🔗 관련 이슈
- #215 

## ✏️ 변경 사항
- MVP 단계에서 구현했지만, 이제는 SSE가 도입됨에 따라 더 이상 사용되지 않는 API 삭제

## 📋 상세 설명
- ChannelController에서 해당 API의 메서드 삭제
- ChannelService에서 해당 API의 메서드 삭제

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 없음

## 📎 참고 자료 (선택)
- 없음
