### PR TITLE
Refactor: socket.io receive_message 내 sendAt 날짜 포맷 변경

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/socketio/dto/SocketIoMessageResponse.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/socketio/dto/SocketIoMessageResponse.java
@@ -2,13 +2,13 @@ package com.hertz.hertz_be.global.socketio.dto;
 
 import com.hertz.hertz_be.domain.channel.entity.SignalMessage;
 
-import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 public record SocketIoMessageResponse(
         Long roomId,
         Long senderId,
         String message,
-        LocalDateTime sendAt,
+        String sendAt,
         Long messageId
 ){
     public static SocketIoMessageResponse from (SignalMessage message) {
@@ -16,7 +16,7 @@ public record SocketIoMessageResponse(
                 message.getSignalRoom().getId(),
                 message.getSenderUser().getId(),
                 message.getMessage(),
-                message.getSendAt(),
+                message.getSendAt().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
                 message.getId()
         );
     }
@@ -26,7 +26,7 @@ public record SocketIoMessageResponse(
                 message.getSignalRoom().getId(),
                 message.getSenderUser().getId(),
                 decryptMessage,
-                message.getSendAt(),
+                message.getSendAt().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
                 message.getId()
         );
     }


### PR DESCRIPTION
## 🔗 관련 이슈

## ✏️ 변경 사항
- socket.io `receive_message` 이벤트 내 `sendAt` 날짜 포맷 변경

## 📋 상세 설명
- Netty-Socket IO 특성상 Jackson ObjectMapper를 써서 직렬화 과정을 거치는데, 현 소스에서는 ObjectMapper에 커스텀(날짜 포맷 지정)이 되어있지 않아 기본 설정으로 전달되고 있었음
- `message.getSendAt().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)` 와 같은 형식으로 지정하여 response 보내도록 수정함

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.
