### PR TITLE
[#306] Feat: V3의 개인정보 등록 API 구현 

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/AuthController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/AuthController.java
@@ -6,7 +6,7 @@ import com.hertz.hertz_be.domain.auth.responsecode.AuthResponseCode;
 import com.hertz.hertz_be.domain.auth.repository.RefreshTokenRepository;
 import com.hertz.hertz_be.domain.auth.service.AuthService;
 import com.hertz.hertz_be.domain.auth.dto.request.TestLoginRequestDto;
-import com.hertz.hertz_be.domain.user.service.UserService;
+import com.hertz.hertz_be.domain.user.service.v1.UserService;
 import com.hertz.hertz_be.global.auth.token.JwtTokenProvider;
 import com.hertz.hertz_be.global.common.ResponseDto;
 import com.hertz.hertz_be.global.exception.BusinessException;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/v1/UserController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/v1/UserController.java
@@ -1,10 +1,9 @@
-package com.hertz.hertz_be.domain.user.controller;
+package com.hertz.hertz_be.domain.user.controller.v1;
 
-import com.hertz.hertz_be.domain.user.dto.request.UserInfoRequestDto;
-import com.hertz.hertz_be.domain.user.dto.response.UserInfoResponseDto;
-import com.hertz.hertz_be.domain.user.dto.response.UserProfileDTO;
+import com.hertz.hertz_be.domain.user.dto.request.v1.UserInfoRequestDto;
+import com.hertz.hertz_be.domain.user.dto.response.v1.UserInfoResponseDto;
 import com.hertz.hertz_be.domain.user.responsecode.UserResponseCode;
-import com.hertz.hertz_be.domain.user.service.UserService;
+import com.hertz.hertz_be.domain.user.service.v1.UserService;
 import com.hertz.hertz_be.global.common.ResponseDto;
 import com.hertz.hertz_be.global.util.AuthUtil;
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,16 +12,15 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
 import java.util.Map;
 
-@RestController
+@RestController("userControllerV1")
 @RequestMapping("/api")
 @RequiredArgsConstructor
-@Tag(name = "사용자 관련 API")
+@Tag(name = "사용자 관련 V1 API")
 public class UserController {
 
     @Value("${is.local}")
@@ -79,33 +77,5 @@ public class UserController {
                         data)
 
         );
-    }
-
-
-    /**
-     * 사용자 정보 조회 (마이페이지, 상대방 상세 조회 페이지)
-     * @author daisy.lee
-     */
-    @GetMapping("/v2/users/{userId}")
-    @Operation(summary = "사용자 정보 조회")
-    public ResponseEntity<ResponseDto<UserProfileDTO>> getUserProfile(@PathVariable Long userId,
-                                                                      @AuthenticationPrincipal Long id) {
-        UserProfileDTO response = userService.getUserProfile(userId, id);
-
-        if("ME".equals(response.getRelationType())) {
-            return ResponseEntity.ok(
-                    new ResponseDto<>(
-                            UserResponseCode.USER_INFO_FETCH_SUCCESS.getCode(),
-                            UserResponseCode.USER_INFO_FETCH_SUCCESS.getMessage(),
-                            response)
-            );
-        } else {
-            return ResponseEntity.ok(
-                    new ResponseDto<>(
-                            UserResponseCode.OTHER_USER_INFO_FETCH_SUCCESS.getCode(),
-                            UserResponseCode.OTHER_USER_INFO_FETCH_SUCCESS.getMessage(),
-                            response)
-            );
-        }
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/v2/UserController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/v2/UserController.java
@@ -1,0 +1,48 @@
+package com.hertz.hertz_be.domain.user.controller.v2;
+
+import com.hertz.hertz_be.domain.user.dto.response.v2.UserProfileDTO;
+import com.hertz.hertz_be.domain.user.responsecode.UserResponseCode;
+import com.hertz.hertz_be.domain.user.service.v2.UserService;
+import com.hertz.hertz_be.global.common.ResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController("userControllerV2")
+@RequestMapping("/api")
+@RequiredArgsConstructor
+@Tag(name = "사용자 관련 V2 API")
+public class UserController {
+
+    private final UserService userService;
+
+    /**
+     * 사용자 정보 조회 (마이페이지, 상대방 상세 조회 페이지)
+     * @author daisy.lee
+     */
+    @GetMapping("/v2/users/{userId}")
+    @Operation(summary = "사용자 정보 조회")
+    public ResponseEntity<ResponseDto<UserProfileDTO>> getUserProfile(@PathVariable Long userId,
+                                                                      @AuthenticationPrincipal Long id) {
+        UserProfileDTO response = userService.getUserProfile(userId, id);
+
+        if("ME".equals(response.getRelationType())) {
+            return ResponseEntity.ok(
+                    new ResponseDto<>(
+                            UserResponseCode.USER_INFO_FETCH_SUCCESS.getCode(),
+                            UserResponseCode.USER_INFO_FETCH_SUCCESS.getMessage(),
+                            response)
+            );
+        } else {
+            return ResponseEntity.ok(
+                    new ResponseDto<>(
+                            UserResponseCode.OTHER_USER_INFO_FETCH_SUCCESS.getCode(),
+                            UserResponseCode.OTHER_USER_INFO_FETCH_SUCCESS.getMessage(),
+                            response)
+            );
+        }
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/v3/UserController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/v3/UserController.java
@@ -45,7 +45,6 @@ public class UserController {
                 isLocal
         );
 
-        // ✅ 응답 바디 구성
         Map<String, Object> data = new HashMap<>();
         data.put("userId", userInfoResponseDto.getUserId());
         data.put("accessToken", userInfoResponseDto.getAccessToken());

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/v3/UserController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/v3/UserController.java
@@ -1,0 +1,62 @@
+package com.hertz.hertz_be.domain.user.controller.v3;
+
+import com.hertz.hertz_be.domain.user.dto.request.v3.UserInfoRequestDto;
+import com.hertz.hertz_be.domain.user.dto.response.v3.UserInfoResponseDto;
+import com.hertz.hertz_be.domain.user.responsecode.UserResponseCode;
+import com.hertz.hertz_be.domain.user.service.v3.UserService;
+import com.hertz.hertz_be.global.common.ResponseDto;
+import com.hertz.hertz_be.global.util.AuthUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController("userControllerV3")
+@RequestMapping("/api")
+@RequiredArgsConstructor
+@Tag(name = "사용자 관련 V3 API")
+public class UserController {
+
+    @Value("${is.local}")
+    private boolean isLocal;
+
+    private final UserService userService;
+
+    @PostMapping("/v3/users")
+    @Operation(summary = "개인정보 등록 API")
+    public ResponseEntity<ResponseDto<Map<String, Object>>> createUser(
+            @RequestBody UserInfoRequestDto userInfoRequestDto,
+            HttpServletResponse response) {
+
+        UserInfoResponseDto userInfoResponseDto = userService.createUser(userInfoRequestDto);
+
+        AuthUtil.setRefreshTokenCookie(response,
+                userInfoResponseDto.getRefreshToken(),
+                userInfoResponseDto.getRefreshSecondsUntilExpiry(),
+                isLocal
+        );
+
+        // ✅ 응답 바디 구성
+        Map<String, Object> data = new HashMap<>();
+        data.put("userId", userInfoResponseDto.getUserId());
+        data.put("accessToken", userInfoResponseDto.getAccessToken());
+
+        return ResponseEntity.ok(
+                new ResponseDto<>(
+                        UserResponseCode.PROFILE_SAVED_SUCCESSFULLY.getCode(),
+                        UserResponseCode.PROFILE_SAVED_SUCCESSFULLY.getMessage(),
+                        data
+                )
+        );
+    }
+
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/request/v1/UserInfoRequestDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/request/v1/UserInfoRequestDto.java
@@ -1,0 +1,49 @@
+package com.hertz.hertz_be.domain.user.dto.request.v1;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.hertz.hertz_be.domain.user.entity.enums.AgeGroup;
+import com.hertz.hertz_be.domain.user.entity.enums.Gender;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserInfoRequestDto {
+
+    @NotBlank
+    private String providerId;
+
+    @NotBlank
+    private String provider;
+
+    @NotBlank
+    private String profileImage;
+
+    private String email;
+
+    @NotBlank
+    private String nickname;
+
+    @NotNull
+    private AgeGroup ageGroup;
+
+    @NotNull
+    private Gender gender;
+
+    @NotBlank
+    private String oneLineIntroduction;
+
+
+    // Todo. FE 개발용 테스트 필드 (추후 삭제 필요)
+    @JsonProperty("isTest")
+    private boolean isTest;
+
+
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/request/v3/UserInfoRequestDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/request/v3/UserInfoRequestDto.java
@@ -26,8 +26,6 @@ public class UserInfoRequestDto {
     @NotBlank
     private String profileImage;
 
-    private String email;
-
     @NotBlank
     private String nickname;
 

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/request/v3/UserInfoRequestDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/request/v3/UserInfoRequestDto.java
@@ -1,4 +1,4 @@
-package com.hertz.hertz_be.domain.user.dto.request;
+package com.hertz.hertz_be.domain.user.dto.request.v3;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.hertz.hertz_be.domain.user.entity.enums.AgeGroup;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/request/v3/UserInfoRequestDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/request/v3/UserInfoRequestDto.java
@@ -40,10 +40,19 @@ public class UserInfoRequestDto {
     @NotBlank
     private String oneLineIntroduction;
 
+    @NotNull
+    private int authCode;
+
+    @NotNull
+    private boolean friendAllowed;
+
+    @NotNull
+    private boolean coupleAllowed;
+
 
     // Todo. FE 개발용 테스트 필드 (추후 삭제 필요)
     @JsonProperty("isTest")
-    private boolean isTest;
+    private boolean test;
 
 
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/request/v3/UserInfoRequestDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/request/v3/UserInfoRequestDto.java
@@ -41,7 +41,7 @@ public class UserInfoRequestDto {
     private String oneLineIntroduction;
 
     @NotNull
-    private int authCode;
+    private int invitationCode;
 
     @NotNull
     private boolean friendAllowed;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/response/v1/UserInfoResponseDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/response/v1/UserInfoResponseDto.java
@@ -1,4 +1,4 @@
-package com.hertz.hertz_be.domain.user.dto.response;
+package com.hertz.hertz_be.domain.user.dto.response.v1;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/response/v2/InterestsDTO.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/response/v2/InterestsDTO.java
@@ -1,4 +1,4 @@
-package com.hertz.hertz_be.domain.user.dto.response;
+package com.hertz.hertz_be.domain.user.dto.response.v2;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/response/v2/KeywordsDTO.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/response/v2/KeywordsDTO.java
@@ -1,4 +1,4 @@
-package com.hertz.hertz_be.domain.user.dto.response;
+package com.hertz.hertz_be.domain.user.dto.response.v2;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/response/v2/UserProfileDTO.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/response/v2/UserProfileDTO.java
@@ -1,4 +1,4 @@
-package com.hertz.hertz_be.domain.user.dto.response;
+package com.hertz.hertz_be.domain.user.dto.response.v2;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.hertz.hertz_be.domain.user.entity.enums.Gender;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/response/v3/UserInfoResponseDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/response/v3/UserInfoResponseDto.java
@@ -1,0 +1,17 @@
+package com.hertz.hertz_be.domain.user.dto.response.v3;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserInfoResponseDto {
+    private Long userId;
+    private String accessToken;
+    private String refreshToken;
+    private int refreshSecondsUntilExpiry;
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/responsecode/UserResponseCode.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/responsecode/UserResponseCode.java
@@ -16,6 +16,7 @@ public enum UserResponseCode {
     DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "DUPLICATE_NICKNAME", "이미 사용 중인 닉네임입니다."),
     NICKNAME_API_FAILED(HttpStatus.BAD_GATEWAY, "NICKNAME_API_FAILED", "닉네임 생성 API 호출 실패"),
     NICKNAME_GENERATION_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "NICKNAME_GENERATION_TIMEOUT", "5초 내에 중복되지 않은 닉네임을 찾지 못했습니다."),
+    WRONG_INVITATION_CODE(HttpStatus.BAD_REQUEST, "WRONG_INVITATION_CODE", "유효하지 않은 초대코드입니다."),
 
     // 성공 응답 코드
     USER_INFO_FETCH_SUCCESS(HttpStatus.OK, "USER_INFO_FETCH_SUCCESS", "사용자의 정보가 정상적으로 조회되었습니다."),

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/service/v2/UserService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/service/v2/UserService.java
@@ -1,0 +1,73 @@
+package com.hertz.hertz_be.domain.user.service.v2;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hertz.hertz_be.domain.interests.service.InterestsService;
+import com.hertz.hertz_be.domain.user.dto.response.v2.InterestsDTO;
+import com.hertz.hertz_be.domain.user.dto.response.v2.KeywordsDTO;
+import com.hertz.hertz_be.domain.user.dto.response.v2.UserProfileDTO;
+import com.hertz.hertz_be.domain.user.entity.User;
+import com.hertz.hertz_be.domain.user.repository.UserRepository;
+import com.hertz.hertz_be.domain.user.responsecode.UserResponseCode;
+import com.hertz.hertz_be.global.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+@Slf4j
+@Service("userServiceV2")
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+    private final InterestsService interestsService;
+
+    public UserProfileDTO getUserProfile(Long targetUserId, Long userId) {
+        User targetUser = userRepository.findByIdAndDeletedAtIsNull(targetUserId)
+                .orElseThrow(() -> new BusinessException(
+                        UserResponseCode.USER_DEACTIVATED.getCode(),
+                        UserResponseCode.USER_DEACTIVATED.getHttpStatus(),
+                        UserResponseCode.USER_DEACTIVATED.getMessage()));
+
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        Map<String, String> keywordsMap = interestsService.getUserKeywords(targetUser.getId());
+        Map<String, List<String>> currentUserInterestsMap = interestsService.getUserInterests(userId);
+
+        KeywordsDTO keywordsDto = objectMapper.convertValue(keywordsMap, KeywordsDTO.class);
+        InterestsDTO currentUserDto = objectMapper.convertValue(currentUserInterestsMap, InterestsDTO.class);
+
+
+        if(Objects.equals(targetUser.getId(), userId)) { // 마이페이지 조회
+            return new UserProfileDTO(
+                    targetUser.getProfileImageUrl(),
+                    targetUser.getNickname(),
+                    targetUser.getGender(),
+                    targetUser.getOneLineIntroduction(),
+                    "ME",
+                    keywordsDto,
+                    currentUserDto,
+                    null
+            );
+        } else { // 상대방 페이지 조회
+            String relationType = userRepository.findRelationTypeBetweenUsers(userId, targetUser.getId());
+
+            Map<String, List<String>> targetInterestsMap = interestsService.getUserInterests(targetUser.getId());
+            Map<String, List<String>> sameInterestsMap = interestsService.extractSameInterests(targetInterestsMap, currentUserInterestsMap);
+            InterestsDTO sameInterestsDto = objectMapper.convertValue(sameInterestsMap, InterestsDTO.class);
+
+            return new UserProfileDTO(
+                    targetUser.getProfileImageUrl(),
+                    targetUser.getNickname(),
+                    targetUser.getGender(),
+                    targetUser.getOneLineIntroduction(),
+                    relationType,
+                    keywordsDto,
+                    currentUserDto,
+                    sameInterestsDto
+            );
+        }
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/service/v3/UserService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/service/v3/UserService.java
@@ -1,0 +1,120 @@
+package com.hertz.hertz_be.domain.user.service.v3;
+
+import com.hertz.hertz_be.domain.auth.repository.OAuthRedisRepository;
+import com.hertz.hertz_be.domain.auth.repository.RefreshTokenRepository;
+import com.hertz.hertz_be.domain.auth.responsecode.AuthResponseCode;
+import com.hertz.hertz_be.domain.user.dto.request.v3.UserInfoRequestDto;
+import com.hertz.hertz_be.domain.user.dto.response.v3.UserInfoResponseDto;
+import com.hertz.hertz_be.domain.user.entity.User;
+import com.hertz.hertz_be.domain.user.entity.UserOauth;
+import com.hertz.hertz_be.domain.user.repository.UserOauthRepository;
+import com.hertz.hertz_be.domain.user.repository.UserRepository;
+import com.hertz.hertz_be.domain.user.responsecode.UserResponseCode;
+import com.hertz.hertz_be.global.auth.token.JwtTokenProvider;
+import com.hertz.hertz_be.global.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service("userServiceV3")
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserOauthRepository userOauthRepository;
+    private final OAuthRedisRepository oauthRedisRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Value("${max.age.seconds}")
+    private long maxAgeSeconds;
+
+    public UserInfoResponseDto createUser(UserInfoRequestDto userInfoRequestDto) {
+        String redisValue = oauthRedisRepository.get(userInfoRequestDto.getProviderId());
+        if (redisValue == null) {
+            throw new BusinessException(
+                    AuthResponseCode.REFRESH_TOKEN_INVALID.getCode(),
+                    AuthResponseCode.REFRESH_TOKEN_INVALID.getHttpStatus(),
+                    AuthResponseCode.REFRESH_TOKEN_INVALID.getMessage());
+        }
+
+        if (userOauthRepository.existsByProviderIdAndProvider(userInfoRequestDto.getProviderId(), userInfoRequestDto.getProvider())) {
+            throw new BusinessException(
+                    UserResponseCode.DUPLICATE_USER.getCode(),
+                    UserResponseCode.DUPLICATE_USER.getHttpStatus(),
+                    UserResponseCode.DUPLICATE_USER.getMessage());
+        }
+
+        int invitationCode = userInfoRequestDto.getInvitationCode();
+        if (invitationCode != 2502 && invitationCode != 6739) {
+            throw new BusinessException(
+                    UserResponseCode.WRONG_INVITATION_CODE.getCode(),
+                    UserResponseCode.WRONG_INVITATION_CODE.getHttpStatus(),
+                    UserResponseCode.WRONG_INVITATION_CODE.getMessage());
+        }
+
+        String refreshTokenValue = redisValue.split(",")[0];
+        LocalDateTime refreshTokenExpiredAt = LocalDateTime.parse(redisValue.split(",")[1]);
+
+        long secondsUntilExpiry = Duration.between(LocalDateTime.now(), refreshTokenExpiredAt).getSeconds();
+        int maxAge = (int) Math.max(0, secondsUntilExpiry);
+
+        // Todo. FE 개발용 테스트 로직 (추후 삭제 필요)
+        if(userInfoRequestDto.isTest()) {
+            Long fakeUserId = -1L;
+
+            return UserInfoResponseDto.builder()
+                    .userId(fakeUserId)
+                    .accessToken(jwtTokenProvider.createAccessToken(fakeUserId))
+                    .refreshToken(refreshTokenValue)
+                    .refreshSecondsUntilExpiry(maxAge)
+                    .build();
+        }
+
+        String userDomain;
+        if (invitationCode == 2502) {
+            userDomain = "@kakaotech.com";
+        } else {
+            userDomain = "@outside.com";
+        }
+
+        User user = User.builder()
+                .ageGroup(userInfoRequestDto.getAgeGroup())
+                .profileImageUrl(userInfoRequestDto.getProfileImage())
+                .nickname(userInfoRequestDto.getNickname())
+                .email(userInfoRequestDto.getProviderId() + userDomain) //
+                .gender(userInfoRequestDto.getGender())
+                .oneLineIntroduction(userInfoRequestDto.getOneLineIntroduction())
+                .isCoupleAllowed(userInfoRequestDto.isCoupleAllowed())
+                .isFriendAllowed(userInfoRequestDto.isFriendAllowed())
+                .build();
+
+        UserOauth userOauth = UserOauth.builder()
+                .provider(userInfoRequestDto.getProvider())
+                .providerId(userInfoRequestDto.getProviderId())
+                .refreshToken(refreshTokenValue)
+                .refreshTokenExpiresAt(refreshTokenExpiredAt)
+                .user(user)
+                .build();
+
+        user.setUserOauth(userOauth);
+
+        User savedUser = userRepository.save(user);
+
+        String refreshToken = jwtTokenProvider.createRefreshToken(user.getId());
+        refreshTokenRepository.saveRefreshToken(user.getId(), refreshToken, maxAgeSeconds);
+
+        return UserInfoResponseDto.builder()
+                .userId(savedUser.getId())
+                .accessToken(jwtTokenProvider.createAccessToken(savedUser.getId()))
+                .refreshToken(refreshToken)
+                .refreshSecondsUntilExpiry(maxAge)
+                .build();
+
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/auth/filter/JwtAuthenticationFilter.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/auth/filter/JwtAuthenticationFilter.java
@@ -29,6 +29,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             "/api/v1/auth/token",
             "/api/ping",
             "/api/v1/users",
+            "/api/v3/users",
             "/api/v1/nickname",
             "/swagger-ui.html",
             "/api/sse/subscribe"

--- a/hertz-be/src/main/resources/application.properties
+++ b/hertz-be/src/main/resources/application.properties
@@ -40,7 +40,7 @@ is.local=${IS_LOCAL:false}
 # ResponseCookie maxAgeSeconds
 max.age.seconds=${MAX_AGE_SECONDS}
 
-# HikariCP ??
+# HikariCP
 spring.datasource.hikari.maximum-pool-size=20
 spring.datasource.hikari.minimum-idle=5
 spring.datasource.hikari.idle-timeout=600000
@@ -48,7 +48,10 @@ spring.datasource.hikari.max-lifetime=1800000
 spring.datasource.hikari.connection-timeout=30000
 spring.datasource.hikari.leak-detection-threshold=20000
 
-
 # Socket IO
 socketio.server.hostname=${SOCKET_IO_HOSTNAME}
 socketio.server.port=${SOCKET_IO_PORT}
+
+# Invitation Code
+invitation.code.kakaotech=${KAKAOTECH_INVITATION_CODE}
+invitation.code.outside=${OUTSIDE_INVITATION_CODE}

--- a/hertz-be/src/test/java/com/hertz/hertz_be/domain/auth/controller/AuthControllerTest.java
+++ b/hertz-be/src/test/java/com/hertz/hertz_be/domain/auth/controller/AuthControllerTest.java
@@ -9,6 +9,7 @@ import com.hertz.hertz_be.domain.user.entity.User;
 import com.hertz.hertz_be.domain.user.repository.UserRepository;
 import com.hertz.hertz_be.domain.user.responsecode.UserResponseCode;
 import com.hertz.hertz_be.global.auth.token.JwtTokenProvider;
+import com.hertz.hertz_be.global.config.TestContainersConfig;
 import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -20,13 +21,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -37,7 +32,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @Testcontainers
 @ActiveProfiles("test")
-class AuthControllerTest {
+class AuthControllerTest extends TestContainersConfig {
     @MockBean
     private SocketIOServer socketIOServer;
 
@@ -52,26 +47,6 @@ class AuthControllerTest {
 
     private User user;
     private String refreshToken;
-
-    @Container
-    static MySQLContainer<?> mysqlContainer = new MySQLContainer<>("mysql:8.0.32")
-            .withDatabaseName("testdb")
-            .withUsername("testUser")
-            .withPassword("testPW");
-
-    @Container
-    static GenericContainer<?> redisContainer = new GenericContainer<>("redis:6.2")
-            .withExposedPorts(6379)
-            .waitingFor(Wait.forListeningPort());
-
-    @DynamicPropertySource
-    static void setProperties(DynamicPropertyRegistry registry) {
-        registry.add("spring.data.redis.host", redisContainer::getHost);
-        registry.add("spring.data.redis.port", () -> redisContainer.getMappedPort(6379));
-        registry.add("spring.datasource.url", mysqlContainer::getJdbcUrl);
-        registry.add("spring.datasource.username", mysqlContainer::getUsername);
-        registry.add("spring.datasource.password", mysqlContainer::getPassword);
-    }
 
     @BeforeEach
     void initializeUserAndRefreshToken() {

--- a/hertz-be/src/test/java/com/hertz/hertz_be/domain/user/service/v3/UserServiceTest.java
+++ b/hertz-be/src/test/java/com/hertz/hertz_be/domain/user/service/v3/UserServiceTest.java
@@ -1,0 +1,170 @@
+package com.hertz.hertz_be.domain.user.service.v3;
+
+import com.hertz.hertz_be.domain.auth.repository.OAuthRedisRepository;
+import com.hertz.hertz_be.domain.auth.repository.RefreshTokenRepository;
+import com.hertz.hertz_be.domain.auth.responsecode.AuthResponseCode;
+import com.hertz.hertz_be.domain.user.dto.request.v3.UserInfoRequestDto;
+import com.hertz.hertz_be.domain.user.dto.response.v3.UserInfoResponseDto;
+import com.hertz.hertz_be.domain.user.entity.User;
+import com.hertz.hertz_be.domain.user.entity.UserOauth;
+import com.hertz.hertz_be.domain.user.entity.enums.AgeGroup;
+import com.hertz.hertz_be.domain.user.entity.enums.Gender;
+import com.hertz.hertz_be.domain.user.repository.UserOauthRepository;
+import com.hertz.hertz_be.domain.user.repository.UserRepository;
+import com.hertz.hertz_be.domain.user.responsecode.UserResponseCode;
+import com.hertz.hertz_be.global.auth.token.JwtTokenProvider;
+import com.hertz.hertz_be.global.exception.BusinessException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserOauthRepository userOauthRepository;
+
+    @Mock
+    private OAuthRedisRepository oauthRedisRepository;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Value("${invitation.code.kakaotech}")
+    private int kakaotechInvitationCode;
+
+    @Value("${invitation.code.outside}")
+    private int outsideInvitationCode;
+
+    private final String providerId = "test-provider-id";
+    private final String provider = "kakao";
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(userService, "kakaotechInvitationCode", kakaotechInvitationCode);
+        ReflectionTestUtils.setField(userService, "outsideInvitationCode", outsideInvitationCode);
+        ReflectionTestUtils.setField(userService, "maxAgeSeconds", 1209600L);
+    }
+
+    @Test
+    @DisplayName("회원가입 - 성공")
+    void createUser_success() {
+        // given
+        UserInfoRequestDto requestDto = UserInfoRequestDto.builder()
+                .providerId(providerId)
+                .provider(provider)
+                .nickname("nickname")
+                .ageGroup(AgeGroup.AGE_20S)
+                .gender(Gender.MALE)
+                .oneLineIntroduction("hello")
+                .coupleAllowed(true)
+                .friendAllowed(false)
+                .invitationCode(kakaotechInvitationCode)
+                .build();
+
+        String redisValue = "refresh-token,2999-12-31T00:00:00";
+        when(oauthRedisRepository.get(providerId)).thenReturn(redisValue);
+        when(userOauthRepository.existsByProviderIdAndProvider(providerId, provider)).thenReturn(false);
+
+        User mockUser = User.builder().id(1L).build();
+        when(userRepository.save(any(User.class))).thenReturn(mockUser);
+
+        when(jwtTokenProvider.createRefreshToken(mockUser.getId())).thenReturn("new-refresh-token");
+        when(jwtTokenProvider.createAccessToken(mockUser.getId())).thenReturn("new-access-token");
+
+        // when
+        UserInfoResponseDto result = userService.createUser(requestDto);
+
+        // then
+        assertNotNull(result);
+        assertEquals(1L, result.getUserId());
+        assertEquals("new-access-token", result.getAccessToken());
+        assertEquals("new-refresh-token", result.getRefreshToken());
+
+        verify(oauthRedisRepository).get(providerId);
+        verify(userOauthRepository).existsByProviderIdAndProvider(providerId, provider);
+        verify(userRepository).save(any(User.class));
+        verify(refreshTokenRepository).saveRefreshToken(eq(1L), eq("new-refresh-token"), eq(1209600L));
+    }
+
+    @Test
+    @DisplayName("회원가입 - OAuth Redis 값 없음")
+    void createUser_shouldThrowBusinessException_whenRedisValueIsNull() {
+        // given
+        UserInfoRequestDto requestDto = UserInfoRequestDto.builder()
+                .providerId(providerId)
+                .provider(provider)
+                .invitationCode(kakaotechInvitationCode)
+                .build();
+
+        when(oauthRedisRepository.get(providerId)).thenReturn(null);
+
+        // when & then
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            userService.createUser(requestDto);
+        });
+
+        assertEquals(AuthResponseCode.REFRESH_TOKEN_INVALID.getCode(), exception.getCode());
+    }
+
+    @Test
+    @DisplayName("회원가입 - 중복 유저")
+    void createUser_shouldThrowBusinessException_whenDuplicateUser() {
+        // given
+        UserInfoRequestDto requestDto = UserInfoRequestDto.builder()
+                .providerId(providerId)
+                .provider(provider)
+                .invitationCode(kakaotechInvitationCode)
+                .build();
+
+        when(oauthRedisRepository.get(providerId)).thenReturn("token,2999-12-31T00:00:00");
+        when(userOauthRepository.existsByProviderIdAndProvider(providerId, provider)).thenReturn(true);
+
+        // when & then
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            userService.createUser(requestDto);
+        });
+
+        assertEquals(UserResponseCode.DUPLICATE_USER.getCode(), exception.getCode());
+    }
+
+    @Test
+    @DisplayName("회원가입 - 잘못된 초대코드")
+    void createUser_shouldThrowBusinessException_whenWrongInvitationCode() {
+        // given
+        UserInfoRequestDto requestDto = UserInfoRequestDto.builder()
+                .providerId(providerId)
+                .provider(provider)
+                .invitationCode(9999)
+                .build();
+
+        when(oauthRedisRepository.get(providerId)).thenReturn("token,2999-12-31T00:00:00");
+        when(userOauthRepository.existsByProviderIdAndProvider(providerId, provider)).thenReturn(false);
+
+        // when & then
+        BusinessException exception = assertThrows(BusinessException.class, () -> {
+            userService.createUser(requestDto);
+        });
+
+        assertEquals(UserResponseCode.WRONG_INVITATION_CODE.getCode(), exception.getCode());
+    }
+}

--- a/hertz-be/src/test/java/com/hertz/hertz_be/global/config/TestContainersConfig.java
+++ b/hertz-be/src/test/java/com/hertz/hertz_be/global/config/TestContainersConfig.java
@@ -1,0 +1,33 @@
+package com.hertz.hertz_be.global.config;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+
+@Testcontainers
+public abstract class TestContainersConfig {
+
+    @Container
+    static final MySQLContainer<?> mysqlContainer = new MySQLContainer<>("mysql:8.0.32")
+            .withDatabaseName("testdb")
+            .withUsername("testUser")
+            .withPassword("testPW");
+
+    @Container
+    static final GenericContainer<?> redisContainer = new GenericContainer<>("redis:6.2")
+            .withExposedPorts(6379)
+            .waitingFor(Wait.forListeningPort());
+
+    @DynamicPropertySource
+    static void setProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mysqlContainer::getJdbcUrl);
+        registry.add("spring.datasource.username", mysqlContainer::getUsername);
+        registry.add("spring.datasource.password", mysqlContainer::getPassword);
+        registry.add("spring.data.redis.host", redisContainer::getHost);
+        registry.add("spring.data.redis.port", () -> redisContainer.getMappedPort(6379));
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- #306 

## ✏️ 변경 사항
- V3 버전 개인 정보 등록 API 신규 구현
- Request DTO에 `카테고리`, `인증코드` 필드 추가
- Service 로직에 `카테고리`, `인증코드` 처리 로직 추가
- User 도메인 Controller, Service, RequestDto 패키지 버전별로 분리 리팩토링
- V3 API 전용 예외 응답 추가
- JWT 필터에 V3 API URL 추가
- 초대 코드 환경 변수화 처리
- 불필요한 필드 삭제
- V3 API 단위 테스트 코드 추가
- TestContainers 설정 클래스 분리

## 📋 상세 설명
- V3 단계 요구사항에 맞게 개인 정보 등록 API가 `카테고리`와 `인증코드`를 함께 처리할 수 있도록 구현했습니다.
- 유지보수성을 위해 Controller, Service, DTO를 버전별로 패키지 분리하여 구조를 개선했습니다.
- 신규 예외 응답 처리 로직을 추가하여 클라이언트가 요청 오류 상황을 명확히 인지할 수 있게 했습니다.
- JWT 인증 흐름에 V3 URL을 반영하여 접근 제어를 강화했습니다.
- `application.properties`에서 초대 코드를 관리하도록 수정하여 설정 편의성을 높였습니다.
- 사용하지 않는 불필요한 필드를 제거하여 코드베이스를 정리했습니다.
- V3 API의 안정성을 검증하기 위해 단위 테스트를 작성했고, TestContainers 설정 클래스를 분리하여 테스트 환경을 개선했습니다.

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 없음

## 📎 참고 자료 (선택)
- 없음
