### PR TITLE
[#281] Feat: 채팅방 반환 시 상대방이 나간 채팅방인지 여부를 나타내는 필드 추가

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/ChannelRoomResponseDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/ChannelRoomResponseDto.java
@@ -24,16 +24,19 @@ public class ChannelRoomResponseDto {
     private String partnerProfileImage;
     private String partnerNickname;
     private String relationType;
+    private boolean hasPartnerExited;
     private MessagePage messages;
 
     public static ChannelRoomResponseDto of(Long roomId, User partner, String relationType,
-                                         List<MessageDto> messages, Page<SignalMessage> page) {
+                                            boolean hasPartnerExited,
+                                            List<MessageDto> messages, Page<SignalMessage> page) {
         return ChannelRoomResponseDto.builder()
                 .channelRoomId(roomId)
                 .partnerId(partner.getId())
                 .partnerProfileImage(partner.getProfileImageUrl())
                 .partnerNickname(partner.getNickname())
                 .relationType(relationType)
+                .hasPartnerExited(hasPartnerExited)
                 .messages(new MessagePage(messages, page))
                 .build();
     }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/SignalRoom.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/SignalRoom.java
@@ -124,5 +124,16 @@ public class SignalRoom {
             this.receiverExitedAt = LocalDateTime.now();
         }
     }
+
+    /**
+     * 현재 유저 id를 받아서 상대방이 나갔는지 여부를 반환
+     */
+    public boolean isPartnerExited(Long userId) {
+        boolean isSender = senderUser.getId().equals(userId);
+        if (isSender) {
+            return receiverExitedAt != null;
+        }
+        return senderExitedAt != null;
+    }
 }
 

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/ChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/ChannelService.java
@@ -462,6 +462,8 @@ public class ChannelService {
             );
         }
 
+        boolean isPartnerExited = room.isPartnerExited(userId);
+
         Long partnerId = room.getPartnerUser(userId).getId();
 
         User partner = userRepository.findByIdAndDeletedAtIsNull(partnerId)
@@ -498,7 +500,7 @@ public class ChannelService {
             }
         });
 
-        return ChannelRoomResponseDto.of(roomId, partner, room.getRelationType(), messages, messagePage);
+        return ChannelRoomResponseDto.of(roomId, partner, room.getRelationType(), isPartnerExited, messages, messagePage);
     }
 
     @Transactional


### PR DESCRIPTION
## 🔗 관련 이슈
- #281 

## ✏️ 변경 사항
- `SignalRoom` 엔티티에 상대방이 채팅방을 나갔는지 확인하는 메서드 `isPartnerExited` 추가
- `ChannelRoomResponseDto`에 `hasPartnerExited` 필드 추가 및 `of` 팩토리 메서드에 파라미터 반영
- `ChannelService#getChannelRoom`에서 상대방의 나간 상태 여부를 조회하고 응답 DTO에 포함하도록 로직 수정

## 📋 상세 설명
- 기존에는 채팅방 상세 조회 시 상대방이 채팅방을 나갔는지 여부를 클라이언트에서 알 수 없었음
- 이를 해결하기 위해 `SignalRoom`에 `isPartnerExited` 메서드를 구현하여 현재 사용자의 상대방 나간 상태를 쉽게 확인 가능하도록 함
- `ChannelRoomResponseDto`에 `hasPartnerExited` 필드를 추가하여 응답에 포함되도록 변경
- `getChannelRoom` 서비스 로직에서 `isPartnerExited` 결과를 조회해 DTO 생성 시 전달
- 이를 통해 프론트엔드에서 상대방이 이미 나간 채팅방임을 감지하여 채팅 입력창 비활성화 등 적절한 UI 처리가 가능함

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 없음

## 📎 참고 자료 (선택)
- 없음
