### PR TITLE
Fix: socket.io 메세지 읽음 처리 관련 트랜잭션 내 afterCommit 처리, socket 서버 구동 예외 처리

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/socketio/SocketIoController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/socketio/SocketIoController.java
@@ -101,10 +101,13 @@ public class SocketIoController {
     // 메세지 읽음 처리
     private void handleMarkAsRead(SocketIOClient client, SocketIoMessageMarkRequest data, AckRequest ackSender) {
         Long userId = getUserIdFromClient(client);
-        messageService.markMessageAsRead(data.roomId(), userId);
+        Long roomId = data.roomId();
+
+        log.info("✅ 읽음 처리 요청: userId={}, roomId={}", userId, roomId);
+
+        // DB 읽음 처리 + afterCommit에서 웹소켓 응답 브로드캐스트
+        messageService.markMessageAsRead(roomId, userId);
     }
-
-
 
     public int getConnectedUserCount() {
         return connectedUsers.size();

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/socketio/SocketIoServerRunner.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/socketio/SocketIoServerRunner.java
@@ -6,8 +6,6 @@ import jakarta.annotation.PreDestroy;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
-import java.net.BindException;
-
 @Component
 @Slf4j
 public class SocketIoServerRunner {
@@ -24,7 +22,11 @@ public class SocketIoServerRunner {
             server.start();
             log.info("✅ Socket.IO 서버 시작됨 (port={})", server.getConfiguration().getPort());
         } catch (Exception e) {
-            log.error("❌ Socket.IO 서버 시작 중 예외 발생", e);
+            if (e.getCause() instanceof java.net.BindException) {
+                log.warn("⚠️ 이미 해당 포트로 Socket.IO 서버가 실행 중입니다. 무시하고 진행합니다.");
+            } else {
+                log.error("❌ Socket.IO 서버 시작 중 예외 발생", e);
+            }
         }
     }
 

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/socketio/SocketIoService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/socketio/SocketIoService.java
@@ -1,5 +1,6 @@
 package com.hertz.hertz_be.global.socketio;
 
+import com.corundumstudio.socketio.SocketIOServer;
 import com.hertz.hertz_be.domain.channel.entity.SignalMessage;
 import com.hertz.hertz_be.domain.channel.entity.SignalRoom;
 import com.hertz.hertz_be.domain.channel.responsecode.ChannelResponseCode;
@@ -9,24 +10,29 @@ import com.hertz.hertz_be.domain.user.entity.User;
 import com.hertz.hertz_be.domain.user.repository.UserRepository;
 import com.hertz.hertz_be.domain.user.responsecode.UserResponseCode;
 import com.hertz.hertz_be.global.exception.BusinessException;
+import com.hertz.hertz_be.global.socketio.dto.SocketIoMessageMarkResponse;
 import com.hertz.hertz_be.global.socketio.dto.SocketIoMessageResponse;
 import com.hertz.hertz_be.global.util.AESUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.time.LocalDateTime;
 
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class SocketIoService {
 
     private final SignalRoomRepository signalRoomRepository;
     private final SignalMessageRepository signalMessageRepository;
     private final UserRepository userRepository;
     private final AESUtil aesUtil;
+    private final SocketIOServer server;
 
     @Transactional
     public SignalMessage saveMessage(Long roomId, Long senderId, String plainText, LocalDateTime sendAt) {
@@ -62,9 +68,20 @@ public class SocketIoService {
         return SocketIoMessageResponse.from(saved, decrypted);
     }
 
-    @Transactional(readOnly = false, propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     public void markMessageAsRead(Long roomId, Long userId) {
         signalMessageRepository.markUnreadMessagesAsRead(roomId, userId);
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                SocketIoMessageMarkResponse response = new SocketIoMessageMarkResponse(roomId, userId, LocalDateTime.now());
+                server.getRoomOperations("room-" + roomId)
+                        .sendEvent("mark_as_read", response);
+
+                log.info("📡 읽음 상태 전송 완료: {}", response);
+            }
+        });
     }
 
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/socketio/dto/SocketIoMessageMarkResponse.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/socketio/dto/SocketIoMessageMarkResponse.java
@@ -1,0 +1,14 @@
+package com.hertz.hertz_be.global.socketio.dto;
+
+
+import java.time.LocalDateTime;
+
+public record SocketIoMessageMarkResponse(
+        Long roomId,
+        Long userId,
+        LocalDateTime readAt
+) {
+    public static SocketIoMessageMarkResponse from(Long roomId, Long userId) {
+        return new SocketIoMessageMarkResponse(roomId, userId, LocalDateTime.now());
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

## ✏️ 변경 사항
- socket.io 메세지 읽음 처리 관련 트랜잭션 처리
- socket.io 서버 구동 시 예외 처리 작업 추가

## 📋 상세 설명
- Transaction 관련 처리
   - 비동기로 동작하는 웹소켓과 트랜잭션이 겹치지 않도록 알림 관련 로직에 대해 afterCommit 처리하여 커밋 완료 후 실행될 수 있게 수정
   - write 작업이 들어가지 않은 메서드에 readOnly = true로 하여 트랜잭션 접근 최소화
- socket 서버 구동 시 이미 실행 중일 경우, 또 구동시키지 않도록 예외 처리

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.
