### PR TITLE
[#225] 튜닝리포트 조회 및 리액션 API 기능 구현

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/controller/TuningReportController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/controller/TuningReportController.java
@@ -1,0 +1,45 @@
+package com.hertz.hertz_be.domain.tuningreport.controller;
+
+import com.hertz.hertz_be.domain.tuningreport.dto.response.TuningReportListResponse;
+import com.hertz.hertz_be.domain.tuningreport.entity.enums.TuningReportSortType;
+import com.hertz.hertz_be.domain.tuningreport.service.TuningReportService;
+import com.hertz.hertz_be.global.common.ResponseCode;
+import com.hertz.hertz_be.global.common.ResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v2")
+@RequiredArgsConstructor
+@Tag(name = "튜닝 리포트 관련 API")
+public class TuningReportController {
+
+    private final TuningReportService tuningReportService;
+
+    /**
+     * 튜닝 리포트 목록 반환 API
+     * @param page
+     * @param size
+     * @param sort
+     * @param userId
+     * @author daisy.lee
+     */
+    @GetMapping("/reports")
+    @Operation(summary = "튜닝 리포트 목록 반환 API")
+    public ResponseEntity<ResponseDto<TuningReportListResponse>> createTuningReport (@RequestParam(defaultValue = "0") int page,
+                                                                                     @RequestParam(defaultValue = "20") int size,
+                                                                                     @RequestParam(defaultValue = "LATEST") TuningReportSortType sort,
+                                                                                     @AuthenticationPrincipal Long userId) {
+
+        TuningReportListResponse response = tuningReportService.getReportList(userId, page, size, sort);
+        return ResponseEntity.ok(new ResponseDto<>(
+                ResponseCode.REPORT_LIST_FETCH_SUCCESS,
+                "튜닝 리포트가 정상적으로 조회되었습니다.",
+                response
+        ));
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/controller/TuningReportController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/controller/TuningReportController.java
@@ -1,12 +1,16 @@
 package com.hertz.hertz_be.domain.tuningreport.controller;
 
+import com.hertz.hertz_be.domain.tuningreport.dto.request.TuningReportReactionToggleRequest;
 import com.hertz.hertz_be.domain.tuningreport.dto.response.TuningReportListResponse;
+import com.hertz.hertz_be.domain.tuningreport.dto.response.TuningReportReactionResponse;
 import com.hertz.hertz_be.domain.tuningreport.entity.enums.TuningReportSortType;
+import com.hertz.hertz_be.domain.tuningreport.service.TuningReportReactionService;
 import com.hertz.hertz_be.domain.tuningreport.service.TuningReportService;
 import com.hertz.hertz_be.global.common.ResponseCode;
 import com.hertz.hertz_be.global.common.ResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -19,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 public class TuningReportController {
 
     private final TuningReportService tuningReportService;
+    private final TuningReportReactionService tuningReportReactionService;
 
     /**
      * 튜닝 리포트 목록 반환 API
@@ -41,5 +46,35 @@ public class TuningReportController {
                 "튜닝 리포트가 정상적으로 조회되었습니다.",
                 response
         ));
+    }
+
+    /**
+     * 특정 튜닝 리포트 리액션 토글 API
+     * @param reportId
+     * @param userId
+     * @author daisy.lee
+     */
+    @PutMapping("/reports/{reportId}/reactions")
+    @Operation(summary = "특정 튜닝 리포트 리액션 토글 API")
+    public ResponseEntity<ResponseDto<TuningReportReactionResponse>> toggleTuningReport (@PathVariable Long reportId,
+                                                                                         @RequestBody @Valid TuningReportReactionToggleRequest request,
+                                                                                         @AuthenticationPrincipal Long userId) {
+
+        TuningReportReactionResponse response = tuningReportReactionService.toggleReportReaction(userId, reportId, request);
+
+        if(response.isReacted()) {
+            return ResponseEntity.ok(new ResponseDto<>(
+                    ResponseCode.REACTION_ADDED,
+                    "리액션이 성공적으로 추가되었습니다.",
+                    response
+            ));
+        } else {
+            return ResponseEntity.ok(new ResponseDto<>(
+                    ResponseCode.REACTION_REMOVED,
+                    "리액션이 성공적으로 제거되었습니다.",
+                    response
+            ));
+        }
+
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/controller/TuningReportController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/controller/TuningReportController.java
@@ -31,7 +31,7 @@ public class TuningReportController {
     @GetMapping("/reports")
     @Operation(summary = "튜닝 리포트 목록 반환 API")
     public ResponseEntity<ResponseDto<TuningReportListResponse>> createTuningReport (@RequestParam(defaultValue = "0") int page,
-                                                                                     @RequestParam(defaultValue = "20") int size,
+                                                                                     @RequestParam(defaultValue = "10") int size,
                                                                                      @RequestParam(defaultValue = "LATEST") TuningReportSortType sort,
                                                                                      @AuthenticationPrincipal Long userId) {
 

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/controller/TuningReportController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/controller/TuningReportController.java
@@ -41,11 +41,22 @@ public class TuningReportController {
                                                                                      @AuthenticationPrincipal Long userId) {
 
         TuningReportListResponse response = tuningReportService.getReportList(userId, page, size, sort);
-        return ResponseEntity.ok(new ResponseDto<>(
-                ResponseCode.REPORT_LIST_FETCH_SUCCESS,
-                "튜닝 리포트가 정상적으로 조회되었습니다.",
-                response
-        ));
+
+        if(!response.list().isEmpty()) {
+            return ResponseEntity.ok(new ResponseDto<>(
+                    ResponseCode.REPORT_LIST_FETCH_SUCCESS,
+                    "튜닝 리포트가 정상적으로 조회되었습니다.",
+                    response
+            ));
+        } else {
+            return ResponseEntity.ok(new ResponseDto<>(
+                    ResponseCode.NO_REPORTS,
+                    "새로운 튜닝 리포트가 없습니다.",
+                    null
+            ));
+        }
+
+
     }
 
     /**

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/dto/request/TuningReportReactionToggleRequest.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/dto/request/TuningReportReactionToggleRequest.java
@@ -1,0 +1,8 @@
+package com.hertz.hertz_be.domain.tuningreport.dto.request;
+
+import com.hertz.hertz_be.domain.tuningreport.entity.enums.ReactionType;
+import jakarta.validation.constraints.NotNull;
+
+public record TuningReportReactionToggleRequest (
+        @NotNull ReactionType reactionType
+) {}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/dto/response/TuningReportListResponse.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/dto/response/TuningReportListResponse.java
@@ -1,0 +1,37 @@
+package com.hertz.hertz_be.domain.tuningreport.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record TuningReportListResponse(
+        List<ReportItem> list,
+        int pageNumber,
+        int pageSize,
+        boolean isLast
+) {
+        public record ReportItem(
+                LocalDateTime createdDate,
+                Long reportId,
+                String title,
+                String content,
+                Reactions reactions,
+                MyReactions myReactions
+        ) {
+            public record Reactions(
+                    int celebrate,
+                    int thumbsUp,
+                    int laugh,
+                    int eyes,
+                    int heart
+            ) {}
+
+            public record MyReactions(
+                    boolean celebrate,
+                    boolean thumbsUp,
+                    boolean laugh,
+                    boolean eyes,
+                    boolean heart
+            ) {}
+        }
+    }
+

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/dto/response/TuningReportReactionResponse.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/dto/response/TuningReportReactionResponse.java
@@ -1,0 +1,10 @@
+package com.hertz.hertz_be.domain.tuningreport.dto.response;
+
+import com.hertz.hertz_be.domain.tuningreport.entity.enums.ReactionType;
+
+public record TuningReportReactionResponse (
+        Long reportId,
+        ReactionType reactionType,
+        boolean isReacted,
+        int reactionCount
+) {}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/entity/TuningReport.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/entity/TuningReport.java
@@ -1,5 +1,6 @@
 package com.hertz.hertz_be.domain.tuningreport.entity;
 
+import com.hertz.hertz_be.domain.tuningreport.entity.enums.ReactionType;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
@@ -47,6 +48,10 @@ public class TuningReport {
     @ColumnDefault("0")
     private int reactionHeart;
 
+    @Version
+    @Column(name = "version")
+    private Long version;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
@@ -64,5 +69,25 @@ public class TuningReport {
     @PreUpdate
     public void preUpdate() { // 엔티티 수정 전 호출
         this.modifiedAt = LocalDateTime.now();
+    }
+
+    public void increaseReaction(ReactionType type) {
+        switch (type) {
+            case CELEBRATE -> this.reactionCelebrate++;
+            case THUMBS_UP -> this.reactionThumbsUp++;
+            case LAUGH -> this.reactionLaugh++;
+            case EYES -> this.reactionEyes++;
+            case HEART -> this.reactionHeart++;
+        }
+    }
+
+    public void decreaseReaction(ReactionType type) {
+        switch (type) {
+            case CELEBRATE -> this.reactionCelebrate = Math.max(0, this.reactionCelebrate - 1);
+            case THUMBS_UP -> this.reactionThumbsUp = Math.max(0, this.reactionThumbsUp - 1);
+            case LAUGH -> this.reactionLaugh = Math.max(0, this.reactionLaugh - 1);
+            case EYES -> this.reactionEyes = Math.max(0, this.reactionEyes - 1);
+            case HEART -> this.reactionHeart = Math.max(0, this.reactionHeart - 1);
+        }
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/entity/TuningReport.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/entity/TuningReport.java
@@ -1,0 +1,68 @@
+package com.hertz.hertz_be.domain.tuningreport.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@SQLDelete(sql = "UPDATE tuning_report SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
+@Where(clause = "deleted_at IS NULL")
+@Table(name = "tuning_report")
+public class TuningReport {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 50, nullable = false)
+    private String title;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @Column(name = "reaction_celebrate", nullable = false)
+    @ColumnDefault("0")
+    private int reactionCelebrate;
+
+    @Column(name = "reaction_thumbs_up", nullable = false)
+    @ColumnDefault("0")
+    private int reactionThumbsUp;
+
+    @Column(name = "reaction_laugh", nullable = false)
+    @ColumnDefault("0")
+    private int reactionLaugh;
+
+    @Column(name = "reaction_eyes", nullable = false)
+    @ColumnDefault("0")
+    private int reactionEyes;
+
+    @Column(name = "reaction_heart", nullable = false)
+    @ColumnDefault("0")
+    private int reactionHeart;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "modified_at", nullable = false)
+    private LocalDateTime modifiedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @PrePersist
+    public void prePersist() { // 엔티티 저장 전 호출
+        this.createdAt = this.modifiedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void preUpdate() { // 엔티티 수정 전 호출
+        this.modifiedAt = LocalDateTime.now();
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/entity/TuningReportUserReaction.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/entity/TuningReportUserReaction.java
@@ -3,15 +3,13 @@ package com.hertz.hertz_be.domain.tuningreport.entity;
 import com.hertz.hertz_be.domain.tuningreport.entity.enums.ReactionType;
 import com.hertz.hertz_be.domain.user.entity.User;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Builder
 @Table(name = "tuning_report_user_reaction",
        uniqueConstraints = @UniqueConstraint(columnNames = {"report_id", "user_id", "reaction_type"}))
 

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/entity/TuningReportUserReaction.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/entity/TuningReportUserReaction.java
@@ -1,0 +1,34 @@
+package com.hertz.hertz_be.domain.tuningreport.entity;
+
+import com.hertz.hertz_be.domain.tuningreport.entity.enums.ReactionType;
+import com.hertz.hertz_be.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "tuning_report_user_reaction",
+       uniqueConstraints = @UniqueConstraint(columnNames = {"report_id", "user_id", "reaction_type"}))
+
+public class TuningReportUserReaction {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "report_id", nullable = false)
+    private TuningReport report;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "reaction_type", length = 15, nullable = false)
+    private ReactionType reactionType;
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/entity/enums/ReactionType.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/entity/enums/ReactionType.java
@@ -1,0 +1,14 @@
+package com.hertz.hertz_be.domain.tuningreport.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ReactionType {
+    CELEBRATE,
+    THUMBS_UP,
+    LAUGH,
+    EYES,
+    HEART;
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/entity/enums/TuningReportSortType.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/entity/enums/TuningReportSortType.java
@@ -1,0 +1,23 @@
+package com.hertz.hertz_be.domain.tuningreport.entity.enums;
+
+import com.hertz.hertz_be.domain.tuningreport.entity.TuningReport;
+import com.hertz.hertz_be.domain.tuningreport.repository.TuningReportRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public enum TuningReportSortType {
+    LATEST {
+        @Override
+        public Page<TuningReport> fetch(Pageable pageable, TuningReportRepository repository) {
+            return repository.findAllByOrderByCreatedAtDesc(pageable);
+        }
+    },
+    POPULAR {
+        @Override
+        public Page<TuningReport> fetch(Pageable pageable, TuningReportRepository repository) {
+            return repository.findAllOrderByTotalReactionDesc(pageable);
+        }
+    };
+
+    public abstract Page<TuningReport> fetch(Pageable pageable, TuningReportRepository repository);
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/repository/TuningReportRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/repository/TuningReportRepository.java
@@ -1,0 +1,24 @@
+package com.hertz.hertz_be.domain.tuningreport.repository;
+
+import com.hertz.hertz_be.domain.tuningreport.entity.TuningReport;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TuningReportRepository extends JpaRepository<TuningReport, Long> {
+    Page<TuningReport> findAllByOrderByCreatedAtDesc(Pageable pageable);
+    @Query("""
+    SELECT r FROM TuningReport r
+    ORDER BY (
+        r.reactionCelebrate +
+        r.reactionThumbsUp +
+        r.reactionLaugh +
+        r.reactionEyes +
+        r.reactionHeart
+    ) DESC
+""")
+    Page<TuningReport> findAllOrderByTotalReactionDesc(Pageable pageable);
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/repository/TuningReportUserReactionRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/repository/TuningReportUserReactionRepository.java
@@ -1,0 +1,12 @@
+package com.hertz.hertz_be.domain.tuningreport.repository;
+
+import com.hertz.hertz_be.domain.tuningreport.entity.TuningReportUserReaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface TuningReportUserReactionRepository extends JpaRepository<TuningReportUserReaction, Long> {
+    List<TuningReportUserReaction> findAllByUserIdAndReportIdIn(Long userId, List<Long> reportIds);
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/repository/TuningReportUserReactionRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/repository/TuningReportUserReactionRepository.java
@@ -1,6 +1,7 @@
 package com.hertz.hertz_be.domain.tuningreport.repository;
 
 import com.hertz.hertz_be.domain.tuningreport.entity.TuningReportUserReaction;
+import com.hertz.hertz_be.domain.tuningreport.entity.enums.ReactionType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +10,6 @@ import java.util.List;
 @Repository
 public interface TuningReportUserReactionRepository extends JpaRepository<TuningReportUserReaction, Long> {
     List<TuningReportUserReaction> findAllByUserIdAndReportIdIn(Long userId, List<Long> reportIds);
+    boolean existsByReportIdAndUserIdAndReactionType(Long reportId, Long userId, ReactionType reactionType);
+    void deleteByReportIdAndUserIdAndReactionType(Long reportId, Long userId, ReactionType reactionType);
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportReactionService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportReactionService.java
@@ -1,0 +1,61 @@
+package com.hertz.hertz_be.domain.tuningreport.service;
+
+import com.hertz.hertz_be.domain.tuningreport.dto.request.TuningReportReactionToggleRequest;
+import com.hertz.hertz_be.domain.tuningreport.dto.response.TuningReportReactionResponse;
+import com.hertz.hertz_be.domain.tuningreport.entity.TuningReport;
+import com.hertz.hertz_be.domain.tuningreport.entity.TuningReportUserReaction;
+import com.hertz.hertz_be.domain.tuningreport.entity.enums.ReactionType;
+import com.hertz.hertz_be.domain.tuningreport.repository.TuningReportRepository;
+import com.hertz.hertz_be.domain.tuningreport.repository.TuningReportUserReactionRepository;
+import com.hertz.hertz_be.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TuningReportReactionService {
+
+    private final TuningReportRepository tuningReportRepository;
+    private final TuningReportUserReactionRepository tuningReportUserReactionRepository;
+
+    @Transactional
+    @Retryable(
+            value = {ObjectOptimisticLockingFailureException.class},
+            maxAttempts = 3
+    )
+    public TuningReportReactionResponse toggleReportReaction(Long userId, Long reportId, TuningReportReactionToggleRequest request) {
+        TuningReport report = tuningReportRepository.findById(reportId)
+                .orElseThrow(() -> new IllegalArgumentException("리포트가 존재하지 않습니다."));
+
+        ReactionType reactionType = request.reactionType();
+        boolean isReacted;
+
+        if(tuningReportUserReactionRepository.existsByReportIdAndUserIdAndReactionType(reportId, userId, reactionType)) { // 이미 선택한 리액션인지 확인
+            tuningReportUserReactionRepository.deleteByReportIdAndUserIdAndReactionType(reportId, userId, reactionType);
+            report.decreaseReaction(reactionType);
+            isReacted = false;
+        } else {
+            TuningReportUserReaction reaction = TuningReportUserReaction.builder()
+                    .report(report)
+                    .user(User.of(userId))
+                    .reactionType(request.reactionType())
+                    .build();
+
+            tuningReportUserReactionRepository.save(reaction);
+            report.increaseReaction(reactionType);
+            isReacted = true;
+        }
+
+        int reactionCount = report.getReactionCelebrate()
+                + report.getReactionThumbsUp()
+                + report.getReactionLaugh()
+                + report.getReactionEyes()
+                + report.getReactionHeart();
+
+        return new TuningReportReactionResponse (reportId, reactionType, isReacted, reactionCount);
+
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportService.java
@@ -1,0 +1,80 @@
+package com.hertz.hertz_be.domain.tuningreport.service;
+
+import com.hertz.hertz_be.domain.tuningreport.dto.response.TuningReportListResponse;
+import com.hertz.hertz_be.domain.tuningreport.entity.TuningReport;
+import com.hertz.hertz_be.domain.tuningreport.entity.TuningReportUserReaction;
+import com.hertz.hertz_be.domain.tuningreport.entity.enums.ReactionType;
+import com.hertz.hertz_be.domain.tuningreport.entity.enums.TuningReportSortType;
+import com.hertz.hertz_be.domain.tuningreport.repository.TuningReportRepository;
+import com.hertz.hertz_be.domain.tuningreport.repository.TuningReportUserReactionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class TuningReportService {
+
+    private final TuningReportRepository tuningReportRepository;
+    private final TuningReportUserReactionRepository tuningReportUserReactionRepository;
+
+    @Transactional(readOnly = true)
+    public TuningReportListResponse getReportList(Long userId, int page, int size, TuningReportSortType sort) {
+        PageRequest pageRequest = PageRequest.of(page, size);
+        Page<TuningReport> reports = sort.fetch(pageRequest, tuningReportRepository); // 정렬 타입에 따라
+
+        List<Long> reportIds = reports.stream()
+                .map(TuningReport::getId)
+                .toList();
+
+        List<TuningReportUserReaction> userReactions = tuningReportUserReactionRepository
+                .findAllByUserIdAndReportIdIn(userId, reportIds);
+
+        Map<Long, Set<ReactionType>> userReactionMap = userReactions.stream()
+                .collect(Collectors.groupingBy(
+                        r -> r.getReport().getId(),
+                        Collectors.mapping(TuningReportUserReaction::getReactionType, Collectors.toSet())
+                ));
+
+        List<TuningReportListResponse.ReportItem> reportItems = reports.stream()
+                .map(report -> {
+                    Set<ReactionType> myReaction = userReactionMap.getOrDefault(report.getId(), Set.of());
+
+                    return new TuningReportListResponse.ReportItem(
+                            report.getCreatedAt(),
+                            report.getId(),
+                            report.getTitle(),
+                            report.getContent(),
+                            new TuningReportListResponse.ReportItem.Reactions(
+                                    report.getReactionCelebrate(),
+                                    report.getReactionThumbsUp(),
+                                    report.getReactionLaugh(),
+                                    report.getReactionEyes(),
+                                    report.getReactionHeart()
+                            ),
+                            new TuningReportListResponse.ReportItem.MyReactions(
+                                    myReaction.contains(ReactionType.CELEBRATE),
+                                    myReaction.contains(ReactionType.THUMBS_UP),
+                                    myReaction.contains(ReactionType.LAUGH),
+                                    myReaction.contains(ReactionType.EYES),
+                                    myReaction.contains(ReactionType.HEART)
+                            )
+                    );
+                }).toList();
+
+        return new TuningReportListResponse(
+            reportItems,
+            reports.getNumber(),
+            reports.getSize(),
+            reports.isLast()
+        );
+    }
+
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/entity/User.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/entity/User.java
@@ -1,10 +1,8 @@
 package com.hertz.hertz_be.domain.user.entity;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.hertz.hertz_be.domain.channel.entity.SignalMessage;
 import com.hertz.hertz_be.domain.channel.entity.SignalRoom;
 import com.hertz.hertz_be.domain.channel.entity.Tuning;
-import com.hertz.hertz_be.domain.channel.entity.TuningResult;
 import com.hertz.hertz_be.domain.user.entity.enums.AgeGroup;
 import com.hertz.hertz_be.domain.user.entity.enums.Gender;
 import com.hertz.hertz_be.domain.user.entity.enums.MembershipType;
@@ -96,4 +94,10 @@ public class User {
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
     @Builder.Default
     private List<Tuning> recommendListByCategory = new ArrayList<>();
+
+    public static User of(Long id) {
+        User user = new User();
+        user.setId(id);
+        return user;
+    }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/repository/UserRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/repository/UserRepository.java
@@ -1,10 +1,7 @@
 package com.hertz.hertz_be.domain.user.repository;
 
-import com.hertz.hertz_be.domain.channel.entity.SignalMessage;
 import com.hertz.hertz_be.domain.user.entity.User;
 import io.lettuce.core.dynamic.annotation.Param;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseCode.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseCode.java
@@ -90,6 +90,7 @@ public class ResponseCode {
 
     // 튜닝 리포트 관련 응답 code
     public static final String REPORT_LIST_FETCH_SUCCESS = "REPORT_LIST_FETCH_SUCCESS";
+    public static final String NO_REPORTS = "NO_REPORTS";
     public static final String REACTION_ADDED = "REACTION_ADDED";
     public static final String REACTION_REMOVED = "REACTION_REMOVED";
     public static final String DELETED_REPORT = "DELETED_REPORT";

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseCode.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseCode.java
@@ -88,4 +88,7 @@ public class ResponseCode {
      */
     public static final String USER_DELETE_SUCCESS = "USER_DELETE_SUCCESS";
 
+    // 튜닝 리포트 관련 응답 code
+    public static final String REPORT_LIST_FETCH_SUCCESS = "REPORT_LIST_FETCH_SUCCESS";
+
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseCode.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseCode.java
@@ -90,5 +90,9 @@ public class ResponseCode {
 
     // 튜닝 리포트 관련 응답 code
     public static final String REPORT_LIST_FETCH_SUCCESS = "REPORT_LIST_FETCH_SUCCESS";
+    public static final String REACTION_ADDED = "REACTION_ADDED";
+    public static final String REACTION_REMOVED = "REACTION_REMOVED";
+    public static final String DELETED_REPORT = "DELETED_REPORT";
+
 
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- #225 

## ✏️ 변경 사항
- 튜닝 리포트 조회 API 구현
- 튜닝 리포트 리액션 토글 API 구현

## 📋 상세 설명
- 튜닝 리포트 조회 API 구현 (GET `/api/v2/reports?page={페이지번호}&size={페이지크기}`)
   - 로그인 사용자를 위한 튜닝 리포트 리스트 조회
   - 리액션 정보 포함 (전체 리액션 수, 로그인한 사용자의 반응 여부)
   - content : 마크다운 포함 텍스트 지원
   - 인기순/최신순 정렬 방식 지원
- 튜닝 리포트 리액션 토글 API 구현 (PUT `/api/v2/reports/{reportId}/reactions`)
   - 로그인 사용자가 특정 리포트에 리액션(좋아요, 축하 등) 추가/삭제
   - 토글 동작
     - 이미 리액션한 경우 : 제거
     - 아직 리액션하지 않은 경우 : 추가

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.
