### PR TITLE
[#248] Feat: 특정 알림 삭제 API 구현

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/controller/AlarmController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/controller/AlarmController.java
@@ -47,7 +47,7 @@ public class AlarmController {
                 ResponseCode.ALARM_FETCH_SUCCESS, "알림이 정상적으로 조회되었습니다.", dto));
     }
 
-    @DeleteMapping("/api/v2/users/alarms/{alarmId}")
+    @DeleteMapping("/v2/users/alarms/{alarmId}")
     @Operation(summary = "특정 알림 삭제 API")
     public  ResponseEntity<ResponseDto<Void>> deleteAlarm(@PathVariable Long alarmId, @AuthenticationPrincipal Long userId) {
         alarmService.deleteAlarm(alarmId, userId);

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/controller/AlarmController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/controller/AlarmController.java
@@ -47,4 +47,12 @@ public class AlarmController {
                 ResponseCode.ALARM_FETCH_SUCCESS, "알림이 정상적으로 조회되었습니다.", dto));
     }
 
+    @DeleteMapping("/api/v2/users/alarms/{alarmId}")
+    @Operation(summary = "특정 알림 삭제 API")
+    public  ResponseEntity<ResponseDto<Void>> deleteAlarm(@PathVariable Long alarmId, @AuthenticationPrincipal Long userId) {
+        alarmService.deleteAlarm(alarmId, userId);
+        return ResponseEntity.ok(new ResponseDto<>(
+                ResponseCode.ALARM_DELETE_SUCCESS, "알림이 성공적으로 삭제되었습니다.", null));
+    }
+
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/controller/AlarmController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/controller/AlarmController.java
@@ -33,7 +33,7 @@ public class AlarmController {
         );
     }
 
-    @GetMapping("/api/v2/alarms")
+    @GetMapping("/v2/alarms")
     @Operation(summary = "특정 사용자를 위한 최근 30일 동안 모든 알림 반환 API")
     public ResponseEntity<ResponseDto<AlarmListResponseDto>> getAlarmList(@RequestParam(defaultValue = "0") int page,
                                                                           @RequestParam(defaultValue = "10") int size,

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/entity/Alarm.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/entity/Alarm.java
@@ -41,7 +41,7 @@ public class Alarm {
     @Builder.Default
     private LocalDateTime deletedAt = null;
 
-    @OneToMany(mappedBy = "alarm", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "alarm", cascade = CascadeType.REMOVE, orphanRemoval = true)
     @Builder.Default
     private List<UserAlarm> users = new ArrayList<>();
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/entity/Alarm.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/entity/Alarm.java
@@ -41,7 +41,7 @@ public class Alarm {
     @Builder.Default
     private LocalDateTime deletedAt = null;
 
-    @OneToMany(mappedBy = "alarm")
+    @OneToMany(mappedBy = "alarm", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<UserAlarm> users = new ArrayList<>();
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/entity/AlarmNotification.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/entity/AlarmNotification.java
@@ -21,6 +21,10 @@ public class AlarmNotification extends Alarm{
     private String content;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "writer_id", nullable = false)
+    @JoinColumn(name = "writer_id", nullable = true)
     private User writer;
+
+    public void removeWriter() {
+        this.writer = null;
+    }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/repository/AlarmNotificationRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/repository/AlarmNotificationRepository.java
@@ -1,7 +1,13 @@
 package com.hertz.hertz_be.domain.alarm.repository;
 
 import com.hertz.hertz_be.domain.alarm.entity.AlarmNotification;
+import com.hertz.hertz_be.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface AlarmNotificationRepository extends JpaRepository<AlarmNotification, Long> {
+    void deleteAllByWriter(User user);
+
+    List<AlarmNotification> findAllByWriter(User user);
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/repository/UserAlarmRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/repository/UserAlarmRepository.java
@@ -1,6 +1,7 @@
 package com.hertz.hertz_be.domain.alarm.repository;
 
 import com.hertz.hertz_be.domain.alarm.entity.UserAlarm;
+import com.hertz.hertz_be.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
@@ -24,4 +25,6 @@ public interface UserAlarmRepository extends JpaRepository<UserAlarm, Long> {
             @Param("thresholdDate") LocalDateTime thresholdDate,
             Pageable pageable
     );
+
+    void deleteAllByUser(User user);
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/service/AlarmService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/service/AlarmService.java
@@ -11,6 +11,7 @@ import com.hertz.hertz_be.domain.alarm.entity.enums.AlarmCategory;
 import com.hertz.hertz_be.domain.alarm.repository.AlarmMatchingRepository;
 import com.hertz.hertz_be.domain.alarm.repository.AlarmNotificationRepository;
 import com.hertz.hertz_be.domain.alarm.dto.request.CreateNotifyAlarmRequestDto;
+import com.hertz.hertz_be.domain.alarm.repository.AlarmRepository;
 import com.hertz.hertz_be.domain.alarm.repository.UserAlarmRepository;
 import com.hertz.hertz_be.domain.channel.entity.SignalRoom;
 import com.hertz.hertz_be.domain.channel.entity.enums.MatchingStatus;
@@ -34,6 +35,7 @@ import java.util.stream.Collectors;
 public class AlarmService {
     private final AlarmNotificationRepository alarmNotificationRepository;
     private final AlarmMatchingRepository alarmMatchingRepository;
+    private final AlarmRepository alarmRepository;
     private final UserAlarmRepository userAlarmRepository;
     private final UserRepository userRepository;
 
@@ -155,5 +157,13 @@ public class AlarmService {
                 alarms.getSize(),
                 alarms.isLast()
         );
+    }
+
+    @Transactional
+    public void deleteAlarm(Long alarmId, Long userId) {
+        userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
+        alarmRepository.deleteById(alarmId);
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/entity/User.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/entity/User.java
@@ -97,7 +97,7 @@ public class User {
     @Builder.Default
     private List<Tuning> recommendListByCategory = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
     @Builder.Default
     private List<UserAlarm> alarms = new ArrayList<>();
 

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/service/UserService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/service/UserService.java
@@ -1,6 +1,9 @@
 package com.hertz.hertz_be.domain.user.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hertz.hertz_be.domain.alarm.entity.AlarmNotification;
+import com.hertz.hertz_be.domain.alarm.repository.AlarmNotificationRepository;
+import com.hertz.hertz_be.domain.alarm.repository.UserAlarmRepository;
 import com.hertz.hertz_be.domain.auth.repository.OAuthRedisRepository;
 import com.hertz.hertz_be.domain.auth.repository.RefreshTokenRepository;
 import com.hertz.hertz_be.domain.interests.service.InterestsService;
@@ -46,6 +49,8 @@ public class UserService {
     private final SignalRoomRepository signalRoomRepository;
     private final SignalMessageRepository signalMessageRepository;
     private final TuningResultRepository tuningResultRepository;
+    private final AlarmNotificationRepository alarmNotificationRepository;
+    private final UserAlarmRepository userAlarmRepository;
     private final RestTemplate restTemplate = new RestTemplate();
     private final long TIMEOUT_NANOS = 5_000_000_000L; // // 5초 = 5_000_000_000 나노초
 
@@ -205,6 +210,10 @@ public class UserService {
         userInterestsRepository.deleteAllByUser(user);
 
         tuningResultRepository.deleteAllByMatchedUser(user);
+
+        List<AlarmNotification> notifications = alarmNotificationRepository.findAllByWriter(user);
+        notifications.forEach(n -> n.removeWriter());
+        alarmNotificationRepository.saveAll(notifications);
 
         userRepository.delete(user);
     }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseCode.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseCode.java
@@ -77,7 +77,7 @@ public class ResponseCode {
     public static final String NOTICE_CREATED_SUCCESS = "NOTICE_CREATED_SUCCESS";
     public static final String ALARM_FETCH_SUCCESS = "ALARM_FETCH_SUCCESS";
     public static final String NO_ALARMS = "NO_ALARMS";
-
+    public static final String ALARM_DELETE_SUCCESS = "ALARM_DELETE_SUCCESS";
     /**
      * 매칭 수락/거절 관련 응답 code
      */


### PR DESCRIPTION
## 🔗 관련 이슈
- #248 

## ✏️ 변경 사항  
- Alarm 및 UserAlarm 간 JPA 연관관계에 Cascade 설정 추가 및 수정  
- 특정 알림 삭제 API 구현 및 URL 오타 수정  
- 유저 삭제 시 연관된 엔티티(UserAlarm 등) 삭제 로직 추가  
- 특정 사용자에 대한 최근 30일 알림 조회 API URL 수정  

## 📋 상세 설명  
- 기존에 Alarm과 UserAlarm 간 cascade 설정이 불완전하여 유저 또는 알림 삭제 시 연관된 엔티티가 남는 문제가 있었습니다. 이를 해결하기 위해 `CascadeType.REMOVE` 및 `orphanRemoval = true` 설정을 반영했습니다.  
- 특정 알림을 개별 삭제할 수 있는 API를 새로 구현하고, 그 과정에서 URL 오타를 수정했습니다.  
- 유저 삭제 시 연관된 SignalRoom, SignalMessage, Tuning, UserInterests, UserAlarm, AlarmNotification 등을 명시적으로 제거하는 로직을 추가하여 무결성 제약 오류를 해결했습니다.  
- 최근 30일간 특정 유저의 알림을 조회하는 기능에서 API URL 오타가 있어 이를 수정했습니다.  

## ✅ 체크리스트  
- [x] 기능이 정상적으로 동작하는지 확인했습니다.  
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.  
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 없음

## 📎 참고 자료 (선택)
- 없음
