### PR TITLE
[#251] Refactor: ResponseDTO 클래스 record 타입으로 리팩토링

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/OAuthController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/OAuthController.java
@@ -51,21 +51,21 @@ public class OAuthController {
     ) {
         OAuthLoginResult result = oAuthService.oauthLogin(provider, request);
 
-        if (result.isRegistered()) {
-            String newRefreshToken = result.getRefreshToken();
+        if (result.registered()) {
+            String newRefreshToken = result.refreshToken();
 
             AuthUtil.setRefreshTokenCookie(response, newRefreshToken, maxAgeSeconds, isLocal);
 
-            OAuthLoginResponseDto dto = new OAuthLoginResponseDto(result.getUserId(), result.getAccessToken());
+            OAuthLoginResponseDto dto = new OAuthLoginResponseDto(result.userId(), result.accessToken());
 
-            boolean hasSelectedInterests = channelService.hasSelectedInterests(channelService.getUserById(result.getUserId()));
+            boolean hasSelectedInterests = channelService.hasSelectedInterests(channelService.getUserById(result.userId()));
             if (!hasSelectedInterests) {
                 return ResponseEntity.ok(new ResponseDto<>(ResponseCode.USER_INTERESTS_NOT_SELECTED, "사용자가 아직 취향 선택을 완료하지 않았습니다.", dto));
             }
             return ResponseEntity.ok(new ResponseDto<>(ResponseCode.USER_ALREADY_REGISTERED, "로그인에 성공했습니다.", dto));
 
         } else {
-            OAuthSignupResponseDto dto = new OAuthSignupResponseDto(result.getProviderId());
+            OAuthSignupResponseDto dto = new OAuthSignupResponseDto(result.providerId());
             return ResponseEntity.ok(new ResponseDto<>(ResponseCode.USER_NOT_REGISTERED, "신규 회원입니다.", dto));
         }
     }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/dto/response/OAuthLoginResponseDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/dto/response/OAuthLoginResponseDto.java
@@ -1,12 +1,3 @@
 package com.hertz.hertz_be.domain.auth.dto.response;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
-@Getter
-@AllArgsConstructor
-public class OAuthLoginResponseDto {
-    private Long userId;
-    private String accessToken;
-
-}
+public record OAuthLoginResponseDto(Long userId, String accessToken) {}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/dto/response/OAuthLoginResult.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/dto/response/OAuthLoginResult.java
@@ -1,35 +1,17 @@
 package com.hertz.hertz_be.domain.auth.dto.response;
 
-import lombok.Builder;
-import lombok.Getter;
-
-@Getter
-@Builder
-public class OAuthLoginResult {
-
-    private final boolean registered;
-
-    // 기존 회원용
-    private final Long userId;
-    private final String accessToken;
-    private final String refreshToken;
-
-    // 신규 회원용
-    private final String providerId;
-
+public record OAuthLoginResult(
+        boolean registered,
+        Long userId,
+        String accessToken,
+        String refreshToken,
+        String providerId
+) {
     public static OAuthLoginResult registered(Long userId, String accessToken, String refreshToken) {
-        return OAuthLoginResult.builder()
-                .registered(true)
-                .userId(userId)
-                .accessToken(accessToken)
-                .refreshToken(refreshToken)
-                .build();
+        return new OAuthLoginResult(true, userId, accessToken, refreshToken, null);
     }
 
     public static OAuthLoginResult notRegistered(String providerId) {
-        return OAuthLoginResult.builder()
-                .registered(false)
-                .providerId(providerId)
-                .build();
+        return new OAuthLoginResult(false, null, null, null, providerId);
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/dto/response/OAuthSignupResponseDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/dto/response/OAuthSignupResponseDto.java
@@ -1,10 +1,3 @@
 package com.hertz.hertz_be.domain.auth.dto.response;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
-@Getter
-@AllArgsConstructor
-public class OAuthSignupResponseDto {
-    private String providerId;
-}
+public record OAuthSignupResponseDto(String providerId) {}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/dto/response/ReissueAccessTokenResponseDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/dto/response/ReissueAccessTokenResponseDto.java
@@ -1,11 +1,4 @@
 package com.hertz.hertz_be.domain.auth.dto.response;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
-@Getter
-@AllArgsConstructor
-public class ReissueAccessTokenResponseDto {
-    private String accessToken;
-}
+public record ReissueAccessTokenResponseDto(String accessToken) {}
 

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/object/UserMessageCountDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/object/UserMessageCountDto.java
@@ -1,11 +1,3 @@
 package com.hertz.hertz_be.domain.channel.dto.object;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
-@Getter
-@AllArgsConstructor
-public class UserMessageCountDto {
-    private final Long userId;
-    private final Long messageCount;
-}
+public record UserMessageCountDto(Long userId, Long messageCount) {}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/SendSignalResponseDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/SendSignalResponseDto.java
@@ -1,10 +1,3 @@
 package com.hertz.hertz_be.domain.channel.dto.response;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
-@Getter
-@AllArgsConstructor
-public class SendSignalResponseDto {
-    private Long channelRoomId;
-}
+public record SendSignalResponseDto (Long channelRoomId) {}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/TuningResponseDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/TuningResponseDto.java
@@ -1,20 +1,15 @@
 package com.hertz.hertz_be.domain.channel.dto.response;
 
 import com.hertz.hertz_be.domain.user.entity.enums.Gender;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-
 import java.util.List;
 import java.util.Map;
 
-@Getter
-@AllArgsConstructor
-public class TuningResponseDto {
-    private Long userId;
-    private String profileImage;
-    private String nickname;
-    private Gender gender;
-    private String oneLineIntroduction;
-    private Map<String, String> keywords;
-    private Map<String, List<String>> sameInterests;
-}
+public record TuningResponseDto(
+        Long userId,
+        String profileImage,
+        String nickname,
+        Gender gender,
+        String oneLineIntroduction,
+        Map<String, String> keywords,
+        Map<String, List<String>> sameInterests
+) {}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/sse/ChannelListResponseDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/sse/ChannelListResponseDto.java
@@ -1,48 +1,13 @@
 package com.hertz.hertz_be.domain.channel.dto.response.sse;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
 
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class ChannelListResponseDto {
-    private Long channelRoomId;
-    private String partnerProfileImage;
-    private String partnerNickname;
-    private String lastMessage;
-    private String lastMessageTime;
-    private boolean isRead;
-    private String relationType;
-
-    public Long getChannelRoomId() {
-        return channelRoomId;
-    }
-
-    public String getPartnerProfileImage() {
-        return partnerProfileImage;
-    }
-
-    public String getPartnerNickname() {
-        return partnerNickname;
-    }
-
-    public String getLastMessage() {
-        return lastMessage;
-    }
-
-    public String getLastMessageTime() {
-        return lastMessageTime;
-    }
-
-    public String getRelationType() {
-        return relationType;
-    }
-
-    @JsonProperty("isRead")
-    public boolean getIsRead() {
-        return isRead;
-    }
-}
+public record ChannelListResponseDto(
+        Long channelRoomId,
+        String partnerProfileImage,
+        String partnerNickname,
+        String lastMessage,
+        String lastMessageTime,
+        @JsonProperty("isRead") boolean isRead,
+        String relationType
+) {}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/sse/MatchingConvertedInChannelRoomResponseDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/sse/MatchingConvertedInChannelRoomResponseDto.java
@@ -5,13 +5,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Getter
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
-public class MatchingConvertedInChannelRoomResponseDto {
-    private Long channelRoomId;
-    private String partnerNickname;
-    private boolean hasResponded;
-    private boolean partnerHasResponded;
-}
+public record MatchingConvertedInChannelRoomResponseDto(
+        Long channelRoomId,
+        String partnerNickname,
+        boolean hasResponded,
+        boolean partnerHasResponded
+) {}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/sse/MatchingConvertedResponseDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/sse/MatchingConvertedResponseDto.java
@@ -1,21 +1,10 @@
 package com.hertz.hertz_be.domain.channel.dto.response.sse;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
 import java.time.LocalDateTime;
 
-@Getter
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
-public class MatchingConvertedResponseDto {
-
-    private Long channelRoomId;
-    private LocalDateTime matchedAt;
-    private Long partnerId;
-    private String partnerNickname;
-
-}
+public record MatchingConvertedResponseDto(
+        Long channelRoomId,
+        LocalDateTime matchedAt,
+        Long partnerId,
+        String partnerNickname
+) {}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/sse/MatchingResultResponseDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/sse/MatchingResultResponseDto.java
@@ -1,17 +1,8 @@
 package com.hertz.hertz_be.domain.channel.dto.response.sse;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
-public class MatchingResultResponseDto {
-    private Long channelRoomId;
-    private Long partnerId;
-    private String partnerProfileImage;
-    private String partnerNickname;
-}
+public record MatchingResultResponseDto(
+        Long channelRoomId,
+        Long partnerId,
+        String partnerProfileImage,
+        String partnerNickname
+) {}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/sse/NewMessageResponseDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/sse/NewMessageResponseDto.java
@@ -2,16 +2,12 @@ package com.hertz.hertz_be.domain.channel.dto.response.sse;
 
 import lombok.*;
 
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@Builder
-public class NewMessageResponseDto {
-    private Long channelRoomId;
-    private Long partnerId;
-    private String partnerNickname;
-    private String message;
-    private String messageSendAt;
-    private String partnerProfileImage;
-    private String relationType;
-}
+public record NewMessageResponseDto(
+        Long channelRoomId,
+        Long partnerId,
+        String partnerNickname,
+        String message,
+        String messageSendAt,
+        String partnerProfileImage,
+        String relationType
+) {}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/AsyncChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/AsyncChannelService.java
@@ -6,7 +6,6 @@ import com.hertz.hertz_be.domain.channel.entity.SignalMessage;
 import com.hertz.hertz_be.domain.channel.entity.SignalRoom;
 import com.hertz.hertz_be.domain.channel.entity.enums.MatchingStatus;
 import com.hertz.hertz_be.domain.channel.repository.SignalMessageRepository;
-import com.hertz.hertz_be.domain.channel.repository.SignalRoomRepository;
 import com.hertz.hertz_be.domain.user.entity.User;
 import com.hertz.hertz_be.domain.user.exception.UserException;
 import com.hertz.hertz_be.domain.user.repository.UserRepository;
@@ -55,8 +54,8 @@ public class AsyncChannelService {
 
         Map<Long, Long> countMap = counts.stream()
                 .collect(Collectors.toMap(
-                        UserMessageCountDto::getUserId,
-                        UserMessageCountDto::getMessageCount
+                        UserMessageCountDto::userId,
+                        UserMessageCountDto::messageCount
                 ));
 
         if (shouldNotifyMatchingConverted(room, countMap)) {


### PR DESCRIPTION
## 🔗 관련 이슈
- #251 

## ✏️ 변경 사항
- 기존 `ResponseDTO` 클래스들을 Java `record` 타입으로 리팩토링
- `@Getter`, `@AllArgsConstructor`, `@Builder` 등 보일러플레이트 애노테이션 제거
- 서비스 및 컨트롤러 내부에서 DTO 생성 방식을 `new Record(...)` 생성자 방식으로 변경

---

## 📋 상세 설명
- 기존 `ResponseDTO` 클래스에 불필요한 코드가 많아 가독성과 유지보수성이 떨어졌습니다.
- Java 14 이상에서 지원하는 `record` 타입을 적용하여 DTO를 간결하고 명확하게 정의했습니다.
- record는 생성자, getter, toString, equals 등을 자동으로 생성하므로, DTO의 본래 목적에 부합하는 방식입니다.
- 서비스 로직, 컨트롤러 로직에서 `.builder()` 대신 `new ResponseDto(...)` 생성 방식으로 변경했습니다.
- 응답 DTO의 불변성을 보장하며, 명확한 데이터 전달 객체로 기능을 제한함으로써 안정성을 높였습니다.

---

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] Swagger 및 단위 테스트를 통해 응답 포맷을 확인했습니다.

## 👀 리뷰 요청 사항
- 없음

## 📎 참고 자료 (선택)
- 없음
