### PR TITLE
Fix: Socket.io 메세지 전송 필드 수정

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/socketio/SocketIoController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/socketio/SocketIoController.java
@@ -121,10 +121,10 @@ public class SocketIoController {
     // 메세지 수신
     private void handleSendMessage(SocketIOClient client, SocketIoMessageRequest data, AckRequest ackSender) {
         Long senderId = getUserIdFromClient(client);
-        log.info("📨 메시지 수신: [{}] → 방 {}: {}", senderId, data.roomId(), data.message());
+        log.info("📨 메시지 수신: [{}] → 방 {}: {}, 전송 시각: {}", senderId, data.roomId(), data.message(), data.sendAt());
 
         // 저장 + 복호화 응답 생성
-        SocketIoMessageResponse response = messageService.processAndRespond(data.roomId(), senderId, data.message());
+        SocketIoMessageResponse response = messageService.processAndRespond(data.roomId(), senderId, data.message(), data.sendAt());
 
         String roomKey = "room-" + data.roomId();
         server.getRoomOperations(roomKey).sendEvent("receive_message", response);

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/socketio/dto/SocketIoMessageRequest.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/socketio/dto/SocketIoMessageRequest.java
@@ -1,6 +1,9 @@
 package com.hertz.hertz_be.global.socketio.dto;
 
+import java.time.LocalDateTime;
+
 public record SocketIoMessageRequest(
         Long roomId,
-        String message
+        String message,
+        LocalDateTime sendAt
 ) {}


### PR DESCRIPTION
## 🔗 관련 이슈

## ✏️ 변경 사항
- socket.io 내 메세지 전송 필드 추가 

## 📋 상세 설명
- 메세지 전송 시 전송 시각에 대한 정보가 없어 클라이언트에서 Invalid Date 라고 뜨는 현상 발생
- sendAt 필드도 함께 입력받도록 수정
```
data: {
    "roomId": 1, 
    "message": "안녕!",
    "sendAt": "2025-06-24T12:00:00"
}
``` 

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.
