### PR TITLE
Fix: socket.io 채팅방 내 대화 상대가 잘못 인식되는 오류 조치

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/socketio/SocketIoController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/socketio/SocketIoController.java
@@ -6,6 +6,7 @@ import com.corundumstudio.socketio.SocketIOServer;
 import com.corundumstudio.socketio.listener.ConnectListener;
 import com.corundumstudio.socketio.listener.DisconnectListener;
 import com.hertz.hertz_be.domain.channel.repository.SignalRoomRepository;
+import com.hertz.hertz_be.domain.user.repository.UserRepository;
 import com.hertz.hertz_be.global.socketio.dto.SocketIoMessageMarkRequest;
 import com.hertz.hertz_be.global.socketio.dto.SocketIoMessageRequest;
 import com.hertz.hertz_be.global.socketio.dto.SocketIoMessageResponse;
@@ -31,13 +32,14 @@ public class SocketIoController {
     private final JwtTokenProvider jwtTokenProvider;
     private final SocketIoTokenUtil socketIoTokenUtil;
     private final SignalRoomRepository signalRoomRepository;
+    private final UserRepository userRepository;
     private final Map<Long, UUID> connectedUsers = new ConcurrentHashMap<>();
 
     @EventListener(ApplicationReadyEvent.class)
     public void init() {
         server.addConnectListener(onConnected());
         server.addEventListener("send_message", SocketIoMessageRequest.class, this::handleSendMessage);
-        server.addEventListener("mark_as_read", SocketIoMessageMarkRequest.class, this::handleMarkAsRead);
+        //server.addEventListener("mark_as_read", SocketIoMessageMarkRequest.class, this::handleMarkAsRead);
         server.addDisconnectListener(onDisconnected());
     }
 
@@ -47,53 +49,54 @@ public class SocketIoController {
                 String cookie = client.getHandshakeData().getHttpHeaders().get("cookie");
 
                 if (cookie == null) {
-                    log.warn("❗ 연결 시 쿠키 없음 → 연결 종료: sessionId={}", client.getSessionId());
+                    log.warn("[Connect Fail] 쿠키 없음 → 연결 종료: sessionId={}", client.getSessionId());
                     client.disconnect();
                     return;
                 }
-
-                log.debug("🍪 수신한 쿠키: {}", cookie);
 
                 String refreshToken = socketIoTokenUtil.extractCookie(cookie, "refreshToken");
 
                 if (refreshToken == null || refreshToken.isBlank()) {
-                    log.warn("❗ refreshToken 추출 실패 → 연결 종료: sessionId={}", client.getSessionId());
+                    log.warn("[Connect Fail] refreshToken 추출 실패 → 연결 종료: sessionId={}", client.getSessionId());
                     client.disconnect();
                     return;
                 }
 
-                log.debug("🔐 추출된 refreshToken: {}", refreshToken);
-
                 Long userId = null;
                 try {
                     userId = jwtTokenProvider.getUserIdFromToken(refreshToken);
-                    log.info("🪪 JWT 파싱 성공 → userId={}", userId);
+                    if(!userRepository.existsById(userId)) {
+                        log.warn("[Connect Fail] 존재하지 않는 userId={} → 연결 종료: sessionId={}", userId, client.getSessionId());
+                        client.disconnect();
+                        return;
+                    }
                 } catch (Exception jwtEx) {
-                    log.error("❌ JWT 토큰 파싱 실패: {}, 토큰={}", jwtEx.getMessage(), refreshToken);
+                    log.error("[Connect Fail] JWT 토큰 파싱 실패: {}, 토큰={}", jwtEx.getMessage(), refreshToken);
                     client.disconnect();
                     return;
                 }
 
                 client.set("userId", userId);
-                client.sendEvent("init_user", userId);
 
                 List<Long> roomIds = signalRoomRepository.findRoomIdsByUserId(userId);
-                log.info("📦 userId={} 의 채팅방 목록: {}", userId, roomIds);
+                client.set("roomIds", roomIds); // 채팅방 목록 저장
 
-                for (Long roomId : roomIds) {
-                    try {
-                        client.joinRoom("room-" + roomId);
-                        log.info("🚀 userId={} → room-{} 참가 성공", userId, roomId);
-                    } catch (Exception joinEx) {
-                        log.error("❌ userId={} → room-{} 참가 실패: {}", userId, roomId, joinEx.getMessage());
-                    }
-                }
+//                for (Long roomId : roomIds) {
+//                    try {
+//                        client.joinRoom("room-" + roomId);
+//                        log.info("[Connect Success] userId={} → room-{} 참가 성공", userId, roomId);
+//                    } catch (Exception joinEx) {
+//                        log.error("[Connect Fail] userId={} → room-{} 참가 실패: {}", userId, roomId, joinEx.getMessage());
+//                    }
+//                }
+
+                client.sendEvent("init_user", userId);
 
                 connectedUsers.put(userId, client.getSessionId());
-                log.info("✅ userId [{}] 접속 완료, 현재 접속자 수={}", userId, getConnectedUserCount());
+                log.info("[Connect Success] userId [{}] 접속 완료, 현재 접속자 수={}", userId, getConnectedUserCount());
 
             } catch (Exception e) {
-                log.error("❌ 연결 처리 중 예외 발생: {}", e.getMessage(), e);
+                log.error("[Connect Fail] 연결 처리 중 예외 발생: {}", e.getMessage(), e);
                 client.disconnect();
             }
         };
@@ -102,12 +105,17 @@ public class SocketIoController {
     private DisconnectListener onDisconnected() {
         return client -> {
             Long userId = getUserIdFromClient(client);
-            String sessionId = client.getSessionId().toString();
-            log.warn("🔌 disconnect 발생! sessionId={}, userId={}", sessionId, userId);
+            @SuppressWarnings("unchecked")
+            List<Long> roomIds = (List<Long>) client.get("roomIds");
+            Long joinRoomId = client.get("joinRoomId");
+
+            if(roomIds != null && roomIds.contains(joinRoomId)) {
+                client.leaveRoom("room-" + joinRoomId);
+            }
 
             if (userId != null) {
                 connectedUsers.remove(userId);
-                log.info("❌ userId [{}] 연결 종료, 현재 접속자 수={}", userId, getConnectedUserCount());
+                log.info("[Disconnect Success] userId={}, 연결 종료, 현재 접속자 수={}", userId, getConnectedUserCount());
             }
         };
     }
@@ -115,13 +123,23 @@ public class SocketIoController {
     // 메세지 수신
     private void handleSendMessage(SocketIOClient client, SocketIoMessageRequest data, AckRequest ackSender) {
         Long senderId = getUserIdFromClient(client);
-        log.info("📨 메시지 수신: [{}] → 방 {}: {}, 전송 시각: {}", senderId, data.roomId(), data.message(), data.sendAt());
+        Long roomId = data.roomId();
+
+        @SuppressWarnings("unchecked")
+        List<Long> roomIds = (List<Long>) client.get("roomIds");
+
+        if(roomIds == null || !roomIds.contains(roomId)) {
+            log.warn("[Invalid RoomID] [{}]는 [{}} roomID에 접근 권한 없음", senderId, roomId);
+            return;
+        } else {
+            client.set("joinRoomId", roomId);
+            client.joinRoom("room-" + roomId);
+            log.info("[JoinRoom Success] userId={} → room-{} 참가 성공", client.get("userId"), roomId);
+        }
 
         // 저장 + 복호화 응답 생성
         SocketIoMessageResponse response = messageService.processAndRespond(data.roomId(), senderId, data.message(), data.sendAt());
-
-        String roomKey = "room-" + data.roomId();
-        server.getRoomOperations(roomKey).sendEvent("receive_message", response);
+        server.getRoomOperations("room-" + data.roomId()).sendEvent("receive_message", response);
     }
 
     // 메세지 읽음 처리


### PR DESCRIPTION
## 🔗 관련 이슈
- #350 

## ✏️ 변경 사항
- socket.io 통신 연결 후 모든 채팅방에 대한 입장(joinRoom) 처리 -> 클라이언트에서 전달되는 roomId에 대해서만 입장 처리 하는 로직으로 변경

## 📋 상세 설명
- 기존에는 connect 성공 후, 해당 사용자가 참여하고 있는 모든 채팅방에 대해 한 번에 입장처리를 하였음
- 위로 인해 아래와 같은 문제가 발생
   - [A, B], [B, C], [A, C] 로 이루어진 1:1 채팅방들이 존재한다는 가정.
   - (A -> B), (B -> A) 로 메세지 수신은 정상적으로 동작했으나 (C -> A) 로 새로운 연결을 하고 C가 메세지를 보내면 아직 A가 B와의 채팅방에 연결되어 있는데도 불구하고 B가 메세지를 보낸 것처럼 표시됨
- connect 후 모든 채팅방에 대해 한 번에 입장 처리를 하지 않고, 클라이언트에서 전달되는 roomId에 대해 단일 입장 처리
- 채팅방 퇴장 시 해당 방에 대한 단일 퇴장 처리
- 실제로 채팅이 오가지 않는 방에 대해서도 입장 처리를 하여 socket.io 내부적으로 꼬인 것으로 예상

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.
