### PR TITLE
[#312] Feat: 시그널을 받고 싶지 않은 카테고리 수정 API 구현

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/service/AlarmService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/service/AlarmService.java
@@ -178,7 +178,7 @@ public class AlarmService {
         });
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public AlarmListResponseDto getAlarmList(int page, int size, Long userId) {
         PageRequest pageRequest = PageRequest.of(page, size);
         LocalDateTime thresholdDate = LocalDateTime.now().minusDays(30);

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/AuthController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/controller/AuthController.java
@@ -71,7 +71,7 @@ public class AuthController {
 
     @PostMapping("/test/login")
     @Operation(summary = "사용자 Id로 AT와 RT를 반환하는 API(테스트용)", description = "회원가입 안된 임의의 사용자의 Id도 사용 가능")
-    public ResponseEntity<?> login(@Valid @RequestBody TestLoginRequestDto request, HttpServletResponse response) {
+    public ResponseEntity<?> login(@RequestBody @Valid TestLoginRequestDto request, HttpServletResponse response) {
         Long userId = request.getUserId();
 
         String accessToken = jwtTokenProvider.createAccessToken(userId);

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/service/OAuthService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/auth/service/OAuthService.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.HttpClientErrorException;
 
 import java.time.Duration;
@@ -22,6 +23,7 @@ import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class OAuthService {
 
     private final KakaoOAuthClient kakaoOAuthClient;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/v1/ChannelController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/v1/ChannelController.java
@@ -79,7 +79,7 @@ public class ChannelController {
     @Operation(summary = "채널방 메세지 전송 API")
     public ResponseEntity<ResponseDto<ChannelRoomResponseDto>> sendChannelMessage(@PathVariable Long channelRoomId,
                                                                                   @AuthenticationPrincipal Long userId,
-                                                                                  @RequestBody SendSignalRequestDto response) {
+                                                                                  @RequestBody @Valid SendSignalRequestDto response) {
 
         channelService.sendChannelMessage(channelRoomId, userId, response);
         return ResponseEntity

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/v2/ChannelController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/v2/ChannelController.java
@@ -11,6 +11,7 @@ import com.hertz.hertz_be.global.common.ResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -30,7 +31,7 @@ public class ChannelController {
     @Operation(summary = "채널방 매칭 수락 API")
     public ResponseEntity<ResponseDto<Void>> channelMatchingAccept(
             @AuthenticationPrincipal Long userId,
-            @RequestBody SignalMatchingRequestDto response) {
+            @RequestBody @Valid SignalMatchingRequestDto response) {
 
         String matchingResult = channelService.channelMatchingStatusUpdate(userId, response, MatchingStatus.MATCHED);
 
@@ -61,7 +62,7 @@ public class ChannelController {
     @PostMapping("/matching/rejections")
     @Operation(summary = "채널방 매칭 거절 API")
     public ResponseEntity<ResponseDto<ChannelRoomResponseDto>> channelMatchingReject(@AuthenticationPrincipal Long userId,
-                                                                                     @RequestBody SignalMatchingRequestDto response) {
+                                                                                     @RequestBody @Valid SignalMatchingRequestDto response) {
 
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v1/ChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v1/ChannelService.java
@@ -416,6 +416,7 @@ public class ChannelService {
 
     }
 
+    @Transactional(readOnly = true)
     public ChannelListResponseDto getPersonalSignalRoomList(Long userId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         Page<ChannelRoomProjection> result = signalRoomRepository.findChannelRoomsWithPartnerAndLastMessage(userId, pageable);
@@ -436,7 +437,7 @@ public class ChannelService {
         return new ChannelListResponseDto(list, result.getNumber(), result.getSize(), result.isLast());
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public ChannelRoomResponseDto getChannelRoom(Long roomId, Long userId, int page, int size) {
         SignalRoom room = signalRoomRepository.findById(roomId)
                 .orElseThrow(() -> new BusinessException(

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v3/ChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v3/ChannelService.java
@@ -53,6 +53,7 @@ public class ChannelService {
     private final AsyncChannelService asyncChannelService;
     private final AESUtil aesUtil;
 
+    @Transactional(readOnly = true)
     public ChannelListResponseDto getPersonalSignalRoomList(Long userId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         Page<ChannelRoomProjection> result = signalRoomRepository.findChannelRoomsWithPartnerAndLastMessage(userId, pageable);
@@ -73,7 +74,7 @@ public class ChannelService {
         return new ChannelListResponseDto(list, result.getNumber(), result.getSize(), result.isLast());
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public ChannelRoomResponseDto getChannelRoom(Long roomId, Long userId, int page, int size) {
         SignalRoom room = signalRoomRepository.findById(roomId)
                 .orElseThrow(() -> new BusinessException(

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/interests/controller/InterestsController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/interests/controller/InterestsController.java
@@ -8,6 +8,7 @@ import com.hertz.hertz_be.global.common.ResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -35,7 +36,7 @@ public class InterestsController {
      */
     @PostMapping("/users/interests")
     @Operation(summary = "취향 등록 API")
-    public ResponseEntity<ResponseDto<UserInterestsResponseDto>> createUser(@RequestBody UserInterestsRequestDto userInterestsRequestDto,
+    public ResponseEntity<ResponseDto<UserInterestsResponseDto>> createUser(@RequestBody @Valid UserInterestsRequestDto userInterestsRequestDto,
                                                                             @AuthenticationPrincipal Long userId) throws Exception {
         interestsService.saveUserInterests(userInterestsRequestDto, userId);
 

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/v1/UserController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/v1/UserController.java
@@ -9,6 +9,7 @@ import com.hertz.hertz_be.global.util.AuthUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
@@ -36,7 +37,7 @@ public class UserController {
     @PostMapping("/v1/users")
     @Operation(summary = "개인정보 등록 API")
     public ResponseEntity<ResponseDto<Map<String, Object>>> createUser(
-            @RequestBody UserInfoRequestDto userInfoRequestDto,
+            @RequestBody @Valid UserInfoRequestDto userInfoRequestDto,
             HttpServletResponse response) {
 
         UserInfoResponseDto userInfoResponseDto = userService.createUser(userInfoRequestDto);

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/v3/UserController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/v3/UserController.java
@@ -1,5 +1,6 @@
 package com.hertz.hertz_be.domain.user.controller.v3;
 
+import com.hertz.hertz_be.domain.user.dto.request.v3.RejectCategoryChangeRequestDto;
 import com.hertz.hertz_be.domain.user.dto.request.v3.UserInfoRequestDto;
 import com.hertz.hertz_be.domain.user.dto.response.v3.UserInfoResponseDto;
 import com.hertz.hertz_be.domain.user.responsecode.UserResponseCode;
@@ -9,19 +10,18 @@ import com.hertz.hertz_be.global.util.AuthUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
 import java.util.Map;
 
 @RestController("userControllerV3")
-@RequestMapping("/api")
+@RequestMapping("/api/v3")
 @RequiredArgsConstructor
 @Tag(name = "사용자 관련 V3 API")
 public class UserController {
@@ -31,7 +31,7 @@ public class UserController {
 
     private final UserService userService;
 
-    @PostMapping("/v3/users")
+    @PostMapping("/users")
     @Operation(summary = "개인정보 등록 API")
     public ResponseEntity<ResponseDto<Map<String, Object>>> createUser(
             @RequestBody UserInfoRequestDto userInfoRequestDto,
@@ -54,6 +54,23 @@ public class UserController {
                         UserResponseCode.PROFILE_SAVED_SUCCESSFULLY.getCode(),
                         UserResponseCode.PROFILE_SAVED_SUCCESSFULLY.getMessage(),
                         data
+                )
+        );
+    }
+
+    @PatchMapping("/users/category")
+    @Operation(summary = "시그널 받고 싶지 않은 카테고리 수정 API")
+    public ResponseEntity<ResponseDto<Void>> changeRejectCategory(
+            @RequestBody @Valid RejectCategoryChangeRequestDto requestDto,
+            @AuthenticationPrincipal Long userId) {
+
+        userService.changeRejectCategory(userId, requestDto);
+
+        return  ResponseEntity.ok(
+                new ResponseDto<>(
+                        UserResponseCode.CATEGORY_UPDATED_SUCCESSFULLY.getCode(),
+                        UserResponseCode.CATEGORY_UPDATED_SUCCESSFULLY.getMessage(),
+                        null
                 )
         );
     }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/v3/UserController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/v3/UserController.java
@@ -34,7 +34,7 @@ public class UserController {
     @PostMapping("/users")
     @Operation(summary = "개인정보 등록 API")
     public ResponseEntity<ResponseDto<Map<String, Object>>> createUser(
-            @RequestBody UserInfoRequestDto userInfoRequestDto,
+            @RequestBody @Valid UserInfoRequestDto userInfoRequestDto,
             HttpServletResponse response) {
 
         UserInfoResponseDto userInfoResponseDto = userService.createUser(userInfoRequestDto);

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/request/v3/RejectCategoryChangeRequestDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/request/v3/RejectCategoryChangeRequestDto.java
@@ -1,0 +1,10 @@
+package com.hertz.hertz_be.domain.user.dto.request.v3;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class RejectCategoryChangeRequestDto {
+    @NotNull
+    private boolean flag;
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/request/v3/RejectCategoryChangeRequestDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/request/v3/RejectCategoryChangeRequestDto.java
@@ -1,5 +1,6 @@
 package com.hertz.hertz_be.domain.user.dto.request.v3;
 
+import com.hertz.hertz_be.domain.channel.entity.enums.Category;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
@@ -7,4 +8,7 @@ import lombok.Getter;
 public class RejectCategoryChangeRequestDto {
     @NotNull
     private boolean flag;
+
+    @NotNull
+    private Category category;
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/entity/User.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/entity/User.java
@@ -5,6 +5,7 @@ import com.hertz.hertz_be.domain.alarm.entity.UserAlarm;
 import com.hertz.hertz_be.domain.channel.entity.SignalMessage;
 import com.hertz.hertz_be.domain.channel.entity.SignalRoom;
 import com.hertz.hertz_be.domain.channel.entity.Tuning;
+import com.hertz.hertz_be.domain.channel.entity.enums.Category;
 import com.hertz.hertz_be.domain.user.entity.enums.AgeGroup;
 import com.hertz.hertz_be.domain.user.entity.enums.Gender;
 import com.hertz.hertz_be.domain.user.entity.enums.MembershipType;
@@ -20,8 +21,8 @@ import java.util.List;
 @Entity
 @Table(name = "user")
 @Getter
-@Setter // Todo: Setter가 있으면 객체지향면에서 좋지 않기 때문에 제거하는게 좋을 것 같아요
-@NoArgsConstructor(access = AccessLevel.PROTECTED) // 생성자를 만들되 외부에서 접근하지 못 하도록 함
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 public class User {
@@ -105,6 +106,13 @@ public class User {
         User user = new User();
         user.setId(id);
         return user;
+    }
+
+    public void changeRejectCategory(Category category, boolean flag) {
+        switch (category) {
+            case COUPLE -> isCoupleAllowed = flag;
+            case FRIEND -> isFriendAllowed = flag;
+        }
     }
 
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/responsecode/UserResponseCode.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/responsecode/UserResponseCode.java
@@ -17,6 +17,7 @@ public enum UserResponseCode {
     NICKNAME_API_FAILED(HttpStatus.BAD_GATEWAY, "NICKNAME_API_FAILED", "닉네임 생성 API 호출 실패"),
     NICKNAME_GENERATION_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "NICKNAME_GENERATION_TIMEOUT", "5초 내에 중복되지 않은 닉네임을 찾지 못했습니다."),
     WRONG_INVITATION_CODE(HttpStatus.BAD_REQUEST, "WRONG_INVITATION_CODE", "유효하지 않은 초대코드입니다."),
+    CATEGORY_UPDATED_SUCCESSFULLY(HttpStatus.OK, "CATEGORY_UPDATED_SUCCESSFULLY", "사용자의 카테고리가 정상적으로 수정되었습니다."),
 
     // 성공 응답 코드
     USER_INFO_FETCH_SUCCESS(HttpStatus.OK, "USER_INFO_FETCH_SUCCESS", "사용자의 정보가 정상적으로 조회되었습니다."),

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/service/v1/UserService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/service/v1/UserService.java
@@ -72,6 +72,7 @@ public class UserService {
     @Value("${max.age.seconds}")
     private long maxAgeSeconds;
 
+    @Transactional
     public UserInfoResponseDto createUser(UserInfoRequestDto userInfoRequestDto) {
         String redisValue = oauthRedisRepository.get(userInfoRequestDto.getProviderId());
         if (redisValue == null) {
@@ -139,6 +140,7 @@ public class UserService {
 
     }
 
+    @Transactional
     public String fetchRandomNickname() {
         final long startTime = System.nanoTime();
 

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/service/v2/UserService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/service/v2/UserService.java
@@ -12,6 +12,7 @@ import com.hertz.hertz_be.global.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
@@ -24,6 +25,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final InterestsService interestsService;
 
+    @Transactional(readOnly = true)
     public UserProfileDTO getUserProfile(Long targetUserId, Long userId) {
         User targetUser = userRepository.findByIdAndDeletedAtIsNull(targetUserId)
                 .orElseThrow(() -> new BusinessException(

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/service/v3/UserService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/service/v3/UserService.java
@@ -3,6 +3,7 @@ package com.hertz.hertz_be.domain.user.service.v3;
 import com.hertz.hertz_be.domain.auth.repository.OAuthRedisRepository;
 import com.hertz.hertz_be.domain.auth.repository.RefreshTokenRepository;
 import com.hertz.hertz_be.domain.auth.responsecode.AuthResponseCode;
+import com.hertz.hertz_be.domain.user.dto.request.v3.RejectCategoryChangeRequestDto;
 import com.hertz.hertz_be.domain.user.dto.request.v3.UserInfoRequestDto;
 import com.hertz.hertz_be.domain.user.dto.response.v3.UserInfoResponseDto;
 import com.hertz.hertz_be.domain.user.entity.User;
@@ -16,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -136,5 +138,19 @@ public class UserService {
                 .refreshToken(refreshToken)
                 .refreshSecondsUntilExpiry(secondsUntilExpiry)
                 .build();
+    }
+
+    @Transactional
+    public void changeRejectCategory(Long userId, RejectCategoryChangeRequestDto requestDto) {
+        User user = getUserWithSentSignalRoomsOrThrow(userId);
+        user.changeRejectCategory(requestDto.getCategory(), requestDto.isFlag());
+    }
+
+    private User getUserWithSentSignalRoomsOrThrow(Long userId) {
+        return userRepository.findByIdWithSentSignalRooms(userId)
+                .orElseThrow(() -> new BusinessException(
+                        UserResponseCode.USER_NOT_FOUND.getCode(),
+                        UserResponseCode.USER_NOT_FOUND.getHttpStatus(),
+                        UserResponseCode.USER_NOT_FOUND.getMessage()));
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/service/v3/UserService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/service/v3/UserService.java
@@ -45,6 +45,7 @@ public class UserService {
     @Value("${max.age.seconds}")
     private long maxAgeSeconds;
 
+    @Transactional
     public UserInfoResponseDto createUser(UserInfoRequestDto userInfoRequestDto) {
         String redisValue = oauthRedisRepository.get(userInfoRequestDto.getProviderId());
         validateRedisValue(redisValue);


### PR DESCRIPTION
## 🔗 관련 이슈
- #312 

## ✏️ 변경 사항
- 카테고리별 시그널 수신 설정을 수정할 수 있는 RequestDto 구현
- `category` 필드가 포함된 DTO 클래스 생성
- 사용자 Entity에 설정 변경 메서드(`changeRejectCategory`) 추가
- API 응답 코드 및 예외 처리 로직 추가
- 컨트롤러에 API 메서드 추가 및 `@Valid` 어노테이션 적용
- 서비스 계층 메서드에 `@Transactional` 어노테이션 추가

## 📋 상세 설명
- 사용자가 마이페이지에서 특정 시그널 카테고리(`COUPLE`, `FRIEND`)에 대한 수신 여부를 설정할 수 있도록 기능을 구현했습니다.
- 요청 본문에는 사용자가 off 하고자 하는 카테고리를 전달하며, 서버에서는 해당 카테고리에 대한 시그널 수신 플래그를 수정합니다.
- `ChangeSignalReceiveCategoryRequestDto` 클래스에는 `Category category`와 `Boolean isAllowed` 필드를 포함시켜 유연하게 동작할 수 있도록 구성했습니다.
- 사용자 엔티티 내부에서 `changeRejectCategory` 메서드를 통해 요청된 카테고리에 따라 `isFriendAllowed` 또는 `isCoupleAllowed` 값을 수정합니다.
- 컨트롤러에서 해당 API를 `@Valid`와 함께 매핑하고, 서비스 계층에서는 트랜잭션 처리를 통해 안정적인 데이터 갱신을 보장합니다.
- 향후 `Category`가 추가될 경우를 대비해 `switch` 문으로 명시적 분기 처리하도록 설계했습니다.

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 없음

## 📎 참고 자료 (선택)
- 없음
