### PR TITLE
Hotfix: 튜닝 리포트 리액션 토글 시 발생하던 Deadlock 및 LockTimeout 해결

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/repository/TuningReportRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/repository/TuningReportRepository.java
@@ -2,12 +2,11 @@ package com.hertz.hertz_be.domain.tuningreport.repository;
 
 import com.hertz.hertz_be.domain.channel.entity.SignalRoom;
 import com.hertz.hertz_be.domain.tuningreport.entity.TuningReport;
-import io.lettuce.core.dynamic.annotation.Param;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -40,5 +39,11 @@ public interface TuningReportRepository extends JpaRepository<TuningReport, Long
 
     @Modifying
     @Query("UPDATE TuningReport t SET t.deletedAt = CURRENT_TIMESTAMP WHERE t.id = :id")
-    void softDeleteById(@Param("id") Long id);
+    void softDeleteById(@org.springframework.data.repository.query.Param("id") Long id);
+
+    // 교착 상태 예방용 비관적 락 메서드 추가
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT r FROM TuningReport r WHERE r.id = :id")
+    Optional<TuningReport> findWithLockById(@org.springframework.data.repository.query.Param("id") Long id);
+
 }


### PR DESCRIPTION
- TuningReportRepository에 PESSIMISTIC_WRITE 락 메서드(findWithLockById) 추가
- TuningReportReactionService에서 해당 메서드 사용하여 교착 상태 방지
- @Retryable에 Deadlock 및 Lock 관련 예외(CannotAcquireLockException 등) 추가
- 리액션 수치 업데이트 및 리액션 row 조작 순서를 트랜잭션 내에서 명확히 분리
- 잘못된 Param import (lettuce) 제거 및 Spring Data JPA용으로 정리