### PR TITLE
[#325] Feat: 마이페이지 한 줄 소개 수정 API 구현

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/v3/UserController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/v3/UserController.java
@@ -1,5 +1,6 @@
 package com.hertz.hertz_be.domain.user.controller.v3;
 
+import com.hertz.hertz_be.domain.user.dto.request.v3.OneLineIntroductionRequestDto;
 import com.hertz.hertz_be.domain.user.dto.request.v3.RejectCategoryChangeRequestDto;
 import com.hertz.hertz_be.domain.user.dto.request.v3.UserInfoRequestDto;
 import com.hertz.hertz_be.domain.user.dto.response.v3.UserInfoResponseDto;
@@ -71,6 +72,23 @@ public class UserController {
                         UserResponseCode.CATEGORY_UPDATED_SUCCESSFULLY.getCode(),
                         UserResponseCode.CATEGORY_UPDATED_SUCCESSFULLY.getMessage(),
                         null
+                )
+        );
+    }
+
+    @PatchMapping("/users/{userId}")
+    @Operation(summary = "마이페이지 한 줄 소개 수정 API")
+    public ResponseEntity<ResponseDto<Void>> updateOneLineIntroduction(@RequestBody @Valid OneLineIntroductionRequestDto requestDto,
+                                                                       @PathVariable Long userId,
+                                                                       @AuthenticationPrincipal Long requesterId) {
+
+        userService.updateOneLineIntroduction(userId, requesterId, requestDto);
+
+        return ResponseEntity.ok(
+                new ResponseDto<>(
+                    UserResponseCode.PROFILE_UPDATED_SUCCESSFULLY.getCode(),
+                    UserResponseCode.PROFILE_UPDATED_SUCCESSFULLY.getMessage(),
+                    null
                 )
         );
     }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/request/v3/OneLineIntroductionRequestDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/request/v3/OneLineIntroductionRequestDto.java
@@ -1,0 +1,10 @@
+package com.hertz.hertz_be.domain.user.dto.request.v3;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class OneLineIntroductionRequestDto {
+    @NotNull
+    private String oneLineIntroduction;
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/entity/User.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/entity/User.java
@@ -122,4 +122,8 @@ public class User {
         };
     }
 
+    public void updateOneLineIntroduction(String newOneLineIntroduction) {
+        this.oneLineIntroduction = newOneLineIntroduction;
+    }
+
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/responsecode/UserResponseCode.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/responsecode/UserResponseCode.java
@@ -18,11 +18,13 @@ public enum UserResponseCode {
     NICKNAME_GENERATION_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "NICKNAME_GENERATION_TIMEOUT", "5초 내에 중복되지 않은 닉네임을 찾지 못했습니다."),
     WRONG_INVITATION_CODE(HttpStatus.BAD_REQUEST, "WRONG_INVITATION_CODE", "유효하지 않은 초대코드입니다."),
     CATEGORY_UPDATED_SUCCESSFULLY(HttpStatus.OK, "CATEGORY_UPDATED_SUCCESSFULLY", "사용자의 카테고리가 정상적으로 수정되었습니다."),
-    CATEGORY_IS_REJECTED(HttpStatus.BAD_REQUEST, "CATEGORY_IS_REJECTED", "상대방이 시그널을 받고 싶지 않은 카테고리입나다."),
+    CATEGORY_IS_REJECTED(HttpStatus.BAD_REQUEST, "CATEGORY_IS_REJECTED", "상대방이 시그널을 받고 싶지 않은 카테고리입니다."),
+    PROFILE_UPDATED_UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "PROFILE_UPDATED_UNAUTHORIZED", "자기 자신의 한 줄 소개만 수정할 수 있습니다."),
 
     // 성공 응답 코드
     USER_INFO_FETCH_SUCCESS(HttpStatus.OK, "USER_INFO_FETCH_SUCCESS", "사용자의 정보가 정상적으로 조회되었습니다."),
     OTHER_USER_INFO_FETCH_SUCCESS(HttpStatus.OK, "OTHER_USER_INFO_FETCH_SUCCESS", "상대방의 정보가 정상적으로 조회되었습니다."),
+    PROFILE_UPDATED_SUCCESSFULLY(HttpStatus.OK, "PROFILE_UPDATED_SUCCESSFULLY", "사용자 프로필이 정상적으로 수정되었습니다."),
     PROFILE_SAVED_SUCCESSFULLY(HttpStatus.CREATED, "PROFILE_SAVED_SUCCESSFULLY", "개인정보가 정상적으로 저장되었습니다."),
     NICKNAME_CREATED(HttpStatus.CREATED, "NICKNAME_CREATED", "닉네임이 성공적으로 생성되었습니다.");
 


### PR DESCRIPTION
## 🔗 관련 이슈
- #325 

## ✏️ 변경 사항
- 마이페이지 내 한 줄 소개를 수정할 수 있도록 기능 구현

## 📋 상세 설명
- `/api/v3/users` -> `/api/v3/users/{userId}`으로 API 명세 수정
   - 기존 url은 `JwtAuthenticationFilter`에서 `EXCLUDE_PATHS`로 관리되고 있었음
   - 마이페이지 관련해서는 뒤에 `PathVariable`로 관리하고 있었기 때문에 `{userId}`를 붙이는 것이 맞다고 판단

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- [API 명세서](https://docs.google.com/spreadsheets/d/19OiUmoIrlbFr20BKg5lpO1wkBBeqZ8rd7ZEcPmRCkho/edit?gid=461270540#gid=461270540) - `개인정보 수정 페이지 > 한줄 소개 수정` 참고
