### PR TITLE
[#324] Feat: 특정 사용자의 개인정보 및 취향반환 v3 API 구현

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/v2/UserController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/v2/UserController.java
@@ -24,7 +24,7 @@ public class UserController {
      * @author daisy.lee
      */
     @GetMapping("/v2/users/{userId}")
-    @Operation(summary = "사용자 정보 조회")
+    @Operation(summary = "사용자 정보 조회 API")
     public ResponseEntity<ResponseDto<UserProfileDTO>> getUserProfile(@PathVariable Long userId,
                                                                       @AuthenticationPrincipal Long id) {
         UserProfileDTO response = userService.getUserProfile(userId, id);

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/v3/UserController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/controller/v3/UserController.java
@@ -3,6 +3,7 @@ package com.hertz.hertz_be.domain.user.controller.v3;
 import com.hertz.hertz_be.domain.user.dto.request.v3.OneLineIntroductionRequestDto;
 import com.hertz.hertz_be.domain.user.dto.request.v3.RejectCategoryChangeRequestDto;
 import com.hertz.hertz_be.domain.user.dto.request.v3.UserInfoRequestDto;
+import com.hertz.hertz_be.domain.user.dto.response.v3.UserProfileDTO;
 import com.hertz.hertz_be.domain.user.dto.response.v3.UserInfoResponseDto;
 import com.hertz.hertz_be.domain.user.responsecode.UserResponseCode;
 import com.hertz.hertz_be.domain.user.service.v3.UserService;
@@ -91,6 +92,29 @@ public class UserController {
                     null
                 )
         );
+    }
+
+    @GetMapping("/users/{userId}")
+    @Operation(summary = "사용자 정보 조회 API")
+    public ResponseEntity<ResponseDto<UserProfileDTO>> getUserProfile(@PathVariable Long userId,
+                                                                      @AuthenticationPrincipal Long id) {
+        UserProfileDTO response = userService.getUserProfile(userId, id);
+
+        if("ME".equals(response.getRelationType())) {
+            return ResponseEntity.ok(
+                    new ResponseDto<>(
+                            UserResponseCode.USER_INFO_FETCH_SUCCESS.getCode(),
+                            UserResponseCode.USER_INFO_FETCH_SUCCESS.getMessage(),
+                            response)
+            );
+        } else {
+            return ResponseEntity.ok(
+                    new ResponseDto<>(
+                            UserResponseCode.OTHER_USER_INFO_FETCH_SUCCESS.getCode(),
+                            UserResponseCode.OTHER_USER_INFO_FETCH_SUCCESS.getMessage(),
+                            response)
+            );
+        }
     }
 
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/response/v3/InterestsDTO.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/response/v3/InterestsDTO.java
@@ -1,0 +1,23 @@
+package com.hertz.hertz_be.domain.user.dto.response.v3;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InterestsDTO {
+    private List<String> personality;
+    private List<String> preferredPeople;
+    private List<String> currentInterests;
+    private List<String> favoriteFoods;
+    private List<String> likedSports;
+    private List<String> pets;
+    private List<String> selfDevelopment;
+    private List<String> hobbies;
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/response/v3/KeywordsDTO.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/response/v3/KeywordsDTO.java
@@ -1,0 +1,17 @@
+package com.hertz.hertz_be.domain.user.dto.response.v3;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class KeywordsDTO {
+    private String mbti;
+    private String religion;
+    private String smoking;
+    private String drinking;
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/response/v3/UserProfileDTO.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/user/dto/response/v3/UserProfileDTO.java
@@ -1,0 +1,31 @@
+package com.hertz.hertz_be.domain.user.dto.response.v3;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.hertz.hertz_be.domain.user.dto.response.v3.InterestsDTO;
+import com.hertz.hertz_be.domain.user.dto.response.v3.KeywordsDTO;
+import com.hertz.hertz_be.domain.user.entity.enums.Gender;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserProfileDTO {
+    private String profileImage;
+    private String nickname;
+    private Gender gender;
+    private String oneLineIntroduction;
+    private String relationType;
+
+    private KeywordsDTO keywords;
+    private InterestsDTO interests;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private InterestsDTO sameInterests;
+
+    private Boolean friendAllowed;
+    private Boolean coupleAllowed;
+
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- #324 

## ✏️ 변경 사항
- v2 -> v3 카테고리 도입으로 인한 마이페이지 조회 필드 수정

## 📋 상세 설명
- 마이페이지에서는 본인의 freindAllowed, coupleAllowed 값 조회
- 상대방 상세 정보 페이지 조회에서는 두 필드 모두 null로 반환

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.
