### PR TITLE
[#322] Feat: 메세지 신고 API 구현 및 AI 서버 API 연동

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/dto/response/object/AlarmItem.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/dto/response/object/AlarmItem.java
@@ -11,9 +11,10 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonSubTypes({
         @JsonSubTypes.Type(value = NoticeAlarm.class, name = "NOTICE"),
         @JsonSubTypes.Type(value = ReportAlarm.class, name = "REPORT"),
-        @JsonSubTypes.Type(value = MatchingAlarm.class, name = "MATCHING")
+        @JsonSubTypes.Type(value = MatchingAlarm.class, name = "MATCHING"),
+        @JsonSubTypes.Type(value = AlertAlarm.class, name = "ALERT")
 })
-public sealed interface AlarmItem permits NoticeAlarm, ReportAlarm, MatchingAlarm {
+public sealed interface AlarmItem permits AlertAlarm, MatchingAlarm, NoticeAlarm, ReportAlarm {
     String type();
     String title();
     String createdDate();

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/dto/response/object/AlertAlarm.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/dto/response/object/AlertAlarm.java
@@ -1,0 +1,7 @@
+package com.hertz.hertz_be.domain.alarm.dto.response.object;
+
+public record AlertAlarm(
+        String type,
+        String title,
+        String createdDate
+) implements AlarmItem {}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/entity/AlarmAlert.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/entity/AlarmAlert.java
@@ -1,0 +1,23 @@
+package com.hertz.hertz_be.domain.alarm.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@SuperBuilder
+@Getter
+@Table(name = "alarm_alert")
+@NoArgsConstructor
+@AllArgsConstructor
+@DiscriminatorValue("ALERT")
+public class AlarmAlert extends Alarm {
+
+    @Column(nullable = false, name = "report_message")
+    private String reportedMessage;
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/entity/enums/AlarmCategory.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/entity/enums/AlarmCategory.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum AlarmCategory {
     NOTICE("공지 알림", "NOTICE"),
     REPORT("리포트 알림", "REPORT"),
-    MATCHING("매칭 결과 알림", "MATCHING");
+    MATCHING("매칭 결과 알림", "MATCHING"),
+    ALERT("경고 알람", "ALERT");
 
     private final String label;
     private final String value;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/repository/AlarmAlertRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/repository/AlarmAlertRepository.java
@@ -1,0 +1,7 @@
+package com.hertz.hertz_be.domain.alarm.repository;
+
+import com.hertz.hertz_be.domain.alarm.entity.AlarmAlert;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AlarmAlertRepository extends JpaRepository<AlarmAlert, Long> {
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/service/AlarmService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/alarm/service/AlarmService.java
@@ -2,10 +2,7 @@ package com.hertz.hertz_be.domain.alarm.service;
 
 import static com.hertz.hertz_be.global.util.MessageCreatorUtil.*;
 import com.hertz.hertz_be.domain.alarm.dto.response.AlarmListResponseDto;
-import com.hertz.hertz_be.domain.alarm.dto.response.object.AlarmItem;
-import com.hertz.hertz_be.domain.alarm.dto.response.object.MatchingAlarm;
-import com.hertz.hertz_be.domain.alarm.dto.response.object.NoticeAlarm;
-import com.hertz.hertz_be.domain.alarm.dto.response.object.ReportAlarm;
+import com.hertz.hertz_be.domain.alarm.dto.response.object.*;
 import com.hertz.hertz_be.domain.alarm.entity.*;
 import com.hertz.hertz_be.domain.alarm.entity.enums.AlarmCategory;
 import com.hertz.hertz_be.domain.alarm.repository.*;
@@ -252,6 +249,12 @@ public class AlarmService {
                                 AlarmCategory.REPORT.getValue(),
                                 report.getTitle(),
                                 report.getCreatedAt().toString()
+                        );
+                    } else if (alarm instanceof AlarmAlert alert) {
+                        return new AlertAlarm(
+                                AlarmCategory.ALERT.getValue(),
+                                alert.getTitle(),
+                                alert.getCreatedAt().toString()
                         );
                     } else {
                         throw new BusinessException(

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/v3/ChannelController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/controller/v3/ChannelController.java
@@ -1,5 +1,6 @@
 package com.hertz.hertz_be.domain.channel.controller.v3;
 
+import com.hertz.hertz_be.domain.channel.dto.request.v3.ChatReportRequestDto;
 import com.hertz.hertz_be.domain.channel.dto.request.v3.SendSignalRequestDto;
 import com.hertz.hertz_be.domain.channel.dto.response.v3.TuningResponseDto;
 import com.hertz.hertz_be.domain.channel.dto.response.v3.SendSignalResponseDto;
@@ -73,6 +74,15 @@ public class ChannelController {
         }
         return ResponseEntity.ok(
                 new ResponseDto<>(ChannelResponseCode.TUNING_SUCCESS.getCode(), ChannelResponseCode.TUNING_SUCCESS.getMessage(), response)
+        );
+    }
+
+    @PostMapping("/reports")
+    @Operation(summary = "메시지 신고 API")
+    public ResponseEntity<ResponseDto<Void>> reportMessage(@AuthenticationPrincipal Long userId,
+                                                            @RequestBody @Valid ChatReportRequestDto requestDto) {
+        channelService.reportMessage(userId, requestDto);
+        return ResponseEntity.ok(new ResponseDto<>(ChannelResponseCode.MESSAGE_REPORTED.getCode(), ChannelResponseCode.MESSAGE_REPORTED.getMessage(), null )
         );
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/request/v3/ChatReportRequestDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/request/v3/ChatReportRequestDto.java
@@ -1,0 +1,22 @@
+package com.hertz.hertz_be.domain.channel.dto.request.v3;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatReportRequestDto {
+
+    @NotNull
+    private int messageId;
+
+    @NotBlank
+    private String messageContent;
+
+    @NotNull
+    private int reportedUserId;
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/request/v3/ChatReportRequestDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/request/v3/ChatReportRequestDto.java
@@ -18,5 +18,5 @@ public class ChatReportRequestDto {
     private String messageContent;
 
     @NotNull
-    private int reportedUserId;
+    private long reportedUserId;
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/responsecode/ChannelResponseCode.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/responsecode/ChannelResponseCode.java
@@ -21,6 +21,7 @@ public enum ChannelResponseCode {
     TUNING_SUCCESS(HttpStatus.OK, "TUNING_SUCCESS", "튜닝이 성공적으로 완료되었습니다."),
     NO_TUNING_CANDIDATE(HttpStatus.OK, "NO_TUNING_CANDIDATE", "추천할 튜닝 후보자가 없습니다."),
     TUNING_SUCCESS_BUT_NO_MATCH(HttpStatus.OK, "TUNING_SUCCESS_BUT_NO_MATCH", "튜닝은 성공했으나 매칭 상대가 없습니다."),
+    MESSAGE_REPORTED(HttpStatus.OK, "MESSAGE_REPORTED", "신고가 정상적으로 접수되었습니다."),
 
     // 예외 응답 코드
     CHANNEL_NOT_FOUND(HttpStatus.GONE, "CHANNEL_NOT_FOUND", "찾을 수 없는 채팅방입니다."),

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/responsecode/ChannelResponseCode.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/responsecode/ChannelResponseCode.java
@@ -22,6 +22,7 @@ public enum ChannelResponseCode {
     NO_TUNING_CANDIDATE(HttpStatus.OK, "NO_TUNING_CANDIDATE", "추천할 튜닝 후보자가 없습니다."),
     TUNING_SUCCESS_BUT_NO_MATCH(HttpStatus.OK, "TUNING_SUCCESS_BUT_NO_MATCH", "튜닝은 성공했으나 매칭 상대가 없습니다."),
     MESSAGE_REPORTED(HttpStatus.OK, "MESSAGE_REPORTED", "신고가 정상적으로 접수되었습니다."),
+    CENSORED_SUCCESS(HttpStatus.OK, "CENSORED_SUCCESS", "메세지 신고 검열이 성공적으로 완료되었습니다."),
 
     // 예외 응답 코드
     CHANNEL_NOT_FOUND(HttpStatus.GONE, "CHANNEL_NOT_FOUND", "찾을 수 없는 채팅방입니다."),
@@ -31,7 +32,9 @@ public enum ChannelResponseCode {
     MATCH_FAILED(HttpStatus.CONFLICT, "MATCH_FAILED", "매칭에 실패했습니다."),
     TUNING_BAD_REQUEST(HttpStatus.BAD_REQUEST, "TUNING_BAD_REQUEST", "AI 서버에서 bad request 발생했습니다."),
     TUNING_NOT_FOUND_USER(HttpStatus.BAD_REQUEST, "TUNING_NOT_FOUND_USER", "AI 서버에서 사용자를 찾지 못했습니다."),
-    TUNING_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "TUNING_INTERNAL_SERVER_ERROR", "AI 서버 오류 발생했습니다.");
+    TUNING_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "TUNING_INTERNAL_SERVER_ERROR", "AI 서버 오류 발생했습니다."),
+    CENSORED_BAD_REQUEST(HttpStatus.BAD_REQUEST, "CENSORED_BAD_REQUEST", "올바르지 않은 메세지 신고 요청입니다."),
+    CENSORED_INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "CENSORED_INTERNAL_SERVER_ERROR", "메세지 신고 요청 과정에서 AI 서버 오류 발생했습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/batch/TuningReportGenerationJobConfig.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/batch/TuningReportGenerationJobConfig.java
@@ -3,7 +3,7 @@ package com.hertz.hertz_be.global.batch;
 import com.hertz.hertz_be.domain.channel.entity.SignalRoom;
 import com.hertz.hertz_be.domain.tuningreport.entity.TuningReport;
 import com.hertz.hertz_be.global.exception.AiServerBadRequestException;
-import com.hertz.hertz_be.global.infra.ai.dto.AiTuningReportGenerationRequest;
+import com.hertz.hertz_be.global.infra.ai.dto.request.AiTuningReportGenerationRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.batch.core.Job;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/batch/TuningReportGenerationProcessor.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/batch/TuningReportGenerationProcessor.java
@@ -2,9 +2,8 @@ package com.hertz.hertz_be.global.batch;
 
 import com.hertz.hertz_be.domain.channel.entity.SignalRoom;
 import com.hertz.hertz_be.domain.channel.repository.SignalMessageRepository;
-import com.hertz.hertz_be.domain.channel.repository.SignalRoomRepository;
 import com.hertz.hertz_be.domain.user.repository.UserRepository;
-import com.hertz.hertz_be.global.infra.ai.dto.AiTuningReportGenerationRequest;
+import com.hertz.hertz_be.global.infra.ai.dto.request.AiTuningReportGenerationRequest;
 import com.hertz.hertz_be.global.infra.ai.support.UserDataAssembler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.item.ItemProcessor;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/batch/TuningReportGenerationWriter.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/batch/TuningReportGenerationWriter.java
@@ -5,7 +5,7 @@ import com.hertz.hertz_be.domain.channel.repository.SignalRoomRepository;
 import com.hertz.hertz_be.domain.tuningreport.entity.TuningReport;
 import com.hertz.hertz_be.domain.tuningreport.repository.TuningReportRepository;
 import com.hertz.hertz_be.global.infra.ai.client.TuningAiClient;
-import com.hertz.hertz_be.global.infra.ai.dto.AiTuningReportGenerationRequest;
+import com.hertz.hertz_be.global.infra.ai.dto.request.AiTuningReportGenerationRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/config/WebClientConfig.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/config/WebClientConfig.java
@@ -8,18 +8,8 @@ import org.springframework.web.reactive.function.client.WebClient;
 @Configuration
 public class WebClientConfig {
 
-    @Value("${ai.server.ip}")
-    private String aiServerIp;
-
     @Bean
     public WebClient.Builder webClientBuilder() {
         return WebClient.builder();
-    }
-
-    @Bean
-    public WebClient tuningAiServerWebClient(WebClient.Builder builder) {
-        return builder
-                .baseUrl(aiServerIp)
-                .build();
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/infra/ai/client/TuningAiClient.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/infra/ai/client/TuningAiClient.java
@@ -21,15 +21,23 @@ public class TuningAiClient {
 
     @Value("${ai.tuningreport.ip}")
     private String AI_TUNING_REPORT_IP;
+
+    @Value("${ai.server.ip}")
+    private String AI_TUNING_SERVER_IP;
+
+    @Value("${ai.message.report.server.ip}")
+    private String AI_MESSAGE_REPORT_SERVER_IP;
+
     private final WebClient.Builder webClientBuilder;
-    private final WebClient tuningWebClient;
 
     public Map<String, Object> requestTuningReport(AiTuningReportGenerationRequest aiReportRequest) {
-        WebClient webClient = webClientBuilder.baseUrl(AI_TUNING_REPORT_IP).build();
-        String uri = "api/v2/report";
+        String uri = "/api/v2/report";
 
-        try{
-            return webClient.post()
+        try {
+            return webClientBuilder
+                    .baseUrl(AI_TUNING_REPORT_IP)
+                    .build()
+                    .post()
                     .uri(uri)
                     .contentType(MediaType.APPLICATION_JSON)
                     .bodyValue(aiReportRequest)
@@ -44,7 +52,10 @@ public class TuningAiClient {
     public Map<String, Object> requestTuningByCategory(Long userId, String category) {
         String uri = "/api/v3/tuning?userId=" + userId + "&category=" + category;
 
-        Map<String, Object> responseMap = tuningWebClient.get()
+        Map<String, Object> responseMap = webClientBuilder
+                .baseUrl(AI_TUNING_SERVER_IP)
+                .build()
+                .get()
                 .uri(uri)
                 .retrieve()
                 .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
@@ -65,7 +76,9 @@ public class TuningAiClient {
         String uri = "/api/v3/chat/report";
 
         try {
-            return tuningWebClient
+            return webClientBuilder
+                    .baseUrl(AI_MESSAGE_REPORT_SERVER_IP)
+                    .build()
                     .post()
                     .uri(uri)
                     .contentType(MediaType.APPLICATION_JSON)

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/infra/ai/client/TuningAiClient.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/infra/ai/client/TuningAiClient.java
@@ -1,9 +1,11 @@
 package com.hertz.hertz_be.global.infra.ai.client;
 
+import com.hertz.hertz_be.domain.channel.dto.request.v3.ChatReportRequestDto;
 import com.hertz.hertz_be.global.common.NewResponseCode;
 import com.hertz.hertz_be.global.exception.AiServerBadRequestException;
 import com.hertz.hertz_be.global.exception.BusinessException;
 import com.hertz.hertz_be.global.infra.ai.dto.request.AiTuningReportGenerationRequest;
+import com.hertz.hertz_be.global.infra.ai.dto.response.AiChatReportResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
@@ -57,5 +59,26 @@ public class TuningAiClient {
         }
 
         return responseMap;
+    }
+
+    public AiChatReportResponseDto sendChatReport(ChatReportRequestDto request) {
+        String uri = "/api/v3/chat/report";
+
+        try {
+            return tuningWebClient
+                    .post()
+                    .uri(uri)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono(AiChatReportResponseDto.class)
+                    .block();
+        } catch (Exception e) {
+            throw new BusinessException(
+                    NewResponseCode.AI_SERVER_ERROR.getCode(),
+                    NewResponseCode.AI_SERVER_ERROR.getHttpStatus(),
+                    "메세지 신고 과정에서 AI 서버 API 요청 오류 발생했습니다."
+            );
+        }
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/infra/ai/client/TuningAiClient.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/infra/ai/client/TuningAiClient.java
@@ -3,7 +3,7 @@ package com.hertz.hertz_be.global.infra.ai.client;
 import com.hertz.hertz_be.global.common.NewResponseCode;
 import com.hertz.hertz_be.global.exception.AiServerBadRequestException;
 import com.hertz.hertz_be.global.exception.BusinessException;
-import com.hertz.hertz_be.global.infra.ai.dto.AiTuningReportGenerationRequest;
+import com.hertz.hertz_be.global.infra.ai.dto.request.AiTuningReportGenerationRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/infra/ai/dto/object/AiSignalRoomDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/infra/ai/dto/object/AiSignalRoomDto.java
@@ -1,4 +1,4 @@
-package com.hertz.hertz_be.global.infra.ai.dto;
+package com.hertz.hertz_be.global.infra.ai.dto.object;
 
 
 import com.hertz.hertz_be.domain.channel.entity.SignalRoom;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/infra/ai/dto/request/AiTuningReportGenerationRequest.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/infra/ai/dto/request/AiTuningReportGenerationRequest.java
@@ -1,7 +1,8 @@
-package com.hertz.hertz_be.global.infra.ai.dto;
+package com.hertz.hertz_be.global.infra.ai.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.hertz.hertz_be.domain.channel.entity.SignalRoom;
+import com.hertz.hertz_be.global.infra.ai.dto.object.AiSignalRoomDto;
 
 import java.util.List;
 

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/infra/ai/dto/response/AiChatReportResponseDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/infra/ai/dto/response/AiChatReportResponseDto.java
@@ -1,0 +1,6 @@
+package com.hertz.hertz_be.global.infra.ai.dto.response;
+
+import java.util.Map;
+
+public record AiChatReportResponseDto (String code, Map<String, Object> data){
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/infra/ai/support/UserDataAssembler.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/infra/ai/support/UserDataAssembler.java
@@ -3,7 +3,7 @@ package com.hertz.hertz_be.global.infra.ai.support;
 import com.hertz.hertz_be.domain.interests.repository.UserInterestsRepository;
 import com.hertz.hertz_be.domain.user.entity.User;
 import com.hertz.hertz_be.domain.user.repository.UserRepository;
-import com.hertz.hertz_be.global.infra.ai.dto.AiTuningReportGenerationRequest;
+import com.hertz.hertz_be.global.infra.ai.dto.request.AiTuningReportGenerationRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/util/MessageCreatorUtil.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/util/MessageCreatorUtil.java
@@ -13,5 +13,9 @@ public class MessageCreatorUtil {
         return "이번 주 튜닝 결과가 왔어요! 👈확인하러가기";
     }
 
+    public static String createAlertMessageForInappropriateContent() {
+        return "부적절한 표현이 담긴 메시지를 전송하여 경고를 받았어요!";
+    }
+
     private MessageCreatorUtil() {}
 }

--- a/hertz-be/src/main/resources/application-prod.properties
+++ b/hertz-be/src/main/resources/application-prod.properties
@@ -15,7 +15,7 @@ springdoc.swagger-ui.path=/swagger-ui.html
 swagger.server-url=${SWAGGER_SERVER_URL}
 
 # Signal Domain
-matching.convert.delay-minutes=1440
+matching.convert.delay-minutes=360
 
 # Spring Batch
 spring.batch.job.enabled=true

--- a/hertz-be/src/main/resources/application.properties
+++ b/hertz-be/src/main/resources/application.properties
@@ -33,6 +33,7 @@ aes.secret=${AES_SECRET}
 # AI server IP address
 ai.server.ip=${AI_SERVER_IP}
 ai.tuningreport.ip=${AI_TUNING_REPORT_IP}
+ai.message.report.server.ip=${AI_MESSAGE_REPORT_SERVER_IP}
 
 # SameSite config
 is.local=${IS_LOCAL:false}


### PR DESCRIPTION
## 🔗 관련 이슈
- #322 

## ✏️ 변경 사항
- 메시지 신고 기능 구현
- AI 서버와 연동되는 메시지 신고 판단 로직 추가
- 신고 대상 사용자에게 경고 알림 전송 기능 추가
- 메시지 신고 관련 Request/Response DTO, 알림 엔티티 및 서비스 구현
- AI 서버 IP 구분 및 WebClient 세분화

---

## 📋 상세 설명

###  작업 배경
- 대화 중 상대방의 욕설 또는 비하 발언을 신고할 수 있도록 기능을 구현하기 위함
- AI 서버의 판단 결과를 기반으로 신고 처리 및 경고 알림 전송까지 자동화

###  주요 구현 내용
1. **신고 API 구현**
   - `/api/v3/chat/report` 엔드포인트로 메시지 신고 접수
   - `ChatReportRequestDto`, `AiChatReportResponseDto` 생성 및 매핑 처리

2. **AI 서버 연동**
   - 외부 AI 서버에 신고 메시지 전송 (`/api/v3/chat/report`)
   - 응답을 기반으로 신고 사유 판단 결과 수신

3. **경고 알림 전송**
   - AI 서버 응답이 "신고 사유에 해당함"일 경우, 해당 사용자에게 경고 알림 전송
   - 신규 알림 엔티티(`Alert`) 및 알림 전송 메서드 구현

4. **기타 개선**
   - `infra/ai/dto` 패키지 구조 세분화
   - `WebClient` 구성 통합 및 AI 서버 IP 설정 세분화

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 없음

## 📎 참고 자료 (선택)
- 없음
