### PR TITLE
[#244] Feat: 특정 사용자를 위한 최근 30일 동안 모든 알림 반환 API 구현

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/controller/AlarmController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/controller/AlarmController.java
@@ -1,6 +1,7 @@
 package com.hertz.hertz_be.domain.alarm.controller;
 
 import com.hertz.hertz_be.domain.alarm.dto.request.CreateNotifyAlarmRequestDto;
+import com.hertz.hertz_be.domain.alarm.dto.response.AlarmListResponseDto;
 import com.hertz.hertz_be.domain.alarm.service.AlarmService;
 import com.hertz.hertz_be.global.common.ResponseCode;
 import com.hertz.hertz_be.global.common.ResponseDto;
@@ -11,10 +12,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -33,6 +31,20 @@ public class AlarmController {
         return ResponseEntity.status(201).body(
                 new ResponseDto<>(ResponseCode.NOTICE_CREATED_SUCCESS, "공지가 성공적으로 등록되었습니다.", null)
         );
+    }
+
+    @GetMapping("/api/v2/alarms")
+    @Operation(summary = "특정 사용자를 위한 최근 30일 동안 모든 알림 반환 API")
+    public ResponseEntity<ResponseDto<AlarmListResponseDto>> getAlarmList(@RequestParam(defaultValue = "0") int page,
+                                                                          @RequestParam(defaultValue = "10") int size,
+                                                                          @AuthenticationPrincipal Long userId) {
+        AlarmListResponseDto dto = alarmService.getAlarmList(page, size, userId);
+        if (dto.list().isEmpty()) {
+            return ResponseEntity.ok(new ResponseDto<>(
+                    ResponseCode.NO_ALARMS, "최근 30일 동안 새로운 알림이 없습니다.", dto));
+        }
+        return ResponseEntity.ok(new ResponseDto<>(
+                ResponseCode.ALARM_FETCH_SUCCESS, "알림이 정상적으로 조회되었습니다.", dto));
     }
 
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/dto/response/AlarmListResponseDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/dto/response/AlarmListResponseDto.java
@@ -1,0 +1,12 @@
+package com.hertz.hertz_be.domain.alarm.dto.response;
+
+import com.hertz.hertz_be.domain.alarm.dto.response.object.AlarmItem;
+
+import java.util.List;
+
+public record AlarmListResponseDto(
+        List<AlarmItem> list,
+        int pageNumber,
+        int pageSize,
+        boolean isLast
+) {}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/dto/response/object/AlarmItem.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/dto/response/object/AlarmItem.java
@@ -1,0 +1,20 @@
+package com.hertz.hertz_be.domain.alarm.dto.response.object;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        include = JsonTypeInfo.As.PROPERTY,
+        property = "type"
+)
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = NoticeAlarm.class, name = "NOTICE"),
+        @JsonSubTypes.Type(value = ReportAlarm.class, name = "REPORT"),
+        @JsonSubTypes.Type(value = MatchingAlarm.class, name = "MATCHING")
+})
+public sealed interface AlarmItem permits NoticeAlarm, ReportAlarm, MatchingAlarm {
+    String type();
+    String title();
+    String createdDate();
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/dto/response/object/MatchingAlarm.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/dto/response/object/MatchingAlarm.java
@@ -1,0 +1,8 @@
+package com.hertz.hertz_be.domain.alarm.dto.response.object;
+
+public record MatchingAlarm(
+        String type,
+        String title,
+        Long channelRoomId,
+        String createdDate
+) implements AlarmItem {}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/dto/response/object/NoticeAlarm.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/dto/response/object/NoticeAlarm.java
@@ -1,0 +1,8 @@
+package com.hertz.hertz_be.domain.alarm.dto.response.object;
+
+public record NoticeAlarm(
+        String type,
+        String title,
+        String content,
+        String createdDate
+) implements AlarmItem {}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/dto/response/object/ReportAlarm.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/dto/response/object/ReportAlarm.java
@@ -1,0 +1,7 @@
+package com.hertz.hertz_be.domain.alarm.dto.response.object;
+
+public record ReportAlarm(
+        String type,
+        String title,
+        String createdDate
+) implements AlarmItem {}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/entity/AlarmMatching.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/entity/AlarmMatching.java
@@ -1,5 +1,6 @@
 package com.hertz.hertz_be.domain.alarm.entity;
 
+import com.hertz.hertz_be.domain.channel.entity.SignalRoom;
 import com.hertz.hertz_be.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -23,8 +24,9 @@ public class AlarmMatching extends Alarm{
     @Column(name = "partner_nickname", nullable = false)
     private String partnerNickname;
 
-    @Column(name = "channel_roomId", nullable = false)
-    private Long channelRoomId;
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "signal_room_id", nullable = false)
+    private SignalRoom signalRoom;
 
     @Column(name = "is_matched", nullable = false)
     private boolean isMatched;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/entity/AlarmMatching.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/entity/AlarmMatching.java
@@ -23,6 +23,9 @@ public class AlarmMatching extends Alarm{
     @Column(name = "partner_nickname", nullable = false)
     private String partnerNickname;
 
+    @Column(name = "channel_roomId", nullable = false)
+    private Long channelRoomId;
+
     @Column(name = "is_matched", nullable = false)
     private boolean isMatched;
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/entity/enums/AlarmCategory.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/entity/enums/AlarmCategory.java
@@ -1,0 +1,15 @@
+package com.hertz.hertz_be.domain.alarm.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AlarmCategory {
+    NOTICE("공지 알림", "NOTICE"),
+    REPORT("리포트 알림", "REPORT"),
+    MATCHING("매칭 결과 알림", "MATCHING");
+
+    private final String label;
+    private final String value;
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/repository/UserAlarmRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/repository/UserAlarmRepository.java
@@ -1,7 +1,27 @@
 package com.hertz.hertz_be.domain.alarm.repository;
 
 import com.hertz.hertz_be.domain.alarm.entity.UserAlarm;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+
 public interface UserAlarmRepository extends JpaRepository<UserAlarm, Long> {
+
+    @Query("""
+        SELECT ua
+        FROM UserAlarm ua
+        JOIN FETCH ua.alarm a
+        WHERE ua.user.id = :userId
+          AND a.createdAt >= :thresholdDate
+        ORDER BY a.createdAt DESC
+    """)
+    Page<UserAlarm> findRecentUserAlarms(
+            @Param("userId") Long userId,
+            @Param("thresholdDate") LocalDateTime thresholdDate,
+            Pageable pageable
+    );
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/service/AlarmService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/service/AlarmService.java
@@ -1,18 +1,28 @@
 package com.hertz.hertz_be.domain.alarm.service;
 
-import com.hertz.hertz_be.domain.alarm.entity.AlarmNotification;
-import com.hertz.hertz_be.domain.alarm.entity.UserAlarm;
+import com.hertz.hertz_be.domain.alarm.dto.response.AlarmListResponseDto;
+import com.hertz.hertz_be.domain.alarm.dto.response.object.AlarmItem;
+import com.hertz.hertz_be.domain.alarm.dto.response.object.MatchingAlarm;
+import com.hertz.hertz_be.domain.alarm.dto.response.object.NoticeAlarm;
+import com.hertz.hertz_be.domain.alarm.dto.response.object.ReportAlarm;
+import com.hertz.hertz_be.domain.alarm.entity.*;
 import com.hertz.hertz_be.domain.alarm.repository.AlarmNotificationRepository;
 import com.hertz.hertz_be.domain.alarm.dto.request.CreateNotifyAlarmRequestDto;
 import com.hertz.hertz_be.domain.alarm.repository.UserAlarmRepository;
+import com.hertz.hertz_be.domain.channel.entity.SignalRoom;
 import com.hertz.hertz_be.domain.channel.exception.UserNotFoundException;
 import com.hertz.hertz_be.domain.user.entity.User;
 import com.hertz.hertz_be.domain.user.repository.UserRepository;
-import jakarta.transaction.Transactional;
+import com.hertz.hertz_be.global.exception.InternalServerErrorException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -44,5 +54,54 @@ public class AlarmService {
                 .toList();
 
         userAlarmRepository.saveAll(userAlarms);
+    }
+
+    @Transactional(readOnly = true)
+    public AlarmListResponseDto getAlarmList(int page, int size, Long userId) {
+        PageRequest pageRequest = PageRequest.of(page, size);
+        LocalDateTime thresholdDate = LocalDateTime.now().minusDays(30);
+
+        Page<UserAlarm> alarms = userAlarmRepository.findRecentUserAlarms(userId, thresholdDate, pageRequest);
+
+        List<AlarmItem> alarmItems = alarms.getContent().stream()
+                .map(userAlarm -> {
+                    Alarm alarm = userAlarm.getAlarm();
+
+                    if (alarm instanceof AlarmNotification notification) {
+                        return new NoticeAlarm(
+                                "NOTICE",
+                                notification.getTitle(),
+                                notification.getContent(),
+                                notification.getCreatedAt().toString()
+                        );
+                    }
+                    else if (alarm instanceof AlarmMatching matching) {
+                        SignalRoom signalRoom = matching.getSignalRoom();
+                        Long channelRoomId = signalRoom.isUserExited(userId) ? null : signalRoom.getId();
+
+                        return new MatchingAlarm(
+                                "MATCHING",
+                                matching.getTitle(),
+                                channelRoomId,
+                                matching.getCreatedAt().toString()
+                        );
+                    } else if (alarm instanceof AlarmReport report) {
+                        return new ReportAlarm(
+                                "REPORT",
+                                report.getTitle(),
+                                report.getCreatedAt().toString()
+                        );
+                    } else {
+                        throw new InternalServerErrorException();
+                    }
+                })
+                .collect(Collectors.toList());
+
+        return new AlarmListResponseDto(
+                alarmItems,
+                alarms.getNumber(),
+                alarms.getSize(),
+                alarms.isLast()
+        );
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/service/AlarmService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/service/AlarmService.java
@@ -6,6 +6,7 @@ import com.hertz.hertz_be.domain.alarm.dto.response.object.MatchingAlarm;
 import com.hertz.hertz_be.domain.alarm.dto.response.object.NoticeAlarm;
 import com.hertz.hertz_be.domain.alarm.dto.response.object.ReportAlarm;
 import com.hertz.hertz_be.domain.alarm.entity.*;
+import com.hertz.hertz_be.domain.alarm.entity.enums.AlarmCategory;
 import com.hertz.hertz_be.domain.alarm.repository.AlarmNotificationRepository;
 import com.hertz.hertz_be.domain.alarm.dto.request.CreateNotifyAlarmRequestDto;
 import com.hertz.hertz_be.domain.alarm.repository.UserAlarmRepository;
@@ -69,7 +70,7 @@ public class AlarmService {
 
                     if (alarm instanceof AlarmNotification notification) {
                         return new NoticeAlarm(
-                                "NOTICE",
+                                AlarmCategory.NOTICE.getValue(),
                                 notification.getTitle(),
                                 notification.getContent(),
                                 notification.getCreatedAt().toString()
@@ -80,14 +81,14 @@ public class AlarmService {
                         Long channelRoomId = signalRoom.isUserExited(userId) ? null : signalRoom.getId();
 
                         return new MatchingAlarm(
-                                "MATCHING",
+                                AlarmCategory.MATCHING.getValue(),
                                 matching.getTitle(),
                                 channelRoomId,
                                 matching.getCreatedAt().toString()
                         );
                     } else if (alarm instanceof AlarmReport report) {
                         return new ReportAlarm(
-                                "REPORT",
+                                AlarmCategory.REPORT.getValue(),
                                 report.getTitle(),
                                 report.getCreatedAt().toString()
                         );

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/SignalRoom.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/SignalRoom.java
@@ -90,11 +90,11 @@ public class SignalRoom {
      */
     public String getRelationType() {
         if (senderMatchingStatus == MatchingStatus.MATCHED && receiverMatchingStatus == MatchingStatus.MATCHED) {
-            return "MATCHING";
+            return MatchingStatus.MATCHED.getValue();
         } else if (senderMatchingStatus == MatchingStatus.SIGNAL && receiverMatchingStatus == MatchingStatus.SIGNAL) {
-            return "SIGNAL";
-        }// 상황에 따라 ENUM으로 바꿔도 됨
-        return "UNMATCHING";
+            return MatchingStatus.SIGNAL.getValue();
+        }
+        return MatchingStatus.UNMATCHED.getValue();
     }
 
     /**

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/SignalRoom.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/SignalRoom.java
@@ -50,6 +50,16 @@ public class SignalRoom {
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
+    @CreationTimestamp
+    @Column(name = "receiver_exited_at")
+    @Builder.Default
+    private LocalDateTime receiverExitedAt = null;
+
+    @CreationTimestamp
+    @Column(name = "sender_exited_at")
+    @Builder.Default
+    private LocalDateTime senderExitedAt = null;
+
     @OneToMany(mappedBy = "signalRoom")
     @Builder.Default
     private List<SignalMessage> messages = new ArrayList<>();

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/SignalRoom.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/SignalRoom.java
@@ -97,5 +97,15 @@ public class SignalRoom {
         return "UNMATCHING";
     }
 
+    /**
+     * 현재 유저가 SignalRoom을 나갔는지 아닌지 여부
+     */
+    public boolean isUserExited(Long userId) {
+        boolean isSender = senderUser.getId().equals(userId);
+        LocalDateTime exitedAt = isSender ? senderExitedAt : receiverExitedAt;
+        return exitedAt != null;
+    }
+
+
 }
 

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/SignalRoom.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/SignalRoom.java
@@ -1,7 +1,7 @@
 package com.hertz.hertz_be.domain.channel.entity;
 
 import com.hertz.hertz_be.domain.alarm.entity.AlarmMatching;
-import com.hertz.hertz_be.domain.channel.entity.enums.Category;
+import com.hertz.hertz_be.domain.channel.entity.enums.ChannelCategory;
 import com.hertz.hertz_be.domain.channel.entity.enums.MatchingStatus;
 import com.hertz.hertz_be.domain.user.entity.User;
 import jakarta.persistence.*;
@@ -34,7 +34,7 @@ public class SignalRoom {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 10)
-    private Category category;
+    private ChannelCategory category;
 
     @Column(name = "user_pair_signal", nullable = false, unique = true, length = 35)
     private String userPairSignal;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/SignalRoom.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/SignalRoom.java
@@ -1,5 +1,6 @@
 package com.hertz.hertz_be.domain.channel.entity;
 
+import com.hertz.hertz_be.domain.alarm.entity.AlarmMatching;
 import com.hertz.hertz_be.domain.channel.entity.enums.Category;
 import com.hertz.hertz_be.domain.channel.entity.enums.MatchingStatus;
 import com.hertz.hertz_be.domain.user.entity.User;
@@ -63,6 +64,10 @@ public class SignalRoom {
     @OneToMany(mappedBy = "signalRoom")
     @Builder.Default
     private List<SignalMessage> messages = new ArrayList<>();
+
+    @OneToMany(mappedBy = "signalRoom")
+    @Builder.Default
+    private List<AlarmMatching> alarms = new ArrayList<>();
 
     /**
      * 현재 유저 기준으로 상대방을 반환

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/Tuning.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/Tuning.java
@@ -1,7 +1,6 @@
 package com.hertz.hertz_be.domain.channel.entity;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.hertz.hertz_be.domain.channel.entity.enums.Category;
+import com.hertz.hertz_be.domain.channel.entity.enums.ChannelCategory;
 import com.hertz.hertz_be.domain.user.entity.User;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -33,7 +32,7 @@ public class Tuning {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 15)
-    private Category category;
+    private ChannelCategory category;
 
     @CreationTimestamp
     @Column(nullable = false)

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/enums/Category.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/enums/Category.java
@@ -6,9 +6,9 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum Category {
-    FRIEND("친구"),
-    COUPLE("커플"),
-    MEAL_FRIEND("밥친구");
+    FRIEND("친구", "FRIEND"),
+    COUPLE("커플", "COUPLE");
 
     private final String label;
+    private final String value;
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/enums/ChannelCategory.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/enums/ChannelCategory.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public enum Category {
+public enum ChannelCategory {
     FRIEND("친구", "FRIEND"),
     COUPLE("커플", "COUPLE");
 

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/enums/MatchingStatus.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/enums/MatchingStatus.java
@@ -6,9 +6,10 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum MatchingStatus {
-    SIGNAL("시그널"),
-    MATCHED("매칭 수락"),
-    UNMATCHED("매칭 거절");
+    SIGNAL("시그널", "SIGNAL"),
+    MATCHED("매칭 수락", "MATCHED"),
+    UNMATCHED("매칭 거절", "UNMATCHED");
 
     private final String label;
+    private final String value;
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/TuningRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/TuningRepository.java
@@ -1,7 +1,7 @@
 package com.hertz.hertz_be.domain.channel.repository;
 
 import com.hertz.hertz_be.domain.channel.entity.Tuning;
-import com.hertz.hertz_be.domain.channel.entity.enums.Category;
+import com.hertz.hertz_be.domain.channel.entity.enums.ChannelCategory;
 import com.hertz.hertz_be.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -12,5 +12,5 @@ import java.util.Optional;
 @Repository
 public interface TuningRepository extends JpaRepository<Tuning, Long> {
     List<Tuning> findByUser(User user);
-    Optional<Tuning> findByUserAndCategory(User user, Category category);
+    Optional<Tuning> findByUserAndCategory(User user, ChannelCategory category);
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/ChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/ChannelService.java
@@ -3,7 +3,7 @@ package com.hertz.hertz_be.domain.channel.service;
 import com.hertz.hertz_be.domain.channel.dto.request.SignalMatchingRequestDto;
 import com.hertz.hertz_be.domain.channel.dto.response.*;
 import com.hertz.hertz_be.domain.channel.entity.*;
-import com.hertz.hertz_be.domain.channel.entity.enums.Category;
+import com.hertz.hertz_be.domain.channel.entity.enums.ChannelCategory;
 import com.hertz.hertz_be.domain.channel.entity.enums.MatchingStatus;
 import com.hertz.hertz_be.domain.channel.dto.request.SendSignalRequestDto;
 import com.hertz.hertz_be.domain.channel.exception.*;
@@ -111,7 +111,7 @@ public class ChannelService {
         SignalRoom signalRoom = SignalRoom.builder()
                 .senderUser(sender)
                 .receiverUser(receiver)
-                .category(Category.FRIEND)
+                .category(ChannelCategory.FRIEND)
                 .senderMatchingStatus(MatchingStatus.SIGNAL)
                 .receiverMatchingStatus(MatchingStatus.SIGNAL)
                 .userPairSignal(userPairSignal)
@@ -245,11 +245,11 @@ public class ChannelService {
     }
 
     private Tuning getOrCreateTuning(User user) {
-        return tuningRepository.findByUserAndCategory(user, Category.FRIEND)
+        return tuningRepository.findByUserAndCategory(user, ChannelCategory.FRIEND)
                 .orElseGet(() -> tuningRepository.save(
                         Tuning.builder()
                                 .user(user)
-                                .category(Category.FRIEND)
+                                .category(ChannelCategory.FRIEND)
                                 .build()));
     }
 

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseCode.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseCode.java
@@ -75,6 +75,8 @@ public class ResponseCode {
      * 알림창 관련 응답 code
      */
     public static final String NOTICE_CREATED_SUCCESS = "NOTICE_CREATED_SUCCESS";
+    public static final String ALARM_FETCH_SUCCESS = "ALARM_FETCH_SUCCESS";
+    public static final String NO_ALARMS = "NO_ALARMS";
 
     /**
      * 매칭 수락/거절 관련 응답 code


### PR DESCRIPTION
## 🔗 관련 이슈
- #244 

## ✏️ 변경 사항
- 특정 사용자를 위한 최근 30일 동안 모든 알림 반환 API를 위한 로직 구현

## 📋 상세 설명
- 사용자 조직(이메일) 별로 구분해서 적절한 알림 반환
- 페이징을 통해 한번에 10개 알림 데이터 반환
- 최근 30일 동안 발생한 알림만 반환
- 알람 종류 총 3가지: 매칭 결과, 공지, 튜닝레포트
- SignalRoom 엔티티에서 사용자 나감을 나타내는 컬럼 추가

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 없음

## 📎 참고 자료 (선택)
- 없음
