### PR TITLE
[#246] Feat: 매칭 결과 알림 생성 로직 구현

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/repository/AlarmMatchingRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/repository/AlarmMatchingRepository.java
@@ -1,0 +1,7 @@
+package com.hertz.hertz_be.domain.alarm.repository;
+
+import com.hertz.hertz_be.domain.alarm.entity.AlarmMatching;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AlarmMatchingRepository extends JpaRepository<AlarmMatching, Long> {
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/service/AlarmService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/service/AlarmService.java
@@ -1,5 +1,6 @@
 package com.hertz.hertz_be.domain.alarm.service;
 
+import static com.hertz.hertz_be.global.util.MessageCreatorUtil.*;
 import com.hertz.hertz_be.domain.alarm.dto.response.AlarmListResponseDto;
 import com.hertz.hertz_be.domain.alarm.dto.response.object.AlarmItem;
 import com.hertz.hertz_be.domain.alarm.dto.response.object.MatchingAlarm;
@@ -105,14 +106,6 @@ public class AlarmService {
 
         userAlarmRepository.save(userAlarmForPartner);
 
-    }
-
-    public String createSuccessMessage(String nickname) {
-        return String.format("🎉 축하드려요, ‘%s’님과 매칭에 성공했습니다!", nickname);
-    }
-
-    public String createFailureMessage(String nickname) {
-        return String.format("😥 아쉽지만, ‘%s’님과의 매칭은 성사되지 않았습니다.", nickname);
     }
 
     @Transactional(readOnly = true)

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/service/AlarmService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/service/AlarmService.java
@@ -7,10 +7,12 @@ import com.hertz.hertz_be.domain.alarm.dto.response.object.NoticeAlarm;
 import com.hertz.hertz_be.domain.alarm.dto.response.object.ReportAlarm;
 import com.hertz.hertz_be.domain.alarm.entity.*;
 import com.hertz.hertz_be.domain.alarm.entity.enums.AlarmCategory;
+import com.hertz.hertz_be.domain.alarm.repository.AlarmMatchingRepository;
 import com.hertz.hertz_be.domain.alarm.repository.AlarmNotificationRepository;
 import com.hertz.hertz_be.domain.alarm.dto.request.CreateNotifyAlarmRequestDto;
 import com.hertz.hertz_be.domain.alarm.repository.UserAlarmRepository;
 import com.hertz.hertz_be.domain.channel.entity.SignalRoom;
+import com.hertz.hertz_be.domain.channel.entity.enums.MatchingStatus;
 import com.hertz.hertz_be.domain.channel.exception.UserNotFoundException;
 import com.hertz.hertz_be.domain.user.entity.User;
 import com.hertz.hertz_be.domain.user.repository.UserRepository;
@@ -23,12 +25,14 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class AlarmService {
     private final AlarmNotificationRepository alarmNotificationRepository;
+    private final AlarmMatchingRepository alarmMatchingRepository;
     private final UserAlarmRepository userAlarmRepository;
     private final UserRepository userRepository;
 
@@ -55,6 +59,60 @@ public class AlarmService {
                 .toList();
 
         userAlarmRepository.saveAll(userAlarms);
+    }
+
+    @Transactional
+    public void createMatchingAlarm(SignalRoom room, User user, User partner) {
+        String alarmTitleForUser;
+        String alarmTitleForPartner;
+        if (Objects.equals(room.getRelationType(), MatchingStatus.UNMATCHED.getValue())) {
+            alarmTitleForUser = createFailureMessage(partner.getNickname());
+            alarmTitleForPartner = createFailureMessage(user.getNickname());
+        } else {
+            alarmTitleForUser = createSuccessMessage(partner.getNickname());
+            alarmTitleForPartner = createSuccessMessage(user.getNickname());
+        }
+
+        AlarmMatching alarmMatchingForUser = AlarmMatching.builder()
+                .title(alarmTitleForUser)
+                .partner(partner)
+                .partnerNickname(partner.getNickname())
+                .signalRoom(room)
+                .isMatched(false)
+                .build();
+        AlarmMatching savedAlarmForUser = alarmMatchingRepository.save(alarmMatchingForUser);
+
+        UserAlarm userAlarmForUser = UserAlarm.builder()
+                .alarm(savedAlarmForUser)
+                .user(user)
+                .build();
+
+        userAlarmRepository.save(userAlarmForUser);
+
+        AlarmMatching alarmMatchingForPartner = AlarmMatching.builder()
+                .title(alarmTitleForPartner)
+                .partner(user)
+                .partnerNickname(user.getNickname())
+                .signalRoom(room)
+                .isMatched(false)
+                .build();
+        AlarmMatching savedAlarmForPartner = alarmMatchingRepository.save(alarmMatchingForPartner);
+
+        UserAlarm userAlarmForPartner = UserAlarm.builder()
+                .alarm(savedAlarmForPartner)
+                .user(partner)
+                .build();
+
+        userAlarmRepository.save(userAlarmForPartner);
+
+    }
+
+    public String createSuccessMessage(String nickname) {
+        return String.format("🎉 축하드려요, ‘%s’님과 매칭에 성공했습니다!", nickname);
+    }
+
+    public String createFailureMessage(String nickname) {
+        return String.format("😥 아쉽지만, ‘%s’님과의 매칭은 성사되지 않았습니다.", nickname);
     }
 
     @Transactional(readOnly = true)

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/AsyncChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/AsyncChannelService.java
@@ -1,5 +1,6 @@
 package com.hertz.hertz_be.domain.channel.service;
 
+import com.hertz.hertz_be.domain.alarm.service.AlarmService;
 import com.hertz.hertz_be.domain.channel.dto.object.UserMessageCountDto;
 import com.hertz.hertz_be.domain.channel.entity.SignalMessage;
 import com.hertz.hertz_be.domain.channel.entity.SignalRoom;
@@ -42,6 +43,7 @@ public class AsyncChannelService {
     private final SignalMessageRepository signalMessageRepository;
     private final SseChannelService sseChannelService;
     private final UserRepository userRepository;
+    private final AlarmService alarmService;
 
     @Async
     public void notifyMatchingConverted(SignalRoom room) {
@@ -135,5 +137,20 @@ public class AsyncChannelService {
         } else {
             sseChannelService.notifyMatchingResultToPartner(room, user, partner, matchingStatus);
         }
+    }
+
+    @Async
+    @Transactional
+    public void createMatchingAlarm(SignalRoom room, Long userId) {
+        SignalRoom latestRoomForm = entityManager.find(SignalRoom.class, room.getId());
+        User partner = latestRoomForm.getPartnerUser(userId);
+        User user = userRepository.findByIdWithSentSignalRooms(userId)
+                .orElseThrow(() -> new UserException(ResponseCode.USER_NOT_FOUND, "사용자가 존재하지 않습니다."));
+
+        boolean isSender = Objects.equals(userId, latestRoomForm.getSenderUser().getId());
+        MatchingStatus partnerMatchingStatus = isSender ? latestRoomForm.getReceiverMatchingStatus() : latestRoomForm.getSenderMatchingStatus();
+
+        if (partnerMatchingStatus == MatchingStatus.SIGNAL) { return; }
+        alarmService.createMatchingAlarm(latestRoomForm, user, partner);
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/AsyncChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/AsyncChannelService.java
@@ -150,7 +150,10 @@ public class AsyncChannelService {
         boolean isSender = Objects.equals(userId, latestRoomForm.getSenderUser().getId());
         MatchingStatus partnerMatchingStatus = isSender ? latestRoomForm.getReceiverMatchingStatus() : latestRoomForm.getSenderMatchingStatus();
 
-        if (partnerMatchingStatus == MatchingStatus.SIGNAL) { return; }
+        if (partnerMatchingStatus == MatchingStatus.SIGNAL) {
+            log.info("[{} 상대방의 상태]", partnerMatchingStatus);
+            return;
+        }
         alarmService.createMatchingAlarm(latestRoomForm, user, partner);
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/ChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/ChannelService.java
@@ -470,6 +470,7 @@ public class ChannelService {
             @Override
             public void afterCommit() {
                 asyncChannelService.notifyMatchingResultToPartner(room, userId, matchingStatus);
+                asyncChannelService.createMatchingAlarm(room, userId);
             }
         });
 

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/util/MessageCreatorUtil.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/util/MessageCreatorUtil.java
@@ -1,0 +1,13 @@
+package com.hertz.hertz_be.global.util;
+
+public class MessageCreatorUtil {
+    public static String createSuccessMessage(String nickname) {
+        return String.format("🎉 축하드려요, ‘%s’님과 매칭에 성공했습니다!", nickname);
+    }
+
+    public static String createFailureMessage(String nickname) {
+        return String.format("😥 아쉽지만, ‘%s’님과의 매칭은 성사되지 않았습니다.", nickname);
+    }
+
+    private MessageCreatorUtil() {}
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- #246 

## ✏️ 변경 사항
- 기존 매칭 처리 로직에서 비동기적으로 알림 생성 기능 추가

## 📋 상세 설명
- 매칭 처리 시 알림 생성을 비동기 방식으로 수행하도록 개선
- `AlarmService`에 매칭 알림 생성 메서드 (`createMatchingAlarmAsync`) 추가
- 문자열 기반 알림 메시지 생성을 위한 `MessageCreatorUtil` 유틸 클래스 구현

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 없음

## 📎 참고 자료 (선택)
- 없음
