### PR TITLE
[#309] Feat: 시그널 보내기 & 채팅방 관련 데이터 반환시 응답데이터에 관계의 카테고리 필드 추가

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/OAuthController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/OAuthController.java
@@ -6,7 +6,7 @@ import com.hertz.hertz_be.domain.auth.dto.response.OAuthLoginResult;
 import com.hertz.hertz_be.domain.auth.dto.response.OAuthSignupResponseDto;
 import com.hertz.hertz_be.domain.auth.responsecode.OAuthResponseCode;
 import com.hertz.hertz_be.domain.auth.service.OAuthService;
-import com.hertz.hertz_be.domain.channel.service.ChannelService;
+import com.hertz.hertz_be.domain.channel.service.v1.ChannelService;
 import com.hertz.hertz_be.global.common.ResponseDto;
 import com.hertz.hertz_be.global.util.AuthUtil;
 import io.swagger.v3.oas.annotations.Operation;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/v1/ChannelController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/v1/ChannelController.java
@@ -1,16 +1,12 @@
-package com.hertz.hertz_be.domain.channel.controller;
+package com.hertz.hertz_be.domain.channel.controller.v1;
 
-import com.hertz.hertz_be.domain.channel.dto.request.SendSignalRequestDto;
-import com.hertz.hertz_be.domain.channel.dto.request.SignalMatchingRequestDto;
-import com.hertz.hertz_be.domain.channel.dto.response.ChannelListResponseDto;
-import com.hertz.hertz_be.domain.channel.dto.response.ChannelRoomResponseDto;
-import com.hertz.hertz_be.domain.channel.dto.response.SendSignalResponseDto;
-import com.hertz.hertz_be.domain.channel.dto.response.TuningResponseDto;
-import com.hertz.hertz_be.domain.channel.entity.enums.MatchingStatus;
+import com.hertz.hertz_be.domain.channel.dto.request.v1.SendSignalRequestDto;
+import com.hertz.hertz_be.domain.channel.dto.response.v1.ChannelListResponseDto;
+import com.hertz.hertz_be.domain.channel.dto.response.v1.ChannelRoomResponseDto;
+import com.hertz.hertz_be.domain.channel.dto.response.v1.SendSignalResponseDto;
+import com.hertz.hertz_be.domain.channel.dto.response.v1.TuningResponseDto;
 import com.hertz.hertz_be.domain.channel.responsecode.ChannelResponseCode;
-import com.hertz.hertz_be.domain.channel.service.ChannelService;
-import com.hertz.hertz_be.domain.user.responsecode.UserResponseCode;
-import com.hertz.hertz_be.global.common.NewResponseCode;
+import com.hertz.hertz_be.domain.channel.service.v1.ChannelService;
 import com.hertz.hertz_be.global.common.ResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -22,16 +18,16 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
-@RestController
-@RequestMapping("/api")
+@RestController("channelControllerV1")
+@RequestMapping("/api/v1")
 @RequiredArgsConstructor
 @SecurityRequirement(name = "JWT")
-@Tag(name = "튜닝/채널 관련 API")
+@Tag(name = "튜닝/채널 관련 v1 API")
 public class ChannelController {
 
     private final ChannelService channelService;
 
-    @PostMapping("/v1/tuning/signal")
+    @PostMapping("/tuning/signal")
     @Operation(summary = "시그널 보내기 API")
     public ResponseEntity<ResponseDto<SendSignalResponseDto>> sendSignal(@RequestBody @Valid SendSignalRequestDto requestDTO,
                                                                          @AuthenticationPrincipal Long userId) {
@@ -42,7 +38,7 @@ public class ChannelController {
 
     }
 
-    @GetMapping("/v1/tuning")
+    @GetMapping("/tuning")
     @Operation(summary = "튜닝된 상대 반환 API")
     public ResponseEntity<ResponseDto<TuningResponseDto>> getTunedUser(@AuthenticationPrincipal Long userId) {
         TuningResponseDto response = channelService.getTunedUser(userId);
@@ -54,7 +50,7 @@ public class ChannelController {
         );
     }
 
-    @GetMapping("/v1/channel")
+    @GetMapping("/channel")
     @Operation(summary = "개인 채널보관함 목록 반환 API")
     public ResponseEntity<ResponseDto<ChannelListResponseDto>> getPersonalSignalRoomList(@AuthenticationPrincipal Long userId,
                                                                                          @RequestParam(defaultValue = "0") int page,
@@ -68,7 +64,7 @@ public class ChannelController {
         return ResponseEntity.ok(new ResponseDto<>(ChannelResponseCode.CHANNEL_ROOM_LIST_FETCHED.getCode(), ChannelResponseCode.CHANNEL_ROOM_LIST_FETCHED.getMessage(), response));
     }
 
-    @GetMapping("/v1/channel-rooms/{channelRoomId}")
+    @GetMapping("/channel-rooms/{channelRoomId}")
     @Operation(summary = "특정 채널방 반환 API")
     public ResponseEntity<ResponseDto<ChannelRoomResponseDto>> getChannelRoomMessages(@PathVariable Long channelRoomId,
                                                                                       @AuthenticationPrincipal Long userId,
@@ -79,7 +75,7 @@ public class ChannelController {
         return ResponseEntity.ok(new ResponseDto<>(ChannelResponseCode.CHANNEL_ROOM_SUCCESS.getCode(), ChannelResponseCode.CHANNEL_ROOM_SUCCESS.getMessage(), response));
     }
 
-    @PostMapping("/v1/channel-rooms/{channelRoomId}/messages")
+    @PostMapping("/channel-rooms/{channelRoomId}/messages")
     @Operation(summary = "채널방 메세지 전송 API")
     public ResponseEntity<ResponseDto<ChannelRoomResponseDto>> sendChannelMessage(@PathVariable Long channelRoomId,
                                                                                   @AuthenticationPrincipal Long userId,
@@ -90,59 +86,5 @@ public class ChannelController {
                 .status(HttpStatus.CREATED)
                 .body(new ResponseDto<>(ChannelResponseCode.MESSAGE_CREATED.getCode(), ChannelResponseCode.MESSAGE_CREATED.getMessage(), null)
         );
-    }
-
-
-    @PostMapping("/v2/matching/acceptances")
-    @Operation(summary = "채널방 매칭 수락 API")
-    public ResponseEntity<ResponseDto<Void>> channelMatchingAccept(
-            @AuthenticationPrincipal Long userId,
-            @RequestBody SignalMatchingRequestDto response) {
-
-        String matchingResult = channelService.channelMatchingStatusUpdate(userId, response, MatchingStatus.MATCHED);
-
-        if (ChannelResponseCode.MATCH_FAILED.getCode().equals(matchingResult)) {
-            return ResponseEntity
-                    .status(HttpStatus.CONFLICT)
-                    .body(new ResponseDto<>(ChannelResponseCode.MATCH_FAILED.getCode(), ChannelResponseCode.MATCH_FAILED.getMessage(), null));
-        } else if (ChannelResponseCode.MATCH_SUCCESS.getCode().equals(matchingResult)) {
-            return ResponseEntity
-                    .status(HttpStatus.OK)
-                    .body(new ResponseDto<>(ChannelResponseCode.MATCH_SUCCESS.getCode(), ChannelResponseCode.MATCH_SUCCESS.getMessage(), null));
-        } else if (ChannelResponseCode.MATCH_PENDING.getCode().equals(matchingResult)) {
-            return ResponseEntity
-                    .status(HttpStatus.ACCEPTED)
-                    .body(new ResponseDto<>(ChannelResponseCode.MATCH_PENDING.getCode(), ChannelResponseCode.MATCH_PENDING.getMessage(), null));
-        } else if (UserResponseCode.USER_DEACTIVATED.getCode().equals(matchingResult)) {
-            return ResponseEntity
-                    .status(HttpStatus.GONE)
-                    .body(new ResponseDto<>(UserResponseCode.USER_DEACTIVATED.getCode(), UserResponseCode.USER_DEACTIVATED.getMessage(), null));
-        } else {
-            return ResponseEntity
-                    .status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(new ResponseDto<>(NewResponseCode.INTERNAL_SERVER_ERROR.getCode(), NewResponseCode.INTERNAL_SERVER_ERROR.getMessage(), null));
-        }
-    }
-
-
-    @PostMapping("/v2/matching/rejections")
-    @Operation(summary = "채널방 매칭 거절 API")
-    public ResponseEntity<ResponseDto<ChannelRoomResponseDto>> channelMatchingReject(@AuthenticationPrincipal Long userId,
-                                                                                     @RequestBody SignalMatchingRequestDto response) {
-
-        return ResponseEntity
-                    .status(HttpStatus.OK)
-                    .body(new ResponseDto<>(
-                            channelService.channelMatchingStatusUpdate(userId, response, MatchingStatus.UNMATCHED)
-                            , ChannelResponseCode.MATCH_REJECTION_SUCCESS.getMessage()
-                            , null));
-    }
-
-    @DeleteMapping("/v2/channel-rooms/{channelRoomId}")
-    @Operation(summary = "채널방 나가기 API")
-    public ResponseEntity<ResponseDto<Void>> leaveChannelRoom(@PathVariable Long channelRoomId,
-                                                              @AuthenticationPrincipal Long userId) {
-        channelService.leaveChannelRoom(channelRoomId, userId);
-        return ResponseEntity.ok(new ResponseDto<>(ChannelResponseCode.CHANNEL_ROOM_EXIT_SUCCESS.getCode(), ChannelResponseCode.CHANNEL_ROOM_EXIT_SUCCESS.getMessage(), null));
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/v2/ChannelController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/v2/ChannelController.java
@@ -1,0 +1,81 @@
+package com.hertz.hertz_be.domain.channel.controller.v2;
+
+import com.hertz.hertz_be.domain.channel.dto.request.v2.SignalMatchingRequestDto;
+import com.hertz.hertz_be.domain.channel.dto.response.v1.ChannelRoomResponseDto;
+import com.hertz.hertz_be.domain.channel.entity.enums.MatchingStatus;
+import com.hertz.hertz_be.domain.channel.responsecode.ChannelResponseCode;
+import com.hertz.hertz_be.domain.channel.service.v2.ChannelService;
+import com.hertz.hertz_be.domain.user.responsecode.UserResponseCode;
+import com.hertz.hertz_be.global.common.NewResponseCode;
+import com.hertz.hertz_be.global.common.ResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController("channelControllerV2")
+@RequestMapping("/api/v2")
+@RequiredArgsConstructor
+@SecurityRequirement(name = "JWT")
+@Tag(name = "튜닝/채널 관련 v2 API")
+public class ChannelController {
+
+    private final ChannelService channelService;
+
+    @PostMapping("/matching/acceptances")
+    @Operation(summary = "채널방 매칭 수락 API")
+    public ResponseEntity<ResponseDto<Void>> channelMatchingAccept(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody SignalMatchingRequestDto response) {
+
+        String matchingResult = channelService.channelMatchingStatusUpdate(userId, response, MatchingStatus.MATCHED);
+
+        if (ChannelResponseCode.MATCH_FAILED.getCode().equals(matchingResult)) {
+            return ResponseEntity
+                    .status(HttpStatus.CONFLICT)
+                    .body(new ResponseDto<>(ChannelResponseCode.MATCH_FAILED.getCode(), ChannelResponseCode.MATCH_FAILED.getMessage(), null));
+        } else if (ChannelResponseCode.MATCH_SUCCESS.getCode().equals(matchingResult)) {
+            return ResponseEntity
+                    .status(HttpStatus.OK)
+                    .body(new ResponseDto<>(ChannelResponseCode.MATCH_SUCCESS.getCode(), ChannelResponseCode.MATCH_SUCCESS.getMessage(), null));
+        } else if (ChannelResponseCode.MATCH_PENDING.getCode().equals(matchingResult)) {
+            return ResponseEntity
+                    .status(HttpStatus.ACCEPTED)
+                    .body(new ResponseDto<>(ChannelResponseCode.MATCH_PENDING.getCode(), ChannelResponseCode.MATCH_PENDING.getMessage(), null));
+        } else if (UserResponseCode.USER_DEACTIVATED.getCode().equals(matchingResult)) {
+            return ResponseEntity
+                    .status(HttpStatus.GONE)
+                    .body(new ResponseDto<>(UserResponseCode.USER_DEACTIVATED.getCode(), UserResponseCode.USER_DEACTIVATED.getMessage(), null));
+        } else {
+            return ResponseEntity
+                    .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new ResponseDto<>(NewResponseCode.INTERNAL_SERVER_ERROR.getCode(), NewResponseCode.INTERNAL_SERVER_ERROR.getMessage(), null));
+        }
+    }
+
+
+    @PostMapping("/matching/rejections")
+    @Operation(summary = "채널방 매칭 거절 API")
+    public ResponseEntity<ResponseDto<ChannelRoomResponseDto>> channelMatchingReject(@AuthenticationPrincipal Long userId,
+                                                                                     @RequestBody SignalMatchingRequestDto response) {
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(new ResponseDto<>(
+                        channelService.channelMatchingStatusUpdate(userId, response, MatchingStatus.UNMATCHED)
+                        , ChannelResponseCode.MATCH_REJECTION_SUCCESS.getMessage()
+                        , null));
+    }
+
+    @DeleteMapping("/channel-rooms/{channelRoomId}")
+    @Operation(summary = "채널방 나가기 API")
+    public ResponseEntity<ResponseDto<Void>> leaveChannelRoom(@PathVariable Long channelRoomId,
+                                                              @AuthenticationPrincipal Long userId) {
+        channelService.leaveChannelRoom(channelRoomId, userId);
+        return ResponseEntity.ok(new ResponseDto<>(ChannelResponseCode.CHANNEL_ROOM_EXIT_SUCCESS.getCode(), ChannelResponseCode.CHANNEL_ROOM_EXIT_SUCCESS.getMessage(), null));
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/v3/ChannelController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/v3/ChannelController.java
@@ -1,0 +1,15 @@
+package com.hertz.hertz_be.domain.channel.controller.v3;
+
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController("channelControllerV3")
+@RequestMapping("/api/v3")
+@RequiredArgsConstructor
+@SecurityRequirement(name = "JWT")
+@Tag(name = "튜닝/채널 관련 v3 API")
+public class ChannelController {
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/v3/ChannelController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/v3/ChannelController.java
@@ -1,5 +1,7 @@
 package com.hertz.hertz_be.domain.channel.controller.v3;
 
+import com.hertz.hertz_be.domain.channel.dto.request.v3.SendSignalRequestDto;
+import com.hertz.hertz_be.domain.channel.dto.response.v3.SendSignalResponseDto;
 import com.hertz.hertz_be.domain.channel.dto.response.v3.ChannelListResponseDto;
 import com.hertz.hertz_be.domain.channel.dto.response.v3.ChannelRoomResponseDto;
 import com.hertz.hertz_be.domain.channel.responsecode.ChannelResponseCode;
@@ -8,6 +10,7 @@ import com.hertz.hertz_be.global.common.ResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -45,5 +48,16 @@ public class ChannelController {
 
         ChannelRoomResponseDto response = channelService.getChannelRoom(channelRoomId, userId, page, size);
         return ResponseEntity.ok(new ResponseDto<>(ChannelResponseCode.CHANNEL_ROOM_SUCCESS.getCode(), ChannelResponseCode.CHANNEL_ROOM_SUCCESS.getMessage(), response));
+    }
+
+    @PostMapping("/tuning/signal")
+    @Operation(summary = "시그널 보내기 API")
+    public ResponseEntity<ResponseDto<SendSignalResponseDto>> sendSignal(@RequestBody @Valid SendSignalRequestDto requestDTO,
+                                                                         @AuthenticationPrincipal Long userId) {
+        SendSignalResponseDto response = channelService.sendSignal(userId, requestDTO);
+        return ResponseEntity.status(201).body(
+                new ResponseDto<>(ChannelResponseCode.SIGNAL_ROOM_CREATED.getCode(), ChannelResponseCode.SIGNAL_ROOM_CREATED.getMessage(), response)
+        );
+
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/v3/ChannelController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/v3/ChannelController.java
@@ -1,10 +1,17 @@
 package com.hertz.hertz_be.domain.channel.controller.v3;
 
+import com.hertz.hertz_be.domain.channel.dto.response.v3.ChannelListResponseDto;
+import com.hertz.hertz_be.domain.channel.dto.response.v3.ChannelRoomResponseDto;
+import com.hertz.hertz_be.domain.channel.responsecode.ChannelResponseCode;
+import com.hertz.hertz_be.domain.channel.service.v3.ChannelService;
+import com.hertz.hertz_be.global.common.ResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController("channelControllerV3")
 @RequestMapping("/api/v3")
@@ -12,4 +19,31 @@ import org.springframework.web.bind.annotation.RestController;
 @SecurityRequirement(name = "JWT")
 @Tag(name = "튜닝/채널 관련 v3 API")
 public class ChannelController {
+
+    private final ChannelService channelService;
+
+    @GetMapping("/channel")
+    @Operation(summary = "개인 채널보관함 목록 반환 API")
+    public ResponseEntity<ResponseDto<ChannelListResponseDto>> getPersonalSignalRoomList(@AuthenticationPrincipal Long userId,
+                                                                                         @RequestParam(defaultValue = "0") int page,
+                                                                                         @RequestParam(defaultValue = "10") int size) {
+
+        ChannelListResponseDto response = channelService.getPersonalSignalRoomList(userId, page, size);
+
+        if (response == null) {
+            return ResponseEntity.ok(new ResponseDto<>(ChannelResponseCode.NO_CHANNEL_ROOM.getCode(), ChannelResponseCode.NO_CHANNEL_ROOM.getMessage(), null));
+        }
+        return ResponseEntity.ok(new ResponseDto<>(ChannelResponseCode.CHANNEL_ROOM_LIST_FETCHED.getCode(), ChannelResponseCode.CHANNEL_ROOM_LIST_FETCHED.getMessage(), response));
+    }
+
+    @GetMapping("/channel-rooms/{channelRoomId}")
+    @Operation(summary = "특정 채널방 반환 API")
+    public ResponseEntity<ResponseDto<ChannelRoomResponseDto>> getChannelRoomMessages(@PathVariable Long channelRoomId,
+                                                                                      @AuthenticationPrincipal Long userId,
+                                                                                      @RequestParam(defaultValue = "0") int page,
+                                                                                      @RequestParam(defaultValue = "20") int size) {
+
+        ChannelRoomResponseDto response = channelService.getChannelRoom(channelRoomId, userId, page, size);
+        return ResponseEntity.ok(new ResponseDto<>(ChannelResponseCode.CHANNEL_ROOM_SUCCESS.getCode(), ChannelResponseCode.CHANNEL_ROOM_SUCCESS.getMessage(), response));
+    }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/request/v1/SendSignalRequestDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/request/v1/SendSignalRequestDto.java
@@ -1,4 +1,4 @@
-package com.hertz.hertz_be.domain.channel.dto.request;
+package com.hertz.hertz_be.domain.channel.dto.request.v1;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/request/v1/SignalMessageRequestDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/request/v1/SignalMessageRequestDto.java
@@ -1,4 +1,4 @@
-package com.hertz.hertz_be.domain.channel.dto.request;
+package com.hertz.hertz_be.domain.channel.dto.request.v1;
 
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/request/v2/SignalMatchingRequestDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/request/v2/SignalMatchingRequestDto.java
@@ -1,4 +1,4 @@
-package com.hertz.hertz_be.domain.channel.dto.request;
+package com.hertz.hertz_be.domain.channel.dto.request.v2;
 
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/request/v3/SendSignalRequestDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/request/v3/SendSignalRequestDto.java
@@ -1,0 +1,19 @@
+package com.hertz.hertz_be.domain.channel.dto.request.v3;
+
+import com.hertz.hertz_be.domain.channel.entity.enums.Category;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class SendSignalRequestDto {
+
+    @NotNull
+    private Long receiverUserId;
+
+    @NotBlank
+    private String message;
+
+    @NotNull
+    private Category category;
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/v1/ChannelListResponseDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/v1/ChannelListResponseDto.java
@@ -1,4 +1,4 @@
-package com.hertz.hertz_be.domain.channel.dto.response;
+package com.hertz.hertz_be.domain.channel.dto.response.v1;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/v1/ChannelRoomResponseDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/v1/ChannelRoomResponseDto.java
@@ -1,4 +1,4 @@
-package com.hertz.hertz_be.domain.channel.dto.response;
+package com.hertz.hertz_be.domain.channel.dto.response.v1;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.hertz.hertz_be.domain.channel.entity.SignalMessage;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/v1/ChannelSummaryDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/v1/ChannelSummaryDto.java
@@ -1,4 +1,4 @@
-package com.hertz.hertz_be.domain.channel.dto.response;
+package com.hertz.hertz_be.domain.channel.dto.response.v1;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.hertz.hertz_be.domain.channel.repository.projection.ChannelRoomProjection;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/v1/DecryptedChannelSummaryConverter.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/v1/DecryptedChannelSummaryConverter.java
@@ -1,4 +1,4 @@
-package com.hertz.hertz_be.domain.channel.dto.response;
+package com.hertz.hertz_be.domain.channel.dto.response.v1;
 
 import com.hertz.hertz_be.global.util.AESUtil;
 import lombok.RequiredArgsConstructor;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/v1/SendSignalResponseDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/v1/SendSignalResponseDto.java
@@ -1,3 +1,3 @@
-package com.hertz.hertz_be.domain.channel.dto.response;
+package com.hertz.hertz_be.domain.channel.dto.response.v1;
 
 public record SendSignalResponseDto (Long channelRoomId) {}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/v1/TuningResponseDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/v1/TuningResponseDto.java
@@ -1,4 +1,4 @@
-package com.hertz.hertz_be.domain.channel.dto.response;
+package com.hertz.hertz_be.domain.channel.dto.response.v1;
 
 import com.hertz.hertz_be.domain.user.entity.enums.Gender;
 import java.util.List;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/v3/ChannelListResponseDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/v3/ChannelListResponseDto.java
@@ -1,0 +1,17 @@
+package com.hertz.hertz_be.domain.channel.dto.response.v3;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ChannelListResponseDto {
+    private List<ChannelSummaryDto> list;
+    private int pageNumber;
+    private int pageSize;
+    @JsonProperty("isLast")
+    private boolean isLast;
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/v3/ChannelRoomResponseDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/v3/ChannelRoomResponseDto.java
@@ -1,0 +1,98 @@
+package com.hertz.hertz_be.domain.channel.dto.response.v3;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.hertz.hertz_be.domain.channel.entity.SignalMessage;
+import com.hertz.hertz_be.domain.user.entity.User;
+import com.hertz.hertz_be.global.util.AESUtil;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ChannelRoomResponseDto {
+
+    private Long channelRoomId;
+    private Long partnerId;
+    private String partnerProfileImage;
+    private String partnerNickname;
+    private String relationType;
+    private boolean hasPartnerExited;
+    private String category;
+    private com.hertz.hertz_be.domain.channel.dto.response.v3.ChannelRoomResponseDto.MessagePage messages;
+
+    public static com.hertz.hertz_be.domain.channel.dto.response.v3.ChannelRoomResponseDto of(Long roomId, User partner, String relationType,
+                                                                                              boolean hasPartnerExited,
+                                                                                              String category,
+                                                                                              List<com.hertz.hertz_be.domain.channel.dto.response.v3.ChannelRoomResponseDto.MessageDto> messages, Page<SignalMessage> page) {
+        return ChannelRoomResponseDto.builder()
+                .channelRoomId(roomId)
+                .partnerId(partner.getId())
+                .partnerProfileImage(partner.getProfileImageUrl())
+                .partnerNickname(partner.getNickname())
+                .relationType(relationType)
+                .hasPartnerExited(hasPartnerExited)
+                .category(category)
+                .messages(new com.hertz.hertz_be.domain.channel.dto.response.v3.ChannelRoomResponseDto.MessagePage(messages, page))
+                .build();
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class MessageDto {
+        private Long messageId;
+        private Long messageSenderId;
+        private String messageContents;
+        private String messageSendAt;
+
+        public static com.hertz.hertz_be.domain.channel.dto.response.v3.ChannelRoomResponseDto.MessageDto fromProjectionWithDecrypt(SignalMessage msg, AESUtil aesUtil) {
+            String decryptedMessage;
+            try {
+                decryptedMessage = aesUtil.decrypt(msg.getMessage());
+            } catch (Exception e) {
+                decryptedMessage = "메세지를 표시할 수 없습니다.";
+            }
+
+            return new com.hertz.hertz_be.domain.channel.dto.response.v3.ChannelRoomResponseDto.MessageDto(
+                    msg.getId(),
+                    msg.getSenderUser().getId(),
+                    decryptedMessage,
+                    msg.getSendAt().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+            );
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class MessagePage {
+        private List<com.hertz.hertz_be.domain.channel.dto.response.v3.ChannelRoomResponseDto.MessageDto> list;
+        private com.hertz.hertz_be.domain.channel.dto.response.v3.ChannelRoomResponseDto.PageableInfo pageable;
+
+        public MessagePage(List<com.hertz.hertz_be.domain.channel.dto.response.v3.ChannelRoomResponseDto.MessageDto> list, Page<?> page) {
+            this.list = list;
+            this.pageable = new com.hertz.hertz_be.domain.channel.dto.response.v3.ChannelRoomResponseDto.PageableInfo(page);
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class PageableInfo {
+        private int pageNumber;
+        private int pageSize;
+        @JsonProperty("isLast")
+        private boolean isLast;
+
+        public PageableInfo(Page<?> page) {
+            this.pageNumber = page.getNumber();
+            this.pageSize = page.getSize();
+            this.isLast = page.isLast();
+        }
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/v3/ChannelSummaryDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/v3/ChannelSummaryDto.java
@@ -1,0 +1,43 @@
+package com.hertz.hertz_be.domain.channel.dto.response.v3;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.hertz.hertz_be.domain.channel.repository.projection.ChannelRoomProjection;
+import com.hertz.hertz_be.global.util.AESUtil;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class ChannelSummaryDto {
+    private Long channelRoomId;
+    private String partnerProfileImage;
+    private String partnerNickname;
+    private String lastMessage;
+    private LocalDateTime lastMessageTime;
+    @JsonProperty("isRead")
+    private boolean isRead;
+    private String category;
+    private String relationType;
+
+    public static com.hertz.hertz_be.domain.channel.dto.response.v3.ChannelSummaryDto fromProjectionWithDecrypt(ChannelRoomProjection p, AESUtil aesUtil) {
+        String decryptedMessage;
+        try {
+            decryptedMessage = aesUtil.decrypt(p.getLastMessage());
+        } catch (Exception e) {
+            decryptedMessage = "메세지를 표시할 수 없습니다.";
+        }
+
+        return new ChannelSummaryDto(
+                p.getChannelRoomId(),
+                p.getPartnerProfileImage(),
+                p.getPartnerNickname(),
+                decryptedMessage,
+                p.getLastMessageTime(),
+                p.getIsRead(),
+                p.getCategory(),
+                p.getRelationType()
+        );
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/v3/SendSignalResponseDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/v3/SendSignalResponseDto.java
@@ -1,0 +1,3 @@
+package com.hertz.hertz_be.domain.channel.dto.response.v3;
+
+public record SendSignalResponseDto (Long channelRoomId) {}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/SignalRoomRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/SignalRoomRepository.java
@@ -30,6 +30,7 @@ public interface SignalRoomRepository extends JpaRepository<SignalRoom, Long> {
         sr.receiver_user_id AS receiverUserId,
         sr.sender_exited_at AS senderExitedAt,
         sr.receiver_exited_at AS receiverExitedAt,
+        sr.category AS category,
         CASE
             WHEN sm.sender_user_id = :userId THEN 'true'
             WHEN sm.sender_user_id != :userId AND sm.is_read = true THEN 'true'

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/projection/ChannelRoomProjection.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/projection/ChannelRoomProjection.java
@@ -14,4 +14,5 @@ public interface ChannelRoomProjection {
     LocalDateTime getReceiverExitedAt();
     Long getSenderUserId();
     Long getReceiverUserId();
+    String getCategory();
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v1/ChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v1/ChannelService.java
@@ -1,8 +1,9 @@
-package com.hertz.hertz_be.domain.channel.service;
+package com.hertz.hertz_be.domain.channel.service.v1;
 
 import com.corundumstudio.socketio.SocketIOServer;
-import com.hertz.hertz_be.domain.channel.dto.request.SignalMatchingRequestDto;
-import com.hertz.hertz_be.domain.channel.dto.response.*;
+import com.hertz.hertz_be.domain.channel.dto.response.v1.*;
+import com.hertz.hertz_be.domain.channel.service.AsyncChannelService;
+import com.hertz.hertz_be.domain.channel.service.SseChannelService;
 import com.hertz.hertz_be.domain.user.responsecode.UserResponseCode;
 import com.hertz.hertz_be.global.common.NewResponseCode;
 import com.hertz.hertz_be.global.exception.*;
@@ -10,7 +11,7 @@ import com.hertz.hertz_be.global.socketio.dto.SocketIoMessageResponse;
 import com.hertz.hertz_be.domain.channel.entity.*;
 import com.hertz.hertz_be.domain.channel.entity.enums.Category;
 import com.hertz.hertz_be.domain.channel.entity.enums.MatchingStatus;
-import com.hertz.hertz_be.domain.channel.dto.request.SendSignalRequestDto;
+import com.hertz.hertz_be.domain.channel.dto.request.v1.SendSignalRequestDto;
 import com.hertz.hertz_be.domain.channel.responsecode.*;
 import com.hertz.hertz_be.domain.channel.repository.*;
 import com.hertz.hertz_be.domain.channel.repository.projection.ChannelRoomProjection;
@@ -45,7 +46,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 @Slf4j
-@Service
+@Service("channelServiceV1")
 @RequiredArgsConstructor
 public class ChannelService {
 
@@ -58,7 +59,6 @@ public class ChannelService {
     private final UserInterestsRepository userInterestsRepository;
     private final SignalRoomRepository signalRoomRepository;
     private final SignalMessageRepository signalMessageRepository;
-    private final ChannelRoomRepository channelRoomRepository;
     private final InterestsService interestsService;
     private final AsyncChannelService asyncChannelService;
     private final WebClient webClient;
@@ -84,7 +84,6 @@ public class ChannelService {
         this.userInterestsRepository = userInterestsRepository;
         this.signalMessageRepository = signalMessageRepository;
         this.signalRoomRepository = signalRoomRepository;
-        this.channelRoomRepository = channelRoomRepository;
         this.interestsService = interestsService;
         this.asyncChannelService = asyncChannelService;
         this.aesUtil = aesUtil;
@@ -560,68 +559,5 @@ public class ChannelService {
                 asyncChannelService.sendNewMessageNotifyToPartner(signalMessage, partnerId, false);
             }
         });
-    }
-
-    @Transactional
-    public String channelMatchingStatusUpdate(Long userId, SignalMatchingRequestDto response, MatchingStatus matchingStatus) {
-        SignalRoom room = signalRoomRepository.findById(response.getChannelRoomId())
-                .orElseThrow(() -> new BusinessException(
-                        ChannelResponseCode.CHANNEL_NOT_FOUND.getCode(),
-                        ChannelResponseCode.CHANNEL_NOT_FOUND.getHttpStatus(),
-                        ChannelResponseCode.CHANNEL_NOT_FOUND.getMessage()
-                ));
-
-        int updatedSender = signalRoomRepository.updateSenderMatchingStatus(room.getId(), userId, matchingStatus);
-        int updatedReceiver = signalRoomRepository.updateReceiverMatchingStatus(room.getId(), userId, matchingStatus);
-
-        if (updatedSender == 0 && updatedReceiver == 0) {
-            throw new BusinessException(
-                    ChannelResponseCode.ALREADY_EXITED_CHANNEL_ROOM.getCode(),
-                    ChannelResponseCode.ALREADY_EXITED_CHANNEL_ROOM.getHttpStatus(),
-                    "사용자가 참여 중인 채팅방 아닙니다."
-            );
-        }
-
-        entityManager.flush();
-
-
-        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-            @Override
-            public void afterCommit() {
-                asyncChannelService.notifyMatchingResultToPartner(room, userId, matchingStatus);
-                asyncChannelService.createMatchingAlarm(room, userId);
-            }
-        });
-
-
-        /**
-         * 매칭 수락/거절 후 현재 관계 반환
-         */
-        if(matchingStatus == MatchingStatus.MATCHED) {
-            return signalRoomRepository.findMatchResultByUser(userId, room.getId());
-        } else {
-            return ChannelResponseCode.MATCH_REJECTION_SUCCESS.getCode();
-        }
-    }
-
-
-    @Transactional
-    public void leaveChannelRoom(Long roomId, Long userId) {
-        SignalRoom room = signalRoomRepository.findById(roomId)
-                .orElseThrow(() -> new BusinessException(
-                        ChannelResponseCode.CHANNEL_NOT_FOUND.getCode(),
-                        ChannelResponseCode.CHANNEL_NOT_FOUND.getHttpStatus(),
-                        ChannelResponseCode.CHANNEL_NOT_FOUND.getMessage()
-                ));
-
-        if (!userRepository.existsById(userId)) {
-            throw new BusinessException(
-                    UserResponseCode.USER_NOT_FOUND.getCode(),
-                    UserResponseCode.USER_NOT_FOUND.getHttpStatus(),
-                    "채팅방 나가기 요청한 사용자가 존재하지 않습니다."
-            );
-        }
-
-        room.leaveChannelRoom(userId);
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v2/ChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v2/ChannelService.java
@@ -1,0 +1,88 @@
+package com.hertz.hertz_be.domain.channel.service.v2;
+
+import com.hertz.hertz_be.domain.channel.dto.request.v2.SignalMatchingRequestDto;
+import com.hertz.hertz_be.domain.channel.entity.SignalRoom;
+import com.hertz.hertz_be.domain.channel.entity.enums.MatchingStatus;
+import com.hertz.hertz_be.domain.channel.repository.*;
+import com.hertz.hertz_be.domain.channel.responsecode.ChannelResponseCode;
+import com.hertz.hertz_be.domain.channel.service.AsyncChannelService;
+import com.hertz.hertz_be.domain.user.repository.UserRepository;
+import com.hertz.hertz_be.domain.user.responsecode.UserResponseCode;
+import com.hertz.hertz_be.global.exception.BusinessException;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@Slf4j
+@Service("channelServiceV2")
+@RequiredArgsConstructor
+public class ChannelService {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private final UserRepository userRepository;
+    private final SignalRoomRepository signalRoomRepository;
+    private final AsyncChannelService asyncChannelService;
+
+    @Transactional
+    public void leaveChannelRoom(Long roomId, Long userId) {
+        SignalRoom room = signalRoomRepository.findById(roomId)
+                .orElseThrow(() -> new BusinessException(
+                        ChannelResponseCode.CHANNEL_NOT_FOUND.getCode(),
+                        ChannelResponseCode.CHANNEL_NOT_FOUND.getHttpStatus(),
+                        ChannelResponseCode.CHANNEL_NOT_FOUND.getMessage()
+                ));
+
+        if (!userRepository.existsById(userId)) {
+            throw new BusinessException(
+                    UserResponseCode.USER_NOT_FOUND.getCode(),
+                    UserResponseCode.USER_NOT_FOUND.getHttpStatus(),
+                    "채팅방 나가기 요청한 사용자가 존재하지 않습니다."
+            );
+        }
+
+        room.leaveChannelRoom(userId);
+    }
+
+    @Transactional
+    public String channelMatchingStatusUpdate(Long userId, SignalMatchingRequestDto response, MatchingStatus matchingStatus) {
+        SignalRoom room = signalRoomRepository.findById(response.getChannelRoomId())
+                .orElseThrow(() -> new BusinessException(
+                        ChannelResponseCode.CHANNEL_NOT_FOUND.getCode(),
+                        ChannelResponseCode.CHANNEL_NOT_FOUND.getHttpStatus(),
+                        ChannelResponseCode.CHANNEL_NOT_FOUND.getMessage()
+                ));
+
+        int updatedSender = signalRoomRepository.updateSenderMatchingStatus(room.getId(), userId, matchingStatus);
+        int updatedReceiver = signalRoomRepository.updateReceiverMatchingStatus(room.getId(), userId, matchingStatus);
+
+        if (updatedSender == 0 && updatedReceiver == 0) {
+            throw new BusinessException(
+                    ChannelResponseCode.ALREADY_EXITED_CHANNEL_ROOM.getCode(),
+                    ChannelResponseCode.ALREADY_EXITED_CHANNEL_ROOM.getHttpStatus(),
+                    "사용자가 참여 중인 채팅방 아닙니다."
+            );
+        }
+
+        entityManager.flush();
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                asyncChannelService.notifyMatchingResultToPartner(room, userId, matchingStatus);
+                asyncChannelService.createMatchingAlarm(room, userId);
+            }
+        });
+
+        if(matchingStatus == MatchingStatus.MATCHED) {
+            return signalRoomRepository.findMatchResultByUser(userId, room.getId());
+        } else {
+            return ChannelResponseCode.MATCH_REJECTION_SUCCESS.getCode();
+        }
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v3/ChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v3/ChannelService.java
@@ -1,0 +1,11 @@
+package com.hertz.hertz_be.domain.channel.service.v3;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service("channelServiceV3")
+@RequiredArgsConstructor
+public class ChannelService {
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v3/ChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v3/ChannelService.java
@@ -1,11 +1,136 @@
 package com.hertz.hertz_be.domain.channel.service.v3;
 
+import com.hertz.hertz_be.domain.channel.dto.response.v3.ChannelListResponseDto;
+import com.hertz.hertz_be.domain.channel.dto.response.v3.ChannelRoomResponseDto;
+import com.hertz.hertz_be.domain.channel.dto.response.v3.ChannelSummaryDto;
+import com.hertz.hertz_be.domain.channel.entity.SignalMessage;
+import com.hertz.hertz_be.domain.channel.entity.SignalRoom;
+import com.hertz.hertz_be.domain.channel.repository.SignalMessageRepository;
+import com.hertz.hertz_be.domain.channel.repository.SignalRoomRepository;
+import com.hertz.hertz_be.domain.channel.repository.projection.ChannelRoomProjection;
+import com.hertz.hertz_be.domain.channel.repository.projection.RoomWithLastSenderProjection;
+import com.hertz.hertz_be.domain.channel.responsecode.ChannelResponseCode;
+import com.hertz.hertz_be.domain.channel.service.AsyncChannelService;
+import com.hertz.hertz_be.domain.user.entity.User;
+import com.hertz.hertz_be.domain.user.repository.UserRepository;
+import com.hertz.hertz_be.domain.user.responsecode.UserResponseCode;
+import com.hertz.hertz_be.global.exception.BusinessException;
+import com.hertz.hertz_be.global.util.AESUtil;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 
 @Slf4j
 @Service("channelServiceV3")
 @RequiredArgsConstructor
 public class ChannelService {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private final UserRepository userRepository;
+    private final SignalRoomRepository signalRoomRepository;
+    private final SignalMessageRepository signalMessageRepository;
+    private final AsyncChannelService asyncChannelService;
+    private final AESUtil aesUtil;
+
+    public ChannelListResponseDto getPersonalSignalRoomList(Long userId, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<ChannelRoomProjection> result = signalRoomRepository.findChannelRoomsWithPartnerAndLastMessage(userId, pageable);
+
+        if (result.isEmpty()) {
+            return null;
+        }
+
+        List<ChannelSummaryDto> list = result.getContent().stream()
+                .filter(p -> {
+                    boolean isSender = userId.equals(p.getSenderUserId());
+                    LocalDateTime exitedAt = isSender ? p.getSenderExitedAt() : p.getReceiverExitedAt();
+                    return exitedAt == null;
+                })
+                .map(p -> ChannelSummaryDto.fromProjectionWithDecrypt(p, aesUtil))
+                .toList();
+
+        return new ChannelListResponseDto(list, result.getNumber(), result.getSize(), result.isLast());
+    }
+
+    @Transactional
+    public ChannelRoomResponseDto getChannelRoom(Long roomId, Long userId, int page, int size) {
+        SignalRoom room = signalRoomRepository.findById(roomId)
+                .orElseThrow(() -> new BusinessException(
+                        ChannelResponseCode.CHANNEL_NOT_FOUND.getCode(),
+                        ChannelResponseCode.CHANNEL_NOT_FOUND.getHttpStatus(),
+                        ChannelResponseCode.CHANNEL_NOT_FOUND.getMessage()
+                ));
+
+        if (!room.isParticipant(userId)) {
+            throw new BusinessException(
+                    ChannelResponseCode.ALREADY_EXITED_CHANNEL_ROOM.getCode(),
+                    ChannelResponseCode.ALREADY_EXITED_CHANNEL_ROOM.getHttpStatus(),
+                    "사용자가 참여 중인 채팅방 아닙니다."
+            );
+        }
+
+        if (room.isUserExited(userId)) {
+            throw new BusinessException(
+                    ChannelResponseCode.ALREADY_EXITED_CHANNEL_ROOM.getCode(),
+                    ChannelResponseCode.ALREADY_EXITED_CHANNEL_ROOM.getHttpStatus(),
+                    ChannelResponseCode.ALREADY_EXITED_CHANNEL_ROOM.getMessage()
+            );
+        }
+
+        boolean isPartnerExited = room.isPartnerExited(userId);
+
+        Long partnerId = room.getPartnerUser(userId).getId();
+
+        User partner = userRepository.findByIdAndDeletedAtIsNull(partnerId)
+                .orElseThrow(() -> new BusinessException(
+                        UserResponseCode.USER_DEACTIVATED.getCode(),
+                        UserResponseCode.USER_DEACTIVATED.getHttpStatus(),
+                        UserResponseCode.USER_DEACTIVATED.getMessage()
+                ));
+
+        Optional<RoomWithLastSenderProjection> result = signalMessageRepository.findRoomsWithLastSender(roomId);
+
+        if(result.isPresent()){
+            RoomWithLastSenderProjection lastSender = result.get();
+            if (!Objects.equals(lastSender.getLastSenderId(), userId)) {
+                signalMessageRepository.markAllMessagesAsReadByRoomId(roomId);
+            }
+        }
+
+        asyncChannelService.notifyMatchingConvertedInChannelRoom(room, userId);
+
+        PageRequest pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "sendAt"));
+        Page<SignalMessage> messagePage = signalMessageRepository.findBySignalRoom_Id(roomId, pageable);
+
+        List<ChannelRoomResponseDto.MessageDto> messages = messagePage.getContent().stream()
+                .map(msg -> ChannelRoomResponseDto.MessageDto.fromProjectionWithDecrypt(msg, aesUtil))
+                .toList();
+
+        entityManager.flush();
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                asyncChannelService.updateNavbarMessageNotification(userId);
+            }
+        });
+
+        return ChannelRoomResponseDto.of(roomId, partner, room.getRelationType(), isPartnerExited, String.valueOf(room.getCategory()), messages, messagePage);
+    }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- #309 

## ✏️ 변경 사항
- `channel` 도메인 `controller`, `dto`, `service` 클래스 버전별로 분리 (`refactor`)
- 개인 채널보관함 목록 반환 API 응답 데이터 구조 수정 (`feat`)
- 특정 채널방 반환 API 응답 데이터 구조 수정 (`feat`)
- 시그널 보내기 API 요청 데이터에 `category` 필드 추가 (`feat`)

---

## 📋 상세 설명
- 3차 카테고리 기능 대응을 위해 **채팅방 관련 응답 데이터에 `category` 필드 추가**
  - 현재 채팅 중인 상대방과의 관계 카테고리를 프론트에서 식별 가능하도록 개선
- `channel` 도메인 구조를 버전별로 세분화하여 유지보수성과 확장성 향상
- 기존 채널보관함 및 특정 채널방 조회 API에서 Projection 및 DTO에 `category` 포함되도록 쿼리 및 매핑 로직 수정
- 시그널 전송 시 `category` 정보를 함께 전달하도록 요청 DTO 확장

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 없음

## 📎 참고 자료 (선택)
- 없음
