### PR TITLE
Fix: socket.io 메세지 읽음 처리 관련 트랜잭션 오류 처리

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/SignalMessageRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/SignalMessageRepository.java
@@ -64,7 +64,7 @@ public interface SignalMessageRepository extends JpaRepository<SignalMessage, Lo
 
     int countBySignalRoom(SignalRoom signalRoom);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("""
     UPDATE SignalMessage sm
     SET sm.isRead = true

--- a/hertz-be/src/main/resources/application-dev.properties
+++ b/hertz-be/src/main/resources/application-dev.properties
@@ -21,3 +21,5 @@ matching.convert.delay-minutes=1
 spring.batch.job.enabled=true
 spring.batch.jdbc.initialize-schema=always
 logging.level.org.springframework.batch=DEBUG
+logging.level.org.springframework.transaction.interceptor=TRACE
+


### PR DESCRIPTION
## 🔗 관련 이슈

## ✏️ 변경 사항
- socket.io 메세지 읽음 처리 관련 트랜잭션 오류 처리

## 📋 상세 설명
- repository 쿼리에 `@Modifying(clearAutomatically = true)` 설정 추가
- JPA 캐시(영속성 컨텍스트)에 남아 있는 이전 엔티티 상태와 충돌 날 수 있기 때문

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.
