### PR TITLE
[#285] Feat: 튜닝레포트 발행시 알림창 페이지 내에서 알림 생성 로직

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/HertzBeApplication.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/HertzBeApplication.java
@@ -2,10 +2,8 @@ package com.hertz.hertz_be;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableScheduling
 public class HertzBeApplication {
 
 	public static void main(String[] args) {

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/entity/AlarmReport.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/entity/AlarmReport.java
@@ -15,6 +15,6 @@ import lombok.experimental.SuperBuilder;
 @DiscriminatorValue("REPORT")
 public class AlarmReport extends Alarm{
 
-    @Column(nullable = false)
-    private int couple_count;
+    @Column(name = "couple_count", nullable = false)
+    private int coupleCount;
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/repository/AlarmReportRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/repository/AlarmReportRepository.java
@@ -1,0 +1,7 @@
+package com.hertz.hertz_be.domain.alarm.repository;
+
+import com.hertz.hertz_be.domain.alarm.entity.AlarmReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AlarmReportRepository extends JpaRepository<AlarmReport, Long> {
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/service/AlarmService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/service/AlarmService.java
@@ -94,11 +94,11 @@ public class AlarmService {
         String alarmTitleForUser;
         String alarmTitleForPartner;
         if (Objects.equals(room.getRelationType(), MatchingStatus.UNMATCHED.getValue())) {
-            alarmTitleForUser = createFailureMessage(partner.getNickname());
-            alarmTitleForPartner = createFailureMessage(user.getNickname());
+            alarmTitleForUser = createMatchingFailureMessage(partner.getNickname());
+            alarmTitleForPartner = createMatchingFailureMessage(user.getNickname());
         } else {
-            alarmTitleForUser = createSuccessMessage(partner.getNickname());
-            alarmTitleForPartner = createSuccessMessage(user.getNickname());
+            alarmTitleForUser = createMatchingSuccessMessage(partner.getNickname());
+            alarmTitleForPartner = createMatchingSuccessMessage(user.getNickname());
         }
 
         AlarmMatching alarmMatchingForUser = AlarmMatching.builder()

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/service/AlarmService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/service/AlarmService.java
@@ -8,11 +8,8 @@ import com.hertz.hertz_be.domain.alarm.dto.response.object.NoticeAlarm;
 import com.hertz.hertz_be.domain.alarm.dto.response.object.ReportAlarm;
 import com.hertz.hertz_be.domain.alarm.entity.*;
 import com.hertz.hertz_be.domain.alarm.entity.enums.AlarmCategory;
-import com.hertz.hertz_be.domain.alarm.repository.AlarmMatchingRepository;
-import com.hertz.hertz_be.domain.alarm.repository.AlarmNotificationRepository;
+import com.hertz.hertz_be.domain.alarm.repository.*;
 import com.hertz.hertz_be.domain.alarm.dto.request.CreateNotifyAlarmRequestDto;
-import com.hertz.hertz_be.domain.alarm.repository.AlarmRepository;
-import com.hertz.hertz_be.domain.alarm.repository.UserAlarmRepository;
 import com.hertz.hertz_be.domain.channel.entity.SignalRoom;
 import com.hertz.hertz_be.domain.channel.entity.enums.MatchingStatus;
 import com.hertz.hertz_be.domain.user.entity.User;
@@ -43,6 +40,7 @@ public class AlarmService {
     private EntityManager entityManager;
 
     private final AlarmNotificationRepository alarmNotificationRepository;
+    private final AlarmReportRepository alarmReportRepository;
     private final AlarmMatchingRepository alarmMatchingRepository;
     private final AlarmRepository alarmRepository;
     private final UserAlarmRepository userAlarmRepository;
@@ -143,6 +141,41 @@ public class AlarmService {
             }
         });
 
+    }
+
+    @Transactional
+    public void createTuningReportAlarm(String emailDomain, int coupleCount) {
+
+        String tuningReportAlarmTitle = createTuningReportMessage();
+
+        AlarmReport alarmReport = AlarmReport.builder()
+                .title(tuningReportAlarmTitle)
+                .coupleCount(coupleCount)
+                .build();
+
+        AlarmReport savedAlarm = alarmReportRepository.save(alarmReport);
+
+        List<User> allUsers = userRepository.findAllByEmailDomain(emailDomain);
+
+        List<UserAlarm> userAlarms = allUsers.stream()
+                .map(user -> UserAlarm.builder()
+                        .alarm(savedAlarm)
+                        .user(user)
+                        .build())
+                .toList();
+
+        userAlarmRepository.saveAll(userAlarms);
+
+        entityManager.flush();
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                for (User user : allUsers) {
+                    asyncAlarmService.updateAlarmNotification(user.getId());
+                }
+            }
+        });
     }
 
     @Transactional

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/AsyncChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/AsyncChannelService.java
@@ -37,7 +37,7 @@ public class AsyncChannelService {
     private final long ONE_MESSAGE = 1L;
 
     //Todo: 2차 압데이트 전에 장확한 날짜로 수정
-    private static final LocalDateTime VERSION_2_UPDATE_DATE = LocalDateTime.of(2025, 5, 15, 0, 0);
+    private static final LocalDateTime VERSION_2_UPDATE_DATE = LocalDateTime.of(2025, 6, 20, 12, 0);
 
     @PersistenceContext
     private EntityManager entityManager;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/batch/TuningReportVisibilityWriter.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/batch/TuningReportVisibilityWriter.java
@@ -19,12 +19,14 @@ public class TuningReportVisibilityWriter implements ItemWriter<TuningReport> {
     @Override
     @Transactional
     public void write(Chunk<? extends TuningReport> chunk) {
+        String emailDomain = chunk.getItems().getFirst().getEmailDomain();
+        int coupleCount = chunk.size();
+
         for (TuningReport report : chunk.getItems()) {
             report.setVisible();
             tuningReportRepository.save(report);
-
-            // 구현할 알람 서비스
-            // alarmService.sendTuningReportVisibleAlarm(report);
         }
+
+        alarmService.createTuningReportAlarm(emailDomain, coupleCount);
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/sse/SseService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/sse/SseService.java
@@ -25,7 +25,7 @@ public class SseService {
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenService;
 
-    private static final Long TIMEOUT = 0L;
+    private static final Long TIMEOUT = 120_000L;
 
     private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
 

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/util/MessageCreatorUtil.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/util/MessageCreatorUtil.java
@@ -2,11 +2,11 @@ package com.hertz.hertz_be.global.util;
 
 public class MessageCreatorUtil {
     public static String createMatchingSuccessMessage(String nickname) {
-        return String.format("🎉 축하드려요, ‘%s’님과 매칭에 성공했습니다!", nickname);
+        return String.format("🎉 축하드려요, ‘%s’님과 매칭에 성공했어요!", nickname);
     }
 
     public static String createMatchingFailureMessage(String nickname) {
-        return String.format("😥 아쉽지만, ‘%s’님과의 매칭은 성사되지 않았습니다.", nickname);
+        return String.format("😥 아쉽지만, ‘%s’님과의 매칭은 성사되지 않았어요.", nickname);
     }
 
     private MessageCreatorUtil() {}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/util/MessageCreatorUtil.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/util/MessageCreatorUtil.java
@@ -9,5 +9,9 @@ public class MessageCreatorUtil {
         return String.format("😥 아쉽지만, ‘%s’님과의 매칭은 성사되지 않았어요.", nickname);
     }
 
+    public static String createTuningReportMessage() {
+        return "이번 주 튜닝 결과가 왔어요! 👈확인하러가기";
+    }
+
     private MessageCreatorUtil() {}
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/util/MessageCreatorUtil.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/util/MessageCreatorUtil.java
@@ -1,11 +1,11 @@
 package com.hertz.hertz_be.global.util;
 
 public class MessageCreatorUtil {
-    public static String createSuccessMessage(String nickname) {
+    public static String createMatchingSuccessMessage(String nickname) {
         return String.format("🎉 축하드려요, ‘%s’님과 매칭에 성공했습니다!", nickname);
     }
 
-    public static String createFailureMessage(String nickname) {
+    public static String createMatchingFailureMessage(String nickname) {
         return String.format("😥 아쉽지만, ‘%s’님과의 매칭은 성사되지 않았습니다.", nickname);
     }
 


### PR DESCRIPTION
## 🔗 관련 이슈
- #285 

## ✏️ 변경 사항
- 튜닝레포트 발행 시 알림창 페이지 내에서도 새로운 알림이 생성되도록 로직 추가
- SSE 서비스 `TIMEOUT`을 2분으로 설정하여 안정적인 연결 유지 및 자동 재연결 환경 개선
- 기존 heartbeat 로직 유지 및 연결 종료/타임아웃 시 emitter 정리 로직 보완

---

## 📋 상세 설명
- 매주 발행되는 튜닝레포트가 사용자 알림창에 자동으로 표시되도록, 튜닝레포트 생성 시점에 모든 사용자에게 알림 객체를 생성하는 로직을 추가했습니다.
- `SseService`의 emitter timeout 값을 기존 `0L` (무제한)에서 `120,000L` (2분)으로 변경하여 서버 socket 누적 방지 및 연결 관리 효율성을 높였습니다.
- 연결 유지를 위해 15초마다 heartbeat 이벤트를 전송하며, 타임아웃 혹은 오류 발생 시 emitter를 안전하게 종료 및 제거하도록 로직을 보완했습니다.
- 이를 통해 사용자는 새로운 튜닝레포트 발행 여부를 알림창과 SSE 실시간 알림을 통해 즉시 확인할 수 있습니다.

---

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 없음

## 📎 참고 자료 (선택)
- 없음
