### PR TITLE
Fix: socket.io 메세지 읽음 처리 관련 트랜잭션 설정 변경

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/v1/ChannelController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/v1/ChannelController.java
@@ -1,6 +1,7 @@
 package com.hertz.hertz_be.domain.channel.controller.v1;
 
 import com.hertz.hertz_be.domain.channel.dto.request.v1.SendSignalRequestDto;
+import com.hertz.hertz_be.domain.channel.dto.request.v3.SendMessageRequestDto;
 import com.hertz.hertz_be.domain.channel.dto.response.v1.ChannelListResponseDto;
 import com.hertz.hertz_be.domain.channel.dto.response.v1.ChannelRoomResponseDto;
 import com.hertz.hertz_be.domain.channel.dto.response.v1.SendSignalResponseDto;
@@ -79,7 +80,7 @@ public class ChannelController {
     @Operation(summary = "채널방 메세지 전송 API")
     public ResponseEntity<ResponseDto<ChannelRoomResponseDto>> sendChannelMessage(@PathVariable Long channelRoomId,
                                                                                   @AuthenticationPrincipal Long userId,
-                                                                                  @RequestBody @Valid SendSignalRequestDto response) {
+                                                                                  @RequestBody @Valid SendMessageRequestDto response) {
 
         channelService.sendChannelMessage(channelRoomId, userId, response);
         return ResponseEntity

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/request/v3/SendMessageRequestDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/request/v3/SendMessageRequestDto.java
@@ -1,0 +1,12 @@
+package com.hertz.hertz_be.domain.channel.dto.request.v3;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class SendMessageRequestDto {
+
+    @NotBlank
+    private String message;
+
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v1/ChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v1/ChannelService.java
@@ -1,13 +1,13 @@
 package com.hertz.hertz_be.domain.channel.service.v1;
 
 import com.corundumstudio.socketio.SocketIOServer;
+import com.hertz.hertz_be.domain.channel.dto.request.v3.SendMessageRequestDto;
 import com.hertz.hertz_be.domain.channel.dto.response.v1.*;
 import com.hertz.hertz_be.domain.channel.service.AsyncChannelService;
 import com.hertz.hertz_be.domain.channel.service.SseChannelService;
 import com.hertz.hertz_be.domain.user.responsecode.UserResponseCode;
 import com.hertz.hertz_be.global.common.NewResponseCode;
 import com.hertz.hertz_be.global.exception.*;
-import com.hertz.hertz_be.global.socketio.dto.SocketIoMessageResponse;
 import com.hertz.hertz_be.domain.channel.entity.*;
 import com.hertz.hertz_be.domain.channel.entity.enums.Category;
 import com.hertz.hertz_be.domain.channel.entity.enums.MatchingStatus;
@@ -64,7 +64,6 @@ public class ChannelService {
     private final AsyncChannelService asyncChannelService;
     private final WebClient webClient;
     private final AESUtil aesUtil;
-    private SocketIOServer socketIOServer;
 
     @Autowired
     public ChannelService(UserRepository userRepository,
@@ -78,7 +77,7 @@ public class ChannelService {
                           AsyncChannelService asyncChannelService,
                           SseChannelService matchingStatusScheduler,
                           AESUtil aesUtil,
-                          @Value("${ai.server.ip}") String aiServerIp, SocketIOServer socketIOServer) {
+                          @Value("${ai.server.ip}") String aiServerIp) {
         this.userRepository = userRepository;
         this.tuningRepository = tuningRepository;
         this.tuningResultRepository = tuningResultRepository;
@@ -89,7 +88,6 @@ public class ChannelService {
         this.asyncChannelService = asyncChannelService;
         this.aesUtil = aesUtil;
         this.webClient = WebClient.builder().baseUrl(aiServerIp).build();
-        this.socketIOServer = socketIOServer;
     }
 
     @Transactional
@@ -505,7 +503,7 @@ public class ChannelService {
     }
 
     @Transactional
-    public void sendChannelMessage(Long roomId, Long userId, SendSignalRequestDto response) {
+    public void sendChannelMessage(Long roomId, Long userId, SendMessageRequestDto response) {
         // 1. 메세지 DB 저장
         SignalRoom room = signalRoomRepository.findById(roomId)
                 .orElseThrow(() -> new BusinessException(

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/config/SocketIoConfig.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/config/SocketIoConfig.java
@@ -36,6 +36,7 @@ public class SocketIoConfig {
 
         List<String> allowedOrigins = List.of(
                 "http://localhost:3000",
+                "http://localhost:5500",
                 "https://hertz-tuning.com",
                 "https://dev.hertz-tuning.com",
                 "https://local.hertz-tuning.com:3000",

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/socketio/SocketIoService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/socketio/SocketIoService.java
@@ -13,6 +13,7 @@ import com.hertz.hertz_be.global.socketio.dto.SocketIoMessageResponse;
 import com.hertz.hertz_be.global.util.AESUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 
@@ -58,7 +59,7 @@ public class SocketIoService {
         return SocketIoMessageResponse.from(saved, decrypted);
     }
 
-    @Transactional
+    @Transactional(readOnly = false, propagation = Propagation.REQUIRES_NEW)
     public void markMessageAsRead(Long roomId, Long userId) {
         signalMessageRepository.markUnreadMessagesAsRead(roomId, userId);
     }


### PR DESCRIPTION
## 🔗 관련 이슈
- 

## ✏️ 변경 사항
- 시그널 보내기 / 메세지 전송 DTO 분리
- `markMessageAsRead` 메서드의 `@Transactional` 설정 변경

## 📋 상세 설명
- '시그널 보내기' 기능과 '메세지 전송'의 요청 구조가 다름에도 불구하고 함께 사용하고 있는 부분이 있어 DTO를 분리함
- Socket.io는 Spring MVC의 DispatcherServlet이나 AOP 기반의 트랜잭션 관리와는 무관한 별도의 Netty 기반 I/O 이벤트 루프에서 작동하게 됨, 따라서 @Transactional이 정상적으로 동작하지 않거나, 커넥션이 read-only로 설정될 수 있음
- @Transactional 에 대한 추가 설정
   - readOnly = false -> 상위에서 걸린 readOnly = true 설정 무시
   - propagation = Propagation.REQUIRES_NEW -> 독립적인 트랜잭션으로 돌아갈 수 있도록 명시
- 트랜잭션 전파 차단 설정을 함으로써 새로운 트랜잭션을 열어 DB 수정이 가능하도록 보장함

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.
