### PR TITLE
[#263] Feat: 새 알림 존재 여부 SSE 구현

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/entity/UserAlarm.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/entity/UserAlarm.java
@@ -30,4 +30,8 @@ public class UserAlarm {
     @Column(name = "is_read", nullable = false)
     @Builder.Default
     private Boolean isRead = false;
+
+    public void setIsRead() {
+        this.isRead = true;
+    }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/repository/UserAlarmRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/repository/UserAlarmRepository.java
@@ -26,5 +26,7 @@ public interface UserAlarmRepository extends JpaRepository<UserAlarm, Long> {
             Pageable pageable
     );
 
-    void deleteAllByUser(User user);
+    @Query("SELECT CASE WHEN COUNT(ua) > 0 THEN true ELSE false END " +
+            "FROM UserAlarm ua WHERE ua.user.id = :userId AND ua.isRead = false")
+    boolean isThereNewAlarm(@Param("userId") Long userId);
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/service/AlarmService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/service/AlarmService.java
@@ -19,11 +19,16 @@ import com.hertz.hertz_be.domain.channel.exception.UserNotFoundException;
 import com.hertz.hertz_be.domain.user.entity.User;
 import com.hertz.hertz_be.domain.user.repository.UserRepository;
 import com.hertz.hertz_be.global.exception.InternalServerErrorException;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationAdapter;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -33,11 +38,16 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class AlarmService {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
     private final AlarmNotificationRepository alarmNotificationRepository;
     private final AlarmMatchingRepository alarmMatchingRepository;
     private final AlarmRepository alarmRepository;
     private final UserAlarmRepository userAlarmRepository;
     private final UserRepository userRepository;
+    private final AsyncAlarmService asyncAlarmService;
 
     @Transactional
     public void createNotifyAlarm(CreateNotifyAlarmRequestDto dto, Long userId) {
@@ -62,6 +72,17 @@ public class AlarmService {
                 .toList();
 
         userAlarmRepository.saveAll(userAlarms);
+
+        entityManager.flush();
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                for (User user : allUsers) {
+                    asyncAlarmService.updateAlarmNotification(user.getId());
+                }
+            }
+        });
     }
 
     @Transactional
@@ -107,6 +128,16 @@ public class AlarmService {
                 .build();
 
         userAlarmRepository.save(userAlarmForPartner);
+
+        entityManager.flush();
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                asyncAlarmService.updateAlarmNotification(user.getId());
+                asyncAlarmService.updateAlarmNotification(partner.getId());
+            }
+        });
 
     }
 

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/service/AlarmService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/service/AlarmService.java
@@ -186,6 +186,15 @@ public class AlarmService {
                 })
                 .collect(Collectors.toList());
 
+        entityManager.flush();
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                asyncAlarmService.updateAlarmNotification(userId);
+            }
+        });
+
         return new AlarmListResponseDto(
                 alarmItems,
                 alarms.getNumber(),

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/service/AlarmService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/service/AlarmService.java
@@ -141,12 +141,16 @@ public class AlarmService {
 
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public AlarmListResponseDto getAlarmList(int page, int size, Long userId) {
         PageRequest pageRequest = PageRequest.of(page, size);
         LocalDateTime thresholdDate = LocalDateTime.now().minusDays(30);
 
         Page<UserAlarm> alarms = userAlarmRepository.findRecentUserAlarms(userId, thresholdDate, pageRequest);
+
+        alarms.getContent().stream()
+                .filter(userAlarm -> !userAlarm.getIsRead())
+                .forEach(UserAlarm::setIsRead);
 
         List<AlarmItem> alarmItems = alarms.getContent().stream()
                 .map(userAlarm -> {

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/service/AsyncAlarmService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/service/AsyncAlarmService.java
@@ -1,0 +1,20 @@
+package com.hertz.hertz_be.domain.alarm.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AsyncAlarmService {
+    private final SseAlarmService sseAlarmService;
+
+    @Async
+    public void updateAlarmNotification(Long userId) {
+        sseAlarmService.updateAlarmNotification(userId);
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/service/SseAlarmService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/service/SseAlarmService.java
@@ -1,0 +1,37 @@
+package com.hertz.hertz_be.domain.alarm.service;
+
+import com.hertz.hertz_be.domain.alarm.repository.UserAlarmRepository;
+import com.hertz.hertz_be.domain.user.entity.User;
+import com.hertz.hertz_be.domain.user.exception.UserException;
+import com.hertz.hertz_be.domain.user.repository.UserRepository;
+import com.hertz.hertz_be.global.common.ResponseCode;
+import com.hertz.hertz_be.global.common.SseEventName;
+import com.hertz.hertz_be.global.sse.SseService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SseAlarmService {
+    private final UserRepository userRepository;
+    private final UserAlarmRepository userAlarmRepository;
+    private final SseService sseService;
+
+    public void updateAlarmNotification(Long userId) {
+        userRepository.findByIdWithSentSignalRooms(userId)
+                .orElseThrow(() -> new UserException(ResponseCode.USER_NOT_FOUND, "사용자가 존재하지 않습니다."));
+
+        boolean isThereNewAlarm = userAlarmRepository.isThereNewAlarm(userId);
+        if (isThereNewAlarm) {
+            boolean result = sseService.sendToClient(userId, SseEventName.NEW_ALARM.getValue(), "");
+            if (result){log.info("[새 알림 존재 SSE 알림 전송] userId={}", userId);}
+        } else {
+            boolean result = sseService.sendToClient(userId, SseEventName.NO_ANY_NEW_ALARM.getValue(), "");
+            if (result){log.info("[새 알림 미존재 SSE 알림 전송] userId={}", userId);}
+        }
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/ChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/ChannelService.java
@@ -410,7 +410,7 @@ public class ChannelService {
 
         entityManager.flush();
 
-        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronizationAdapter() {
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {
                 asyncChannelService.updateNavbarMessageNotification(userId);

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/SseChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/SseChannelService.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -29,6 +30,7 @@ import java.util.stream.Stream;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class SseChannelService {
     @Value("${matching.convert.delay-minutes}")
     private long matchingConvertDelayMinutes;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/common/SseEventName.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/common/SseEventName.java
@@ -18,7 +18,9 @@ public enum SseEventName {
     NEW_SIGNAL_RECEPTION("new-signal-reception"),
     MATCHING_SUCCESS("matching-success"),
     MATCHING_REJECTION("matching-rejection"),
-    MATCHING_CONFIRMED("matching-confirmed");
+    MATCHING_CONFIRMED("matching-confirmed"),
+    NEW_ALARM("new-alarm"),
+    NO_ANY_NEW_ALARM("no-any-new-alarm");
 
     private final String value;
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- 이 PR이 연결된 이슈 번호를 작성해 주세요. (예: `#123`)

## ✏️ 변경 사항
- 사용자의 읽지 않은 알림 여부를 확인하여 SSE 알림을 전송하는 로직 추가
- 알림 조회 시 `isRead` 필드를 `true`로 변경하는 처리 로직 추가
- 트랜잭션 커밋 이후에만 `asyncAlarmService.updateAlarmNotification`이 호출되도록 수정

## 📋 상세 설명
- 사용자가 알림 리스트를 조회하면, 최근 30일 내 알림 중 읽지 않은 알림(`isRead = false`)을 읽음 처리합니다.
- 해당 처리는 JPA의 dirty checking을 활용하여 트랜잭션 커밋 시점에 자동으로 DB에 반영됩니다.
- 알림 데이터 변경이 DB에 반영된 이후에만 SSE 이벤트를 전송하기 위해  
  `TransactionSynchronizationManager.registerSynchronization()`을 활용하여 `afterCommit()` 시점에  
  `asyncAlarmService.updateAlarmNotification(userId)`가 호출되도록 처리했습니다.
- `asyncAlarmService`는 아래와 같이 알림 존재 여부에 따라 적절한 SSE 이벤트를 전송합니다:
  - `event: new-alarm` → 새 알림 존재
  - `event: no-any-new-alarm` → 새 알림 없음
- 이로써 클라이언트는 실시간으로 새로운 알림 여부를 인지할 수 있게 되며 UX가 향상됩니다.

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 없음

## 📎 참고 자료 (선택)
- 없음
