### PR TITLE
[#271] Fix: HikariCP: active 커넥션 고정 상태로 커넥션 반환하지 않는 문제 해결

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/sse/SseService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/sse/SseService.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
@@ -27,9 +28,11 @@ public class SseService {
 
     private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
 
+    @Transactional(readOnly = true)
     public SseEmitter subscribe(Long userId) {
-        userRepository.findById(userId)
-                .orElseThrow(UserNotFoundException::new);
+        if (!userRepository.existsById(userId)) {
+            throw new UserNotFoundException();
+        }
 
         if (emitters.containsKey(userId)) {
             emitters.get(userId).complete();

--- a/hertz-be/src/main/resources/application-dev.properties
+++ b/hertz-be/src/main/resources/application-dev.properties
@@ -3,6 +3,7 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.show-sql=true
+spring.jpa.open-in-view=false
 
 # JWT AT expiration time
 jwt.at.expiration-minutes=180

--- a/hertz-be/src/main/resources/application-local.properties
+++ b/hertz-be/src/main/resources/application-local.properties
@@ -3,6 +3,7 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.show-sql=true
+spring.jpa.open-in-view=false
 
 # JWT AT expiration time
 jwt.at.expiration-minutes=300

--- a/hertz-be/src/main/resources/application-prod.properties
+++ b/hertz-be/src/main/resources/application-prod.properties
@@ -3,6 +3,7 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.show-sql=false
+spring.jpa.open-in-view=false
 
 # JWT AT expiration time
 jwt.at.expiration-minutes=30


### PR DESCRIPTION
## 🔗 관련 이슈
- #271 

## ✏️ 변경 사항
- `spring.jpa.open-in-view=false` 설정을 추가하여 JPA 트랜잭션 범위를 명시적으로 제한

## 📋 상세 설명
- 기존 설정에서는 `spring.jpa.open-in-view=true`가 기본값으로 활성화되어 있었고,
  이로 인해 **트랜잭션이 View 렌더링 혹은 SSE 응답까지 열린 채로 유지**되었습니다.
- 이 구조에서 `SseEmitter`와 함께 Lazy Loading이 발생하거나 응답 지연이 길어지면,
  **커넥션이 즉시 반환되지 않고 풀을 고갈시키는 문제**가 발생했습니다.
- `application.properties`에 다음 설정을 추가하여 View 이후에는 트랜잭션이 이어지지 않도록 변경
  ```properties
  spring.jpa.open-in-view=false

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- https://techblog.woowahan.com/2664/
- https://techblog.woowahan.com/2663/
- https://haedal-uni.github.io/posts/SSE-%EB%AC%B8%EC%A0%9C%EC%A0%90/
