### PR TITLE
[#87] Feat: 채널방 나가기 API 구현

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/ChannelController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/ChannelController.java
@@ -131,4 +131,12 @@ public class ChannelController {
                             , "매칭 거절이 완료되었습니다."
                             , null));
     }
+
+    @DeleteMapping("/v2/channel-rooms/{channelRoomId}")
+    @Operation(summary = "채널방 나가기 API")
+    public ResponseEntity<ResponseDto<Void>> leaveChannelRoom(@PathVariable Long channelRoomId,
+                                                              @AuthenticationPrincipal Long userId) {
+        channelService.leaveChannelRoom(channelRoomId, userId);
+        return ResponseEntity.ok(new ResponseDto<>(ResponseCode.CHANNEL_ROOM_EXIT_SUCCESS, "채널방에서 정상적으로 나갔습니다.", null));
+    }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/ChannelController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/ChannelController.java
@@ -74,7 +74,7 @@ public class ChannelController {
                                                                                       @RequestParam(defaultValue = "0") int page,
                                                                                       @RequestParam(defaultValue = "20") int size) {
 
-        ChannelRoomResponseDto response = channelService.getChannelRoomMessages(channelRoomId, userId, page, size);
+        ChannelRoomResponseDto response = channelService.getChannelRoom(channelRoomId, userId, page, size);
         return ResponseEntity.ok(new ResponseDto<>("CHANNEL_ROOM_SUCCESS", "채널방이 정상적으로 조회되었습니다.", response));
     }
 

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/ChannelController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/ChannelController.java
@@ -58,7 +58,6 @@ public class ChannelController {
                                                                                          @RequestParam(defaultValue = "0") int page,
                                                                                          @RequestParam(defaultValue = "10") int size) {
 
-        // Todo: 추후 시그널 -> 채널로 마이그레이션 시 메소드명 변경 필요 (getPersonalSignalRoomList -> getPersonalChannelList)
         ChannelListResponseDto response = channelService.getPersonalSignalRoomList(userId, page, size);
 
         if (response == null) {

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/SignalRoom.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/SignalRoom.java
@@ -89,10 +89,10 @@ public class SignalRoom {
     public String getRelationType() {
         if (senderMatchingStatus == MatchingStatus.MATCHED && receiverMatchingStatus == MatchingStatus.MATCHED) {
             return MatchingStatus.MATCHED.getValue();
-        } else if (senderMatchingStatus == MatchingStatus.SIGNAL && receiverMatchingStatus == MatchingStatus.SIGNAL) {
-            return MatchingStatus.SIGNAL.getValue();
+        } else if (senderMatchingStatus == MatchingStatus.UNMATCHED || receiverMatchingStatus == MatchingStatus.UNMATCHED) {
+            return MatchingStatus.UNMATCHED.getValue();
         }
-        return MatchingStatus.UNMATCHED.getValue();
+        return MatchingStatus.SIGNAL.getValue();
     }
 
     /**

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/SignalRoom.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/SignalRoom.java
@@ -51,12 +51,10 @@ public class SignalRoom {
     @Column(name = "created_at", nullable = false)
     private LocalDateTime createdAt;
 
-    @CreationTimestamp
     @Column(name = "receiver_exited_at")
     @Builder.Default
     private LocalDateTime receiverExitedAt = null;
 
-    @CreationTimestamp
     @Column(name = "sender_exited_at")
     @Builder.Default
     private LocalDateTime senderExitedAt = null;
@@ -106,6 +104,18 @@ public class SignalRoom {
         return exitedAt != null;
     }
 
-
+    /**
+     * 현재 유저 SignalRoom을 나가기
+     */
+    public void leaveChannelRoom(Long userId) {
+        boolean isSender = senderUser.getId().equals(userId);
+        if (isSender) {
+            if (this.senderExitedAt != null) return;
+            this.senderExitedAt = LocalDateTime.now();
+        } else {
+            if (this.receiverExitedAt != null) return;
+            this.receiverExitedAt = LocalDateTime.now();
+        }
+    }
 }
 

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/enums/MatchingStatus.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/enums/MatchingStatus.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum MatchingStatus {
     SIGNAL("시그널", "SIGNAL"),
-    MATCHED("매칭 수락", "MATCHED"),
+    MATCHED("매칭 수락", "MATCHING"),
     UNMATCHED("매칭 거절", "UNMATCHED");
 
     private final String label;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/exception/AlreadyExitedChannelRoomException.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/exception/AlreadyExitedChannelRoomException.java
@@ -1,0 +1,15 @@
+package com.hertz.hertz_be.domain.channel.exception;
+
+import com.hertz.hertz_be.global.common.ResponseCode;
+import lombok.Getter;
+
+@Getter
+public class AlreadyExitedChannelRoomException extends BaseChannelException {
+  private static final String DEFAULT_MESSAGE = "이미 나간 채팅방입니다.";
+  private final String code;
+
+  public AlreadyExitedChannelRoomException() {
+    super(DEFAULT_MESSAGE);
+    this.code = ResponseCode.ALREADY_EXITED_CHANNEL_ROOM;
+  }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/exception/ChannelExceptionHandler.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/exception/ChannelExceptionHandler.java
@@ -29,7 +29,8 @@ public class ChannelExceptionHandler {
     }
 
     @ExceptionHandler({
-            CannotSendSignalToSelfException.class
+            CannotSendSignalToSelfException.class,
+            AlreadyExitedChannelRoomException.class
     })
     public ResponseEntity<ResponseDto<Void>> badRequestException(RuntimeException ex) {
         String code = ((BaseChannelException) ex).getCode();

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/SignalRoomRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/SignalRoomRepository.java
@@ -36,8 +36,10 @@ public interface SignalRoomRepository extends JpaRepository<SignalRoom, Long> {
             ELSE 'false'
         END AS isRead,
         CASE
-            WHEN sr.receiver_matching_status = 'MATCHED' AND sr.sender_matching_status = 'MATCHED'
-            THEN 'MATCHING'
+            WHEN sr.sender_matching_status = 'MATCHED' AND sr.receiver_matching_status = 'MATCHED'
+                THEN 'MATCHING'
+            WHEN sr.sender_matching_status = 'UNMATCHED' OR sr.receiver_matching_status = 'UNMATCHED'
+                THEN 'UNMATCHED'
             ELSE 'SIGNAL'
         END AS relationType
     FROM signal_room sr

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/SignalRoomRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/SignalRoomRepository.java
@@ -19,45 +19,48 @@ public interface SignalRoomRepository extends JpaRepository<SignalRoom, Long> {
     boolean existsBySenderUserAndReceiverUser(User sender, User receiver);
     Optional<SignalRoom> findByUserPairSignal(String userPairSignal);
 
-    // Todo: 웹소켓 도입 전 임시 사용 (v1), 추후 삭제 필요
     @Query(value = """
-        SELECT 
-            sr.id AS channelRoomId,
-            u.profile_image_url AS partnerProfileImage,
-            u.nickname AS partnerNickname,
-            sm.message AS lastMessage,
-            sm.send_at AS lastMessageTime,
-            CASE
-                WHEN sm.sender_user_id = :userId THEN 'true'
-                WHEN sm.sender_user_id != :userId AND sm.is_read = true THEN 'true'
-                ELSE 'false'
-            END AS isRead,
-            CASE
-                WHEN sr.receiver_matching_status = 'MATCHED' AND sr.sender_matching_status = 'MATCHED'
-                THEN 'MATCHING'
-                ELSE 'SIGNAL'
-            END AS relationType
-        FROM signal_room sr
-        JOIN user u ON 
-            (CASE 
-                WHEN sr.sender_user_id = :userId THEN sr.receiver_user_id 
-                ELSE sr.sender_user_id 
-             END) = u.id
-        LEFT JOIN signal_message sm ON sm.id = (
-            SELECT sm2.id
-            FROM signal_message sm2
-            WHERE sm2.signal_room_id = sr.id
-            ORDER BY sm2.send_at DESC
-            LIMIT 1
-        )
-        WHERE :userId IN (sr.sender_user_id, sr.receiver_user_id)
-        ORDER BY sm.send_at DESC
-        """,
+    SELECT 
+        sr.id AS channelRoomId,
+        u.profile_image_url AS partnerProfileImage,
+        u.nickname AS partnerNickname,
+        sm.message AS lastMessage,
+        sm.send_at AS lastMessageTime,
+        sr.sender_user_id AS senderUserId,
+        sr.receiver_user_id AS receiverUserId,
+        sr.sender_exited_at AS senderExitedAt,
+        sr.receiver_exited_at AS receiverExitedAt,
+        CASE
+            WHEN sm.sender_user_id = :userId THEN 'true'
+            WHEN sm.sender_user_id != :userId AND sm.is_read = true THEN 'true'
+            ELSE 'false'
+        END AS isRead,
+        CASE
+            WHEN sr.receiver_matching_status = 'MATCHED' AND sr.sender_matching_status = 'MATCHED'
+            THEN 'MATCHING'
+            ELSE 'SIGNAL'
+        END AS relationType
+    FROM signal_room sr
+    JOIN user u ON 
+        (CASE 
+            WHEN sr.sender_user_id = :userId THEN sr.receiver_user_id 
+            ELSE sr.sender_user_id 
+         END) = u.id
+    LEFT JOIN signal_message sm ON sm.id = (
+        SELECT sm2.id
+        FROM signal_message sm2
+        WHERE sm2.signal_room_id = sr.id
+        ORDER BY sm2.send_at DESC
+        LIMIT 1
+    )
+    WHERE :userId IN (sr.sender_user_id, sr.receiver_user_id)
+    ORDER BY sm.send_at DESC
+    """,
             countQuery = """
-        SELECT COUNT(*)
-        FROM signal_room sr
-        WHERE :userId IN (sr.sender_user_id, sr.receiver_user_id)
-        """,
+    SELECT COUNT(*)
+    FROM signal_room sr
+    WHERE :userId IN (sr.sender_user_id, sr.receiver_user_id)
+    """,
             nativeQuery = true)
     Page<ChannelRoomProjection> findChannelRoomsWithPartnerAndLastMessage(
             @Param("userId") Long userId,

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/projection/ChannelRoomProjection.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/projection/ChannelRoomProjection.java
@@ -10,4 +10,8 @@ public interface ChannelRoomProjection {
     String getRelationType();
     String getPartnerNickname();
     String getPartnerProfileImage();
+    LocalDateTime getSenderExitedAt();
+    LocalDateTime getReceiverExitedAt();
+    Long getSenderUserId();
+    Long getReceiverUserId();
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/ChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/ChannelService.java
@@ -481,4 +481,15 @@ public class ChannelService {
             return ResponseCode.MATCH_REJECTION_SUCCESS;
         }
     }
+
+
+    @Transactional
+    public void leaveChannelRoom(Long roomId, Long userId) {
+        SignalRoom room = signalRoomRepository.findById(roomId)
+                .orElseThrow(ChannelNotFoundException::new);
+        userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
+        room.leaveChannelRoom(userId);
+    }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/ChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/ChannelService.java
@@ -121,7 +121,7 @@ public class ChannelService {
         try {
             signalRoomRepository.save(signalRoom);
         } catch (DataIntegrityViolationException e) {
-            throw new AlreadyInConversationException(); // 중복 방 생성 시도 감지
+            throw new AlreadyInConversationException();
         }
 
         String encryptMessage = aesUtil.encrypt(dto.getMessage());
@@ -338,11 +338,9 @@ public class ChannelService {
             List<String> list1 = interests1.getOrDefault(category, Collections.emptyList());
             List<String> list2 = interests2.getOrDefault(category, Collections.emptyList());
 
-            // 교집합 추출
             Set<String> common = new HashSet<>(list1);
             common.retainAll(list2);
 
-            // 값이 있으면 1개만 반환, 없으면 빈 리스트
             if (!common.isEmpty()) {
                 sameInterests.put(category, List.of(common.iterator().next()));
             } else {
@@ -388,21 +386,20 @@ public class ChannelService {
         }
 
         Long partnerId = room.getPartnerUser(userId).getId();
-        // Todo: AI 쪽 DB에만 사용자 남아있는 경우 410 발생하며 모든 사용자 서비스 사용 불가능한 부분 리팩토링 필요
+
         User partner = userRepository.findByIdAndDeletedAtIsNull(partnerId)
                 .orElseThrow(() -> new UserException("USER_DEACTIVATED", "상대방이 탈퇴한 사용자입니다."));
 
         Optional<RoomWithLastSenderProjection> result = signalMessageRepository.findRoomsWithLastSender(roomId);
 
-        // 마지막 메세지를 보낸 사람이
         if(result.isPresent()){
             RoomWithLastSenderProjection lastSender = result.get();
-            if (!Objects.equals(lastSender.getLastSenderId(), userId)) { // 내가 아닐 경우
-                signalMessageRepository.markAllMessagesAsReadByRoomId(roomId); // isRead = true 처리
+            if (!Objects.equals(lastSender.getLastSenderId(), userId)) {
+                signalMessageRepository.markAllMessagesAsReadByRoomId(roomId);
             }
         }
 
-        asyncChannelService.notifyMatchingConvertedInChannelRoom(room, userId); // 비동기 실행
+        asyncChannelService.notifyMatchingConvertedInChannelRoom(room, userId);
 
         PageRequest pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "sendAt"));
         Page<SignalMessage> messagePage = signalMessageRepository.findBySignalRoom_Id(roomId, pageable);
@@ -441,7 +438,6 @@ public class ChannelService {
 
         String encryptMessage = aesUtil.encrypt(response.getMessage());
 
-        // 메시지 저장
         SignalMessage signalMessage = SignalMessage.builder()
                 .signalRoom(room)
                 .senderUser(user)
@@ -484,7 +480,10 @@ public class ChannelService {
             }
         });
 
-        // 매칭 수락/거절 후 현재 관계
+
+        /**
+         * 매칭 수락/거절 후 현재 관계 반환
+         */
         if(matchingStatus == MatchingStatus.MATCHED) {
             return signalRoomRepository.findMatchResultByUser(userId, room.getId());
         } else {

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseCode.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseCode.java
@@ -45,6 +45,7 @@ public class ResponseCode {
     public static final String ALREADY_IN_CONVERSATION = "ALREADY_IN_CONVERSATION";
     public static final String NEW_MESSAGE = "NEW_MESSAGE";
     public static final String NO_ANY_NEW_MESSAGE = "NO_ANY_NEW_MESSAGE";
+    public static final String CHANNEL_ROOM_EXIT_SUCCESS = "CHANNEL_ROOM_EXIT_SUCCESS";
 
     // 튜닝 추천 상대 반환 로직 관련 응답 code
     public static final String USER_INTERESTS_NOT_SELECTED = "USER_INTERESTS_NOT_SELECTED";

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseCode.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/common/ResponseCode.java
@@ -46,6 +46,7 @@ public class ResponseCode {
     public static final String NEW_MESSAGE = "NEW_MESSAGE";
     public static final String NO_ANY_NEW_MESSAGE = "NO_ANY_NEW_MESSAGE";
     public static final String CHANNEL_ROOM_EXIT_SUCCESS = "CHANNEL_ROOM_EXIT_SUCCESS";
+    public static final String ALREADY_EXITED_CHANNEL_ROOM = "ALREADY_EXITED_CHANNEL_ROOM";
 
     // 튜닝 추천 상대 반환 로직 관련 응답 code
     public static final String USER_INTERESTS_NOT_SELECTED = "USER_INTERESTS_NOT_SELECTED";


### PR DESCRIPTION
## 🔗 관련 이슈
- #87 

## ✏️ 변경 사항
- 사용자가 채널방(시그널룸)을 나갈 수 있는 API 추가: `DELETE /api/v2/channel-rooms/{channelRoomId}`
- 소프트 델리트를 위한 나간 시간 기록 (`senderExitedAt`, `receiverExitedAt`)
- 중복 요청 방지를 위한 예외 처리 (`AlreadyExitedChannelRoomException`)

---

## 📋 상세 설명
- 사용자가 매칭된 상대방과의 대화를 중단하고 싶을 경우, 채널방을 자율적으로 나갈 수 있도록 기능을 추가했습니다.
- 실제 DB 삭제는 수행하지 않고, `SignalRoom` 엔티티의 `senderExitedAt` 또는 `receiverExitedAt` 필드에 `LocalDateTime.now()`를 기록하여 소프트 델리트 형태로 처리합니다.
- 해당 정보는 추후 매칭 알고리즘에서 **재매칭 방지 조건**으로 활용될 수 있습니다.
- 사용자가 이미 나간 채널방에 대해 다시 나가기 요청을 보내는 경우, `AlreadyExitedChannelRoomException`을 통해 명확한 예외 메시지를 반환합니다.
- 클라이언트에서는 이 필드를 기준으로 채널방 목록에서 제외하거나 "나간 채팅방" 상태로 표시할 수 있습니다.

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 없음

## 📎 참고 자료 (선택)
- 없음
