### PR TITLE
[#316] Feat: 카테고리별 튜닝 추천 API 구현 및 AI 서버 API 연동

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/v3/ChannelController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/v3/ChannelController.java
@@ -1,6 +1,7 @@
 package com.hertz.hertz_be.domain.channel.controller.v3;
 
 import com.hertz.hertz_be.domain.channel.dto.request.v3.SendSignalRequestDto;
+import com.hertz.hertz_be.domain.channel.dto.response.v3.TuningResponseDto;
 import com.hertz.hertz_be.domain.channel.dto.response.v3.SendSignalResponseDto;
 import com.hertz.hertz_be.domain.channel.dto.response.v3.ChannelListResponseDto;
 import com.hertz.hertz_be.domain.channel.dto.response.v3.ChannelRoomResponseDto;
@@ -59,5 +60,19 @@ public class ChannelController {
                 new ResponseDto<>(ChannelResponseCode.SIGNAL_ROOM_CREATED.getCode(), ChannelResponseCode.SIGNAL_ROOM_CREATED.getMessage(), response)
         );
 
+    }
+
+    @GetMapping("/tuning")
+    @Operation(summary = "튜닝된 상대 반환 API")
+    public ResponseEntity<ResponseDto<TuningResponseDto>> getTunedUser(@AuthenticationPrincipal Long userId,
+                                                                       @RequestParam String category) {
+
+        TuningResponseDto response = channelService.getTunedUser(userId, category);
+        if (response == null) {
+            return ResponseEntity.ok(new ResponseDto<>(ChannelResponseCode.NO_TUNING_CANDIDATE.getCode(), ChannelResponseCode.NO_TUNING_CANDIDATE.getMessage(), null));
+        }
+        return ResponseEntity.ok(
+                new ResponseDto<>(ChannelResponseCode.TUNING_SUCCESS.getCode(), ChannelResponseCode.TUNING_SUCCESS.getMessage(), response)
+        );
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/v3/TuningResponseDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/v3/TuningResponseDto.java
@@ -1,0 +1,15 @@
+package com.hertz.hertz_be.domain.channel.dto.response.v3;
+
+import com.hertz.hertz_be.domain.user.entity.enums.Gender;
+import java.util.List;
+import java.util.Map;
+
+public record TuningResponseDto(
+        Long userId,
+        String profileImage,
+        String nickname,
+        Gender gender,
+        String oneLineIntroduction,
+        Map<String, String> keywords,
+        Map<String, List<String>> sameInterests
+) {}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/SignalRoomRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/SignalRoomRepository.java
@@ -4,6 +4,7 @@ import com.hertz.hertz_be.domain.channel.entity.SignalRoom;
 import com.hertz.hertz_be.domain.channel.entity.enums.MatchingStatus;
 import com.hertz.hertz_be.domain.channel.repository.projection.ChannelRoomProjection;
 import com.hertz.hertz_be.domain.user.entity.User;
+import com.hertz.hertz_be.domain.channel.entity.enums.Category;
 import io.lettuce.core.dynamic.annotation.Param;
 import jakarta.transaction.Transactional;
 import org.springframework.data.domain.Page;
@@ -17,7 +18,20 @@ import java.util.Optional;
 
 public interface SignalRoomRepository extends JpaRepository<SignalRoom, Long> {
     boolean existsBySenderUserAndReceiverUser(User sender, User receiver);
+
     Optional<SignalRoom> findByUserPairSignal(String userPairSignal);
+
+    @Query("""
+    SELECT CASE WHEN COUNT(sr) > 0 THEN true ELSE false END 
+    FROM SignalRoom sr 
+    WHERE 
+        ((sr.senderUser = :user1 AND sr.receiverUser = :user2) 
+        OR (sr.senderUser = :user2 AND sr.receiverUser = :user1))
+        AND sr.category = :category
+""")
+    boolean existsByUserPairAndCategory(@Param("user1") User user1,
+                                        @Param("user2") User user2,
+                                        @Param("category") Category category);
 
     @Query(value = """
     SELECT 

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/TuningRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/TuningRepository.java
@@ -11,6 +11,5 @@ import java.util.Optional;
 
 @Repository
 public interface TuningRepository extends JpaRepository<Tuning, Long> {
-    List<Tuning> findByUser(User user);
     Optional<Tuning> findByUserAndCategory(User user, Category category);
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/TuningRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/TuningRepository.java
@@ -12,4 +12,5 @@ import java.util.Optional;
 @Repository
 public interface TuningRepository extends JpaRepository<Tuning, Long> {
     Optional<Tuning> findByUserAndCategory(User user, Category category);
+    List<Tuning> findAllByCategory(Category category);
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/TuningResultRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/TuningResultRepository.java
@@ -6,16 +6,11 @@ import com.hertz.hertz_be.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface TuningResultRepository extends JpaRepository<TuningResult, Long> {
-    List<TuningResult> findByTuning(Tuning tuning);
-
-    Optional<TuningResult> findByTuningAndLineup(Tuning tuning, int lineup);
-
-    boolean existsByTuningAndMatchedUser(Tuning tuning, User matchedUser);
+    void deleteAllByTuning(Tuning tuning);
 
     Optional<TuningResult> findFirstByTuningOrderByLineupAsc(Tuning tuning);
 

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v3/ChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v3/ChannelService.java
@@ -276,7 +276,6 @@ public class ChannelService {
 
     private boolean fetchAndSaveTuningResultsFromAiServer(Long userId, Tuning tuning, String category) {
         Map<String, Object> responseMap = tuningAiClient.requestTuningByCategory(userId, category);
-//        Map<String, Object> responseMap = requestTuningByCategory(userId, category);
         String code = (String) responseMap.get("code");
 
         if (ChannelResponseCode.TUNING_SUCCESS_BUT_NO_MATCH.getCode().equals(code)) {
@@ -334,22 +333,6 @@ public class ChannelService {
             );
         }
     }
-
-// Todo: 머지전에 삭제
-//    public Map<String, Object> requestTuningByCategory(Long userId, String category) {
-//        Map<String, Object> response = new HashMap<>();
-//
-//        response.put("code", "TUNING_SUCCESS");
-//
-//        Map<String, Object> data = new HashMap<>();
-//        List<Integer> userIdList = List.of(2, 4, 6, 782);  // 튜닝 결과 더미 데이터
-//        data.put("userIdList", userIdList);
-//
-//        response.put("data", data);
-//
-//        return response;
-//    }
-
 
     private Tuning getOrCreateTuning(User user, String category) {
         Category enumCategory = convertToCategory(category);

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v3/ChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v3/ChannelService.java
@@ -168,10 +168,8 @@ public class ChannelService {
                         UserResponseCode.USER_DEACTIVATED.getMessage()
                 ));
 
-
-        String userPairSignal = generateUserPairSignal(sender.getId(), receiver.getId());
-        Optional<SignalRoom> existingRoom = signalRoomRepository.findByUserPairSignal(userPairSignal);
-        if (existingRoom.isPresent()) {
+        boolean alreadyExists = signalRoomRepository.existsByUserPairAndCategory(sender, receiver, dto.getCategory());
+        if (alreadyExists) {
             throw new BusinessException(
                     ChannelResponseCode.ALREADY_IN_CONVERSATION.getCode(),
                     ChannelResponseCode.ALREADY_IN_CONVERSATION.getHttpStatus(),
@@ -184,6 +182,8 @@ public class ChannelService {
                     "자기 자신에게는 시그널을 보낼 수 없습니다."
             );
         }
+
+        String userPairSignal = generateUserPairSignal(sender.getId(), receiver.getId());
 
         SignalRoom signalRoom = SignalRoom.builder()
                 .senderUser(sender)

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v3/ChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v3/ChannelService.java
@@ -168,6 +168,14 @@ public class ChannelService {
                         UserResponseCode.USER_DEACTIVATED.getMessage()
                 ));
 
+        if (!receiver.isCategoryAllowed(dto.getCategory())) {
+            throw new BusinessException(
+                    UserResponseCode.CATEGORY_IS_REJECTED.getCode(),
+                    UserResponseCode.CATEGORY_IS_REJECTED.getHttpStatus(),
+                    UserResponseCode.CATEGORY_IS_REJECTED.getMessage()
+            );
+        }
+
         boolean alreadyExists = signalRoomRepository.existsByUserPairAndCategory(sender, receiver, dto.getCategory());
         if (alreadyExists) {
             throw new BusinessException(
@@ -183,7 +191,7 @@ public class ChannelService {
             );
         }
 
-        String userPairSignal = generateUserPairSignal(sender.getId(), receiver.getId());
+        String userPairSignal = generateUserPairSignal(sender.getId(), receiver.getId(), dto.getCategory());
 
         SignalRoom signalRoom = SignalRoom.builder()
                 .senderUser(sender)
@@ -226,10 +234,10 @@ public class ChannelService {
         return new SendSignalResponseDto(signalRoom.getId());
     }
 
-    public static String generateUserPairSignal(Long userId1, Long userId2) {
+    public static String generateUserPairSignal(Long userId1, Long userId2, Category category) {
         Long min = Math.min(userId1, userId2);
         Long max = Math.max(userId1, userId2);
-        return min + "_" + max;
+        return min + "_" + max + "_" + category;
     }
 
     @Transactional

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v3/ChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v3/ChannelService.java
@@ -41,10 +41,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 
 @Slf4j
 @Service("channelServiceV3")
@@ -279,6 +276,7 @@ public class ChannelService {
 
     private boolean fetchAndSaveTuningResultsFromAiServer(Long userId, Tuning tuning, String category) {
         Map<String, Object> responseMap = tuningAiClient.requestTuningByCategory(userId, category);
+//        Map<String, Object> responseMap = requestTuningByCategory(userId, category);
         String code = (String) responseMap.get("code");
 
         if (ChannelResponseCode.TUNING_SUCCESS_BUT_NO_MATCH.getCode().equals(code)) {
@@ -337,6 +335,22 @@ public class ChannelService {
         }
     }
 
+// Todo: 머지전에 삭제
+//    public Map<String, Object> requestTuningByCategory(Long userId, String category) {
+//        Map<String, Object> response = new HashMap<>();
+//
+//        response.put("code", "TUNING_SUCCESS");
+//
+//        Map<String, Object> data = new HashMap<>();
+//        List<Integer> userIdList = List.of(2, 4, 6, 782);  // 튜닝 결과 더미 데이터
+//        data.put("userIdList", userIdList);
+//
+//        response.put("data", data);
+//
+//        return response;
+//    }
+
+
     private Tuning getOrCreateTuning(User user, String category) {
         Category enumCategory = convertToCategory(category);
 
@@ -344,7 +358,7 @@ public class ChannelService {
                 .orElseGet(() -> tuningRepository.save(
                         Tuning.builder()
                                 .user(user)
-                                .category(Category.FRIEND)
+                                .category(enumCategory)
                                 .build()));
     }
 

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v3/ChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v3/ChannelService.java
@@ -1,24 +1,29 @@
 package com.hertz.hertz_be.domain.channel.service.v3;
 
 import com.hertz.hertz_be.domain.channel.dto.request.v3.SendSignalRequestDto;
-import com.hertz.hertz_be.domain.channel.dto.response.v3.SendSignalResponseDto;
-import com.hertz.hertz_be.domain.channel.dto.response.v3.ChannelListResponseDto;
-import com.hertz.hertz_be.domain.channel.dto.response.v3.ChannelRoomResponseDto;
-import com.hertz.hertz_be.domain.channel.dto.response.v3.ChannelSummaryDto;
+import com.hertz.hertz_be.domain.channel.dto.response.v3.*;
 import com.hertz.hertz_be.domain.channel.entity.SignalMessage;
 import com.hertz.hertz_be.domain.channel.entity.SignalRoom;
+import com.hertz.hertz_be.domain.channel.entity.Tuning;
+import com.hertz.hertz_be.domain.channel.entity.TuningResult;
 import com.hertz.hertz_be.domain.channel.entity.enums.Category;
 import com.hertz.hertz_be.domain.channel.entity.enums.MatchingStatus;
 import com.hertz.hertz_be.domain.channel.repository.SignalMessageRepository;
 import com.hertz.hertz_be.domain.channel.repository.SignalRoomRepository;
+import com.hertz.hertz_be.domain.channel.repository.TuningRepository;
+import com.hertz.hertz_be.domain.channel.repository.TuningResultRepository;
 import com.hertz.hertz_be.domain.channel.repository.projection.ChannelRoomProjection;
 import com.hertz.hertz_be.domain.channel.repository.projection.RoomWithLastSenderProjection;
 import com.hertz.hertz_be.domain.channel.responsecode.ChannelResponseCode;
 import com.hertz.hertz_be.domain.channel.service.AsyncChannelService;
+import com.hertz.hertz_be.domain.interests.repository.UserInterestsRepository;
+import com.hertz.hertz_be.domain.interests.service.InterestsService;
 import com.hertz.hertz_be.domain.user.entity.User;
 import com.hertz.hertz_be.domain.user.repository.UserRepository;
 import com.hertz.hertz_be.domain.user.responsecode.UserResponseCode;
+import com.hertz.hertz_be.global.common.NewResponseCode;
 import com.hertz.hertz_be.global.exception.BusinessException;
+import com.hertz.hertz_be.global.infra.ai.client.TuningAiClient;
 import com.hertz.hertz_be.global.util.AESUtil;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
@@ -37,6 +42,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -50,8 +56,14 @@ public class ChannelService {
     private final UserRepository userRepository;
     private final SignalRoomRepository signalRoomRepository;
     private final SignalMessageRepository signalMessageRepository;
+    private final TuningResultRepository tuningResultRepository;
+    private final TuningRepository tuningRepository;
+    private final InterestsService interestsService;
+    private final UserInterestsRepository userInterestsRepository;
     private final AsyncChannelService asyncChannelService;
     private final AESUtil aesUtil;
+    private final TuningAiClient tuningAiClient;
+
 
     @Transactional(readOnly = true)
     public ChannelListResponseDto getPersonalSignalRoomList(Long userId, int page, int size) {
@@ -218,5 +230,188 @@ public class ChannelService {
         Long min = Math.min(userId1, userId2);
         Long max = Math.max(userId1, userId2);
         return min + "_" + max;
+    }
+
+    @Transactional
+    public TuningResponseDto getTunedUser(Long userId, String category) {
+        User requester = getUserById(userId);
+
+        if (!hasSelectedInterests(requester)) {
+            throw new BusinessException(
+                    ChannelResponseCode.USER_INTERESTS_NOT_SELECTED.getCode(),
+                    ChannelResponseCode.USER_INTERESTS_NOT_SELECTED.getHttpStatus(),
+                    ChannelResponseCode.USER_INTERESTS_NOT_SELECTED.getMessage()
+            );
+        }
+
+        Tuning tuning = getOrCreateTuning(requester, category);
+
+        if (!tuningResultRepository.existsByTuning(tuning)) {
+            boolean saved = fetchAndSaveTuningResultsFromAiServer(userId, tuning, category);
+            if (!saved) return null;
+        }
+
+        Optional<TuningResult> optionalResult = tuningResultRepository.findFirstByTuningOrderByLineupAsc(tuning);
+        if (optionalResult.isEmpty()) {
+            boolean saved = fetchAndSaveTuningResultsFromAiServer(userId, tuning, category);
+            if (!saved) return null;
+
+            optionalResult = tuningResultRepository.findFirstByTuningOrderByLineupAsc(tuning);
+            if (optionalResult.isEmpty()) return null;
+        }
+
+        TuningResult topResult = optionalResult.get();
+        tuningResultRepository.delete(topResult);
+
+        User matchedUser = topResult.getMatchedUser();
+        if (matchedUser == null || matchedUser.getId() == null) return null;
+
+        return buildTuningResponseDTO(userId, matchedUser);
+    }
+
+    private boolean fetchAndSaveTuningResultsFromAiServer(Long userId, Tuning tuning, String category) {
+        Map<String, Object> responseMap = tuningAiClient.requestTuningByCategory(userId, category);
+        String code = (String) responseMap.get("code");
+
+        if (ChannelResponseCode.TUNING_SUCCESS_BUT_NO_MATCH.getCode().equals(code)) {
+            return false;
+
+        } else if (ChannelResponseCode.TUNING_BAD_REQUEST.getCode().equals(code)) {
+            throw new BusinessException(
+                    NewResponseCode.AI_SERVER_ERROR.getCode(),
+                    NewResponseCode.AI_SERVER_ERROR.getHttpStatus(),
+                    "AI 서버에서 bad request 발생했습니다."
+            );
+
+        } else if (ChannelResponseCode.TUNING_NOT_FOUND_USER.getCode().equals(code)) {
+            throw new BusinessException(
+                    NewResponseCode.AI_SERVER_ERROR.getCode(),
+                    NewResponseCode.AI_SERVER_ERROR.getHttpStatus(),
+                    "AI 서버에서 사용자를 찾을 수 없습니다."
+            );
+
+        } else if (ChannelResponseCode.TUNING_INTERNAL_SERVER_ERROR.getCode().equals(code)) {
+            throw new BusinessException(
+                    NewResponseCode.AI_SERVER_ERROR.getCode(),
+                    NewResponseCode.AI_SERVER_ERROR.getHttpStatus(),
+                    "튜닝 과정에서 AI 서버 오류 발생했습니다."
+            );
+
+        } else if (ChannelResponseCode.TUNING_SUCCESS.getCode().equals(code)) {
+            Object dataObj = responseMap.get("data");
+            if (!(dataObj instanceof Map)) {
+                throw new BusinessException(
+                        NewResponseCode.AI_SERVER_ERROR.getCode(),
+                        NewResponseCode.AI_SERVER_ERROR.getHttpStatus(),
+                        "튜닝 과정에서 AI 서버 오류 발생했습니다."
+                );
+            }
+
+            Map<?, ?> data = (Map<?, ?>) dataObj;
+            List<Integer> userIdList = (List<Integer>) data.get("userIdList");
+            if (userIdList == null || userIdList.isEmpty()) {
+                throw new BusinessException(
+                        NewResponseCode.AI_SERVER_ERROR.getCode(),
+                        NewResponseCode.AI_SERVER_ERROR.getHttpStatus(),
+                        "튜닝 과정에서 AI 서버 오류 발생했습니다."
+                );
+            }
+
+            saveTuningResults(userIdList, tuning, category);
+            return true;
+
+        } else {
+            throw new BusinessException(
+                    NewResponseCode.INTERNAL_SERVER_ERROR.getCode(),
+                    NewResponseCode.INTERNAL_SERVER_ERROR.getHttpStatus(),
+                    "튜닝 과정에서 BE 서버 오류 발생했습니다."
+            );
+        }
+    }
+
+    private Tuning getOrCreateTuning(User user, String category) {
+        Category enumCategory = convertToCategory(category);
+
+        return tuningRepository.findByUserAndCategory(user, enumCategory)
+                .orElseGet(() -> tuningRepository.save(
+                        Tuning.builder()
+                                .user(user)
+                                .category(Category.FRIEND)
+                                .build()));
+    }
+
+    private Category convertToCategory(String category) {
+        return switch (category.toLowerCase()) {
+            case "friend" -> Category.FRIEND;
+            case "couple" -> Category.COUPLE;
+            default -> throw new BusinessException(
+                    NewResponseCode.BAD_REQUEST.getCode(),
+                    NewResponseCode.BAD_REQUEST.getHttpStatus(),
+                    "유효하지 않은 category: " + category
+            );
+        };
+    }
+
+    private void saveTuningResults(List<Integer> userIdList, Tuning tuning, String category) {
+        int lineup = 1;
+        User requester = tuning.getUser();
+        Category enumCategory = convertToCategory(category);
+
+        for (Integer matchedUserId : userIdList) {
+            Long matchedId = Long.valueOf(matchedUserId);
+
+            User matchedUser = userRepository.findById(matchedId)
+                    .orElseThrow(() -> new BusinessException(
+                            UserResponseCode.USER_DEACTIVATED.getCode(),
+                            UserResponseCode.USER_DEACTIVATED.getHttpStatus(),
+                            "BE 서버에 없는 사용자 id가 AI 서버로부터 넘어왔습니다."
+                    ));
+
+            if (!hasSelectedInterests(matchedUser)) {
+                continue;
+            }
+
+            boolean alreadyExists = signalRoomRepository.existsByUserPairAndCategory(requester, matchedUser, enumCategory);
+
+            if (alreadyExists) continue;
+
+            tuningResultRepository.save(
+                    TuningResult.builder()
+                            .tuning(tuning)
+                            .matchedUser(matchedUser)
+                            .lineup(lineup++)
+                            .build()
+            );
+        }
+    }
+
+    private TuningResponseDto buildTuningResponseDTO(Long requesterId, User target) {
+        Map<String, String> keywords = interestsService.getUserKeywords(target.getId());
+        Map<String, List<String>> requesterInterests = interestsService.getUserInterests(requesterId);
+        Map<String, List<String>> targetInterests = interestsService.getUserInterests(target.getId());
+        Map<String, List<String>> sameInterests = interestsService.extractSameInterests(requesterInterests, targetInterests);
+
+        return new TuningResponseDto(
+                target.getId(),
+                target.getProfileImageUrl(),
+                target.getNickname(),
+                target.getGender(),
+                target.getOneLineIntroduction(),
+                keywords,
+                sameInterests
+        );
+    }
+
+    public User getUserById(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(
+                        UserResponseCode.USER_NOT_FOUND.getCode(),
+                        UserResponseCode.USER_NOT_FOUND.getHttpStatus(),
+                        UserResponseCode.USER_NOT_FOUND.getMessage()
+                ));
+    }
+
+    public boolean hasSelectedInterests(User user) {
+        return userInterestsRepository.existsByUser(user);
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v3/ChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v3/ChannelService.java
@@ -370,9 +370,10 @@ public class ChannelService {
             if (!hasSelectedInterests(matchedUser)) {
                 continue;
             }
-
+            if (!matchedUser.isCategoryAllowed(enumCategory)) {
+                continue;
+            }
             boolean alreadyExists = signalRoomRepository.existsByUserPairAndCategory(requester, matchedUser, enumCategory);
-
             if (alreadyExists) continue;
 
             tuningResultRepository.save(

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/interests/service/InterestsService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/interests/service/InterestsService.java
@@ -236,7 +236,7 @@ public class InterestsService {
     }
 
     private Map<String, Object> saveInterestsToAiServer(Map<String, Object> requestAiBody, Map<String, String> keywordMap, Map<String, String[]> interestsMap) {
-        String uri = "/api/v1/users";
+        String uri = "/api/v1/users"; //Todo: 3차 배포 직전에 "/api/v3/users"로 수정 할 것
         Long userId = (Long) requestAiBody.get("userId");
 
         UserAiInterestsRequestDto aiRequest = UserAiInterestsRequestDto.builder()

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/entity/User.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/entity/User.java
@@ -115,4 +115,11 @@ public class User {
         }
     }
 
+    public boolean isCategoryAllowed(Category category) {
+        return switch (category) {
+            case FRIEND -> isFriendAllowed;
+            case COUPLE -> isCoupleAllowed;
+        };
+    }
+
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/responsecode/UserResponseCode.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/responsecode/UserResponseCode.java
@@ -18,6 +18,7 @@ public enum UserResponseCode {
     NICKNAME_GENERATION_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "NICKNAME_GENERATION_TIMEOUT", "5초 내에 중복되지 않은 닉네임을 찾지 못했습니다."),
     WRONG_INVITATION_CODE(HttpStatus.BAD_REQUEST, "WRONG_INVITATION_CODE", "유효하지 않은 초대코드입니다."),
     CATEGORY_UPDATED_SUCCESSFULLY(HttpStatus.OK, "CATEGORY_UPDATED_SUCCESSFULLY", "사용자의 카테고리가 정상적으로 수정되었습니다."),
+    CATEGORY_IS_REJECTED(HttpStatus.BAD_REQUEST, "CATEGORY_IS_REJECTED", "상대방이 시그널을 받고 싶지 않은 카테고리입나다."),
 
     // 성공 응답 코드
     USER_INFO_FETCH_SUCCESS(HttpStatus.OK, "USER_INFO_FETCH_SUCCESS", "사용자의 정보가 정상적으로 조회되었습니다."),

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/service/v3/UserService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/service/v3/UserService.java
@@ -3,6 +3,9 @@ package com.hertz.hertz_be.domain.user.service.v3;
 import com.hertz.hertz_be.domain.auth.repository.OAuthRedisRepository;
 import com.hertz.hertz_be.domain.auth.repository.RefreshTokenRepository;
 import com.hertz.hertz_be.domain.auth.responsecode.AuthResponseCode;
+import com.hertz.hertz_be.domain.channel.entity.Tuning;
+import com.hertz.hertz_be.domain.channel.repository.TuningRepository;
+import com.hertz.hertz_be.domain.channel.repository.TuningResultRepository;
 import com.hertz.hertz_be.domain.user.dto.request.v3.RejectCategoryChangeRequestDto;
 import com.hertz.hertz_be.domain.user.dto.request.v3.UserInfoRequestDto;
 import com.hertz.hertz_be.domain.user.dto.response.v3.UserInfoResponseDto;
@@ -21,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 @Slf4j
 @Service("userServiceV3")
@@ -35,6 +39,8 @@ public class UserService {
     private final JwtTokenProvider jwtTokenProvider;
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final TuningResultRepository tuningResultRepository;
+    private final TuningRepository tuningRepository;
 
     @Value("${invitation.code.kakaotech}")
     private int kakaotechInvitationCode;
@@ -145,6 +151,11 @@ public class UserService {
     public void changeRejectCategory(Long userId, RejectCategoryChangeRequestDto requestDto) {
         User user = getUserWithSentSignalRoomsOrThrow(userId);
         user.changeRejectCategory(requestDto.getCategory(), requestDto.isFlag());
+
+        if (!requestDto.isFlag()) {
+            tuningRepository.findByUserAndCategory(user, requestDto.getCategory())
+                    .ifPresent(tuningResultRepository::deleteAllByTuning);
+        }
     }
 
     private User getUserWithSentSignalRoomsOrThrow(Long userId) {

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/config/WebClientConfig.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/config/WebClientConfig.java
@@ -1,13 +1,25 @@
 package com.hertz.hertz_be.global.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
 public class WebClientConfig {
+
+    @Value("${ai.server.ip}")
+    private String aiServerIp;
+
     @Bean
     public WebClient.Builder webClientBuilder() {
         return WebClient.builder();
+    }
+
+    @Bean
+    public WebClient tuningAiServerWebClient(WebClient.Builder builder) {
+        return builder
+                .baseUrl(aiServerIp)
+                .build();
     }
 }

--- a/hertz-be/src/main/resources/application-dev.properties
+++ b/hertz-be/src/main/resources/application-dev.properties
@@ -6,7 +6,7 @@ spring.jpa.show-sql=false
 spring.jpa.open-in-view=false
 
 # JWT AT expiration time
-jwt.at.expiration-minutes=1
+jwt.at.expiration-minutes=300
 
 # Swagger
 springdoc.api-docs.enabled=true


### PR DESCRIPTION
## 🔗 관련 이슈
- #316 

## ✏️ 변경 사항
- 카테고리(친구/커플)별 튜닝 추천 API 구현
- 사용자별 카테고리 설정 여부에 따른 추천 필터링 로직 추가
- AI 서버와의 연동을 통한 추천 결과 수신 기능 추가
- 이미 대화 중이거나, 시그널 차단 설정된 경우 예외 처리 추가

## 📋 상세 설명
- 기존에는 친구 관계를 전제로 튜닝 추천이 이뤄졌으나, 커플 등 다른 관계 목적의 추천 니즈를 반영하기 위해 카테고리 구분이 필요해졌습니다.
- 이에 따라 V3 채널 도메인 내에서 **카테고리별 튜닝 추천 API**를 새로 정의하고, 기본 카테고리(친구) 외에도 커플 등으로 확장 가능하도록 구조를 개선했습니다.
- 구현 주요 내용:
  - **AI 서버 API 연동**: WebClient를 이용해 카테고리별 추천 요청 전송 및 응답 처리
  - **ResponseDto 구현**: 카테고리별 추천 결과를 담을 DTO 생성
  - **Service / Controller 추가**: 카테고리 인자를 기반으로 AI 서버 추천 요청 및 사용자 필터링 처리
  - **사용자 카테고리 허용 여부 확인**: user entity에 특정 카테고리가 허용되는지 반환하는 메서드 구현
  - **추천 리스트 필터링 로직**: 추천 받은 사용자 리스트 중에서 해당 카테고리를 false로 설정한 사용자를 제외하는 로직 추가
  - **추천 리스트 업데이트 로직**: 사용자가 특정 카테고리를 false로 설정할 시, 해당 사용자가 포함된 모든 추천 리스트에서 제외하는 로직 추가
  - **예외 처리**: 
    - 이미 해당 카테고리로 대화 중인 상대방이 존재하면 예외 발생
    - 시그널 전송 시 해당 카테고리를 false로 설정한 상대방일 경우 예외 처리

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 없음
## 📎 참고 자료 (선택)
- 없음
