### PR TITLE
Fix: Transactional의 readOnly = true 값 제거

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v1/ChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v1/ChannelService.java
@@ -436,7 +436,7 @@ public class ChannelService {
         return new ChannelListResponseDto(list, result.getNumber(), result.getSize(), result.isLast());
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public ChannelRoomResponseDto getChannelRoom(Long roomId, Long userId, int page, int size) {
         SignalRoom room = signalRoomRepository.findById(roomId)
                 .orElseThrow(() -> new BusinessException(

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v3/ChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v3/ChannelService.java
@@ -88,7 +88,7 @@ public class ChannelService {
         return new ChannelListResponseDto(list, result.getNumber(), result.getSize(), result.isLast());
     }
 
-    @Transactional(readOnly = true)
+    @Transactional
     public ChannelRoomResponseDto getChannelRoom(Long roomId, Long userId, int page, int size) {
         SignalRoom room = signalRoomRepository.findById(roomId)
                 .orElseThrow(() -> new BusinessException(


### PR DESCRIPTION
## 🔗 관련 이슈

## ✏️ 변경 사항
- ChannelService > getChannelRoom 메서드 내 @Transactional 의 readOnly = true 값을 제거

## 📋 상세 설명
- getChannelRoom 메서드 내 쓰기 작업이 이뤄지고 있는데, @Transactional 어노테이션에 readOnly = true 옵션이 붙어있어 오류가 발생하고 있었음
```
2025-07-01 01:20:24.554 | [DB 에러] JDBC exception executing SQL [update signal_message sm1_0 set is_read=1 where sm1_0.signal_room_id=?] [Connection is read-only. Queries leading to data modification are not allowed] [n/a]
2025-07-01 01:20:24.552 | Completing transaction for [com.hertz.hertz_be.domain.channel.service.v1.ChannelService.getChannelRoom] after exception: org.springframework.orm.jpa.JpaSystemException: JDBC exception executing SQL [update signal_message sm1_0 set is_read=1 where sm1_0.signal_room_id=?] [Connection is read-only. Queries leading to data modification are not allowed] [n/a]
2025-07-01 01:20:24.550 | Connection is read-only. Queries leading to data modification are not allowed
2025-07-01 01:20:24.549 | SQL Error: 0, SQLState: S1009
```

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.
