### PR TITLE
Fix: 튜닝 리포트 리액션 토글 내 리액션 개수 수정

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/entity/TuningReport.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/entity/TuningReport.java
@@ -1,5 +1,6 @@
 package com.hertz.hertz_be.domain.tuningreport.entity;
 
+import com.hertz.hertz_be.domain.channel.entity.SignalRoom;
 import com.hertz.hertz_be.domain.tuningreport.entity.enums.ReactionType;
 import jakarta.persistence.*;
 import lombok.*;
@@ -8,6 +9,7 @@ import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 
 @Entity
 @Getter
@@ -16,11 +18,16 @@ import java.time.LocalDateTime;
 @SQLDelete(sql = "UPDATE tuning_report SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
 @Where(clause = "deleted_at IS NULL")
 @Table(name = "tuning_report")
+@Builder
 public class TuningReport {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "signal_room_id", nullable = false, unique = true)
+    private SignalRoom signalRoom;
 
     @Column(length = 50, nullable = false)
     private String title;
@@ -47,6 +54,13 @@ public class TuningReport {
     @Column(name = "reaction_heart", nullable = false)
     @ColumnDefault("0")
     private int reactionHeart;
+
+    @Column(name = "email_domain", nullable = false)
+    private String emailDomain;
+
+    @Column(name = "is_visible", nullable = false)
+    @ColumnDefault("false")
+    private boolean isVisible;
 
     @Version
     @Column(name = "version")
@@ -89,5 +103,17 @@ public class TuningReport {
             case EYES -> this.reactionEyes = Math.max(0, this.reactionEyes - 1);
             case HEART -> this.reactionHeart = Math.max(0, this.reactionHeart - 1);
         }
+    }
+
+    public static TuningReport of(SignalRoom signalRoom, String emailDomain, Map<String, Object> response) {
+        Map<String, Object> dataMap = (Map<String, Object>) response.get("data");
+        return TuningReport.builder()
+                .signalRoom(signalRoom)
+                .title((String) dataMap.get("title"))
+                .content((String) dataMap.get("content"))
+                .emailDomain(emailDomain)
+                .isVisible(false)
+                .createdAt(LocalDateTime.now())
+                .build();
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportReactionService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportReactionService.java
@@ -49,11 +49,13 @@ public class TuningReportReactionService {
             isReacted = true;
         }
 
-        int reactionCount = report.getReactionCelebrate()
-                + report.getReactionThumbsUp()
-                + report.getReactionLaugh()
-                + report.getReactionEyes()
-                + report.getReactionHeart();
+        int reactionCount = switch(reactionType) {
+            case CELEBRATE  -> report.getReactionCelebrate();
+            case EYES       -> report.getReactionEyes();
+            case HEART      -> report.getReactionHeart();
+            case LAUGH      -> report.getReactionLaugh();
+            case THUMBS_UP  -> report.getReactionThumbsUp();
+        };
 
         return new TuningReportReactionResponse (reportId, reactionType, isReacted, reactionCount);
 


### PR DESCRIPTION
## 🔗 관련 이슈

## ✏️ 변경 사항
- reactionCount를 해당 튜닝 리포트의 전체 개수로 잘못 보내고 있었음
- 각 reaction에 대한 개별 count로 보낼 수 있도록 수정

## 📋 상세 설명


## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.
