### PR TITLE
[#363] Feat: 튜낭 레포트의 Get/Put API 로직을 Redis를 통한 캐시 적용

### DIFF
--- a/hertz-be/build.gradle
+++ b/hertz-be/build.gradle
@@ -34,6 +34,7 @@ sourceSets {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-cache'
+	implementation 'org.redisson:redisson-spring-boot-starter:3.23.5'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
 	implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/hertz-be/build.gradle
+++ b/hertz-be/build.gradle
@@ -34,6 +34,7 @@ sourceSets {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-cache'
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 	implementation 'org.redisson:redisson-spring-boot-starter:3.23.5'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/controller/TuningReportController.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/controller/TuningReportController.java
@@ -35,14 +35,15 @@ public class TuningReportController {
      */
     @GetMapping("/reports")
     @Operation(summary = "튜닝 리포트 목록 반환 API")
-    public ResponseEntity<ResponseDto<TuningReportListResponse>> createTuningReport (@RequestParam(defaultValue = "0") int page,
-                                                                                     @RequestParam(defaultValue = "10") int size,
-                                                                                     @RequestParam(defaultValue = "LATEST") TuningReportSortType sort,
-                                                                                     @AuthenticationPrincipal Long userId) {
-
+    public ResponseEntity<ResponseDto<TuningReportListResponse>> createTuningReport(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "LATEST") TuningReportSortType sort,
+            @AuthenticationPrincipal Long userId
+    ) {
         TuningReportListResponse response = tuningReportService.getReportList(userId, page, size, sort);
 
-        if(!response.list().isEmpty()) {
+        if (!response.getList().isEmpty()) {
             return ResponseEntity.ok(new ResponseDto<>(
                     ResponseCode.REPORT_LIST_FETCH_SUCCESS,
                     "튜닝 리포트가 정상적으로 조회되었습니다.",
@@ -55,8 +56,6 @@ public class TuningReportController {
                     null
             ));
         }
-
-
     }
 
     /**

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/dto/response/TuningReportListResponse.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/dto/response/TuningReportListResponse.java
@@ -20,7 +20,7 @@ public class TuningReportListResponse {
     private int pageNumber;
     private int pageSize;
 
-    @JsonProperty("isLast") // JSON에선 isLast 유지
+    @JsonProperty("isLast")
     private boolean isLast;
 
     @Getter
@@ -55,13 +55,27 @@ public class TuningReportListResponse {
     @Getter
     @Setter
     @NoArgsConstructor
-    @AllArgsConstructor
     public static class Reactions {
         private int celebrate;
         private int thumbsUp;
         private int laugh;
         private int eyes;
         private int heart;
+
+        @JsonCreator
+        public Reactions(
+                @JsonProperty("celebrate") int celebrate,
+                @JsonProperty("thumbsUp") int thumbsUp,
+                @JsonProperty("laugh") int laugh,
+                @JsonProperty("eyes") int eyes,
+                @JsonProperty("heart") int heart
+        ) {
+            this.celebrate = celebrate;
+            this.thumbsUp = thumbsUp;
+            this.laugh = laugh;
+            this.eyes = eyes;
+            this.heart = heart;
+        }
 
         public void increase(ReactionType type) {
             switch (type) {
@@ -87,13 +101,27 @@ public class TuningReportListResponse {
     @Getter
     @Setter
     @NoArgsConstructor
-    @AllArgsConstructor
     public static class MyReactions {
         private boolean celebrate;
         private boolean thumbsUp;
         private boolean laugh;
         private boolean eyes;
         private boolean heart;
+
+        @JsonCreator
+        public MyReactions(
+                @JsonProperty("celebrate") boolean celebrate,
+                @JsonProperty("thumbsUp") boolean thumbsUp,
+                @JsonProperty("laugh") boolean laugh,
+                @JsonProperty("eyes") boolean eyes,
+                @JsonProperty("heart") boolean heart
+        ) {
+            this.celebrate = celebrate;
+            this.thumbsUp = thumbsUp;
+            this.laugh = laugh;
+            this.eyes = eyes;
+            this.heart = heart;
+        }
 
         public void set(ReactionType type, boolean value) {
             switch (type) {

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/dto/response/TuningReportListResponse.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/dto/response/TuningReportListResponse.java
@@ -1,37 +1,108 @@
 package com.hertz.hertz_be.domain.tuningreport.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.hertz.hertz_be.domain.tuningreport.entity.enums.ReactionType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
 import java.time.LocalDateTime;
 import java.util.List;
 
-public record TuningReportListResponse(
-        List<ReportItem> list,
-        int pageNumber,
-        int pageSize,
-        boolean isLast
-) {
-        public record ReportItem(
-                LocalDateTime createdDate,
-                Long reportId,
-                String title,
-                String content,
-                Reactions reactions,
-                MyReactions myReactions
-        ) {
-            public record Reactions(
-                    int celebrate,
-                    int thumbsUp,
-                    int laugh,
-                    int eyes,
-                    int heart
-            ) {}
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class TuningReportListResponse {
+    private List<ReportItem> list;
+    private int pageNumber;
+    private int pageSize;
 
-            public record MyReactions(
-                    boolean celebrate,
-                    boolean thumbsUp,
-                    boolean laugh,
-                    boolean eyes,
-                    boolean heart
-            ) {}
+    @JsonProperty("isLast") // JSON에선 isLast 유지
+    private boolean isLast;
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class ReportItem {
+        private LocalDateTime createdDate;
+        private Long reportId;
+        private String title;
+        private String content;
+        private Reactions reactions;
+        private MyReactions myReactions;
+
+        @JsonCreator
+        public ReportItem(
+                @JsonProperty("createdDate") LocalDateTime createdDate,
+                @JsonProperty("reportId") Long reportId,
+                @JsonProperty("title") String title,
+                @JsonProperty("content") String content,
+                @JsonProperty("reactions") Reactions reactions,
+                @JsonProperty("myReactions") MyReactions myReactions
+        ) {
+            this.createdDate = createdDate;
+            this.reportId = reportId;
+            this.title = title;
+            this.content = content;
+            this.reactions = reactions;
+            this.myReactions = myReactions;
         }
     }
 
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Reactions {
+        private int celebrate;
+        private int thumbsUp;
+        private int laugh;
+        private int eyes;
+        private int heart;
+
+        public void increase(ReactionType type) {
+            switch (type) {
+                case CELEBRATE -> celebrate++;
+                case THUMBS_UP -> thumbsUp++;
+                case LAUGH -> laugh++;
+                case EYES -> eyes++;
+                case HEART -> heart++;
+            }
+        }
+
+        public void decrease(ReactionType type) {
+            switch (type) {
+                case CELEBRATE -> celebrate = Math.max(0, celebrate - 1);
+                case THUMBS_UP -> thumbsUp = Math.max(0, thumbsUp - 1);
+                case LAUGH -> laugh = Math.max(0, laugh - 1);
+                case EYES -> eyes = Math.max(0, eyes - 1);
+                case HEART -> heart = Math.max(0, heart - 1);
+            }
+        }
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MyReactions {
+        private boolean celebrate;
+        private boolean thumbsUp;
+        private boolean laugh;
+        private boolean eyes;
+        private boolean heart;
+
+        public void set(ReactionType type, boolean value) {
+            switch (type) {
+                case CELEBRATE -> celebrate = value;
+                case THUMBS_UP -> thumbsUp = value;
+                case LAUGH -> laugh = value;
+                case EYES -> eyes = value;
+                case HEART -> heart = value;
+            }
+        }
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/entity/TuningReport.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/entity/TuningReport.java
@@ -1,6 +1,7 @@
 package com.hertz.hertz_be.domain.tuningreport.entity;
 
 import com.hertz.hertz_be.domain.channel.entity.SignalRoom;
+import com.hertz.hertz_be.domain.tuningreport.dto.response.TuningReportListResponse;
 import com.hertz.hertz_be.domain.tuningreport.entity.enums.ReactionType;
 import jakarta.persistence.*;
 import lombok.*;
@@ -13,8 +14,6 @@ import java.util.Map;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-// @SQLDelete(sql = "UPDATE tuning_report SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
-//@Where(clause = "deleted_at IS NULL")
 @Table(name = "tuning_report")
 @Builder
 public class TuningReport {
@@ -119,5 +118,23 @@ public class TuningReport {
                 .isVisible(false)
                 .createdAt(LocalDateTime.now())
                 .build();
+    }
+
+    public void updateReactionsFrom(TuningReportListResponse.Reactions reactions) {
+        this.reactionCelebrate = reactions.getCelebrate();
+        this.reactionThumbsUp = reactions.getThumbsUp();
+        this.reactionLaugh = reactions.getLaugh();
+        this.reactionEyes = reactions.getEyes();
+        this.reactionHeart = reactions.getHeart();
+    }
+
+    public int getCountByType(ReactionType type) {
+        return switch (type) {
+            case CELEBRATE -> reactionCelebrate;
+            case THUMBS_UP -> reactionThumbsUp;
+            case LAUGH -> reactionLaugh;
+            case EYES -> reactionEyes;
+            case HEART -> reactionHeart;
+        };
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/entity/enums/TuningReportSortType.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/entity/enums/TuningReportSortType.java
@@ -8,16 +8,16 @@ import org.springframework.data.domain.Pageable;
 public enum TuningReportSortType {
     LATEST {
         @Override
-        public Page<TuningReport> fetch(Pageable pageable, TuningReportRepository repository) {
-            return repository.findAllNotDeletedOrderByCreatedAtDesc(pageable);
+        public Page<TuningReport> fetch(Pageable pageable, TuningReportRepository repository, String emailDomain) {
+            return repository.findAllNotDeletedByEmailDomainOrderByCreatedAtDesc(emailDomain, pageable);
         }
     },
     POPULAR {
         @Override
-        public Page<TuningReport> fetch(Pageable pageable, TuningReportRepository repository) {
-            return repository.findAllNotDeletedOrderByTotalReactionDesc(pageable);
+        public Page<TuningReport> fetch(Pageable pageable, TuningReportRepository repository, String emailDomain) {
+            return repository.findAllNotDeletedByEmailDomainOrderByTotalReactionDesc(emailDomain, pageable);
         }
     };
 
-    public abstract Page<TuningReport> fetch(Pageable pageable, TuningReportRepository repository);
+    public abstract Page<TuningReport> fetch(Pageable pageable, TuningReportRepository repository, String emailDomain);
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/repository/TuningReportCacheManager.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/repository/TuningReportCacheManager.java
@@ -24,7 +24,6 @@ import java.util.function.Function;
 @RequiredArgsConstructor
 public class TuningReportCacheManager {
     private final RedisTemplate<String, String> redisTemplate;
-    private final TuningReportFlushScheduler tuningReportFlushScheduler;
     private final ObjectMapper objectMapper = new ObjectMapper()
             .registerModule(new JavaTimeModule())
             .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
@@ -237,7 +236,6 @@ public class TuningReportCacheManager {
 
     @Async
     public void invalidateDomainCache(String domain) {
-        tuningReportFlushScheduler.flushDirtyReports();
         deleteReportItemsAndUserKeysByDomain(domain);
         deleteAllUserDomainKeysByDomain(domain);
         log.info("✅ [캐시 무효화 완료] domain='{}'", domain);

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/repository/TuningReportCacheManager.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/repository/TuningReportCacheManager.java
@@ -39,18 +39,7 @@ public class TuningReportCacheManager {
         return String.format("reports:%d:user:%d", reportId, userId);
     }
 
-    // Redis에서 reports:page=* 형식으로 저장된 모든 페이지 캐시의 key 목록 조회
-    public Set<String> scanPageKeys() {
-        return redisTemplate.execute((RedisCallback<Set<String>>) conn -> {
-            Set<String> result = new HashSet<>();
-            Cursor<byte[]> cursor = conn.scan(ScanOptions.scanOptions()
-                    .match("reports:page=*:list").count(1000).build());
-            cursor.forEachRemaining(b -> result.add(new String(b)));
-            return result;
-        });
-    }
-
-    // === 최신 게시글 10에 대한 Cache : 페이지별 리포트 목록 (Hash) ===
+    // === 최신 게시글 10에 대한 Cache : 페이지별 리포트 목록 (List) ===
     public List<TuningReportListResponse.ReportItem> getCachedReportList() {
         String listKey = pageListKey();
         if (!Boolean.TRUE.equals(redisTemplate.hasKey(listKey))) return null;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/repository/TuningReportCacheManager.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/repository/TuningReportCacheManager.java
@@ -1,0 +1,144 @@
+package com.hertz.hertz_be.domain.tuningreport.repository;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.hertz.hertz_be.domain.tuningreport.dto.response.TuningReportListResponse;
+import com.hertz.hertz_be.domain.tuningreport.entity.enums.ReactionType;
+import com.hertz.hertz_be.domain.tuningreport.entity.enums.TuningReportSortType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.*;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TuningReportCacheManager {
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectMapper objectMapper = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+    private static final Duration PAGE_TTL = Duration.ofMinutes(35);
+    private static final String DIRTY_SET = "dirty:reports";
+
+    // 페이지별 Hash 키 생성
+    public String pageKey() {
+        return String.format("reports:page=%d:size=%d:sort=%s", 0, 10, TuningReportSortType.LATEST);
+    }
+
+    // 사용자별 Hash 키 생성
+    public String userKey(Long reportId, Long userId) {
+        return String.format("reports:%d:user:%d", reportId, userId);
+    }
+
+    // 모든 페이지 키 스캔
+    public Set<String> scanPageKeys() {
+        return redisTemplate.execute((RedisCallback<Set<String>>) conn -> {
+            Set<String> result = new HashSet<>();
+            Cursor<byte[]> cursor = conn.scan(ScanOptions.scanOptions()
+                    .match("reports:page=*" ).count(1000).build());
+            cursor.forEachRemaining(b -> result.add(new String(b)));
+            return result;
+        });
+    }
+
+    // === Cache A: 페이지별 리포트 목록 (Hash) ===
+    public List<TuningReportListResponse.ReportItem> getCachedReportList() {
+        String key = pageKey();
+        if (!Boolean.TRUE.equals(redisTemplate.hasKey(key))) return null;
+        BoundHashOperations<String, String, String> hash = redisTemplate.boundHashOps(key);
+        List<TuningReportListResponse.ReportItem> items = new ArrayList<>();
+        for (String json : hash.values()) {
+            try {
+                items.add(objectMapper.readValue(json, TuningReportListResponse.ReportItem.class));
+            } catch (JsonProcessingException ignored) {
+            }
+        }
+        return items;
+    }
+
+    public void cacheReportList(List<TuningReportListResponse.ReportItem> items) {
+        String key = pageKey();
+        BoundHashOperations<String, String, String> hash = redisTemplate.boundHashOps(key);
+        hash.getOperations().expire(key, PAGE_TTL);
+        // 기존 필드 초기화
+        for (String field : hash.keys()) {
+            hash.delete(field);
+        }
+        // 새로 저장
+        for (TuningReportListResponse.ReportItem item : items) {
+            try {
+                log.info("✅ 게시글 캐싱 되기 직전의 reportID: {}", item.getReportId());
+                String json = objectMapper.writeValueAsString(item);
+                hash.put(item.getReportId().toString(), json);
+            } catch (JsonProcessingException ignored) {
+                log.info("❌ 게시글 캐싱 되기 직전에 redis에 저장 실패 {}", ignored);
+            }
+        }
+    }
+
+    public boolean isReportCached(Long reportId) {
+        return Boolean.TRUE.equals(
+                redisTemplate.boundHashOps(pageKey()).hasKey(reportId.toString())
+        );
+    }
+
+    // === Cache C: 유저별 반응 상태 (Hash) ===
+    public void setUserReaction(Long reportId, Long userId, ReactionType type, boolean reacted) {
+        String key = userKey(reportId, userId);
+        try {
+            log.info("✅ 유저별 반응 상태 캐싱 되기 직전 reportId:{}", reportId);
+            redisTemplate.opsForHash().put(key, type.name(), reacted ? "1" : "0");
+            redisTemplate.expire(key, PAGE_TTL);
+        } catch (Exception e) {
+            log.info("❌ 유저별 반응 상태 캐싱 되기 직전에 redis에 저장 실패 {}", e);
+        }
+    }
+
+    public Boolean getUserReaction(Long reportId, Long userId, ReactionType type) {
+        String key = userKey(reportId, userId);
+        Object v = redisTemplate.opsForHash().get(key, type.name());
+        return v != null && "1".equals(v);
+    }
+
+    public Map<ReactionType, Boolean> getUserReactionMap(Long reportId, Long userId) {
+        String key = userKey(reportId, userId);
+        Map<Object, Object> raw = redisTemplate.opsForHash().entries(key);
+        return Arrays.stream(ReactionType.values())
+                .collect(Collectors.toMap(
+                        r -> r,
+                        r -> "1".equals(raw.getOrDefault(r.name(), "0"))
+                ));
+    }
+
+    // MyReactions DTO 변환
+    public TuningReportListResponse.MyReactions toMyReactions(Map<ReactionType, Boolean> map) {
+        return new TuningReportListResponse.MyReactions(
+                map.getOrDefault(ReactionType.CELEBRATE, false),
+                map.getOrDefault(ReactionType.THUMBS_UP, false),
+                map.getOrDefault(ReactionType.LAUGH, false),
+                map.getOrDefault(ReactionType.EYES, false),
+                map.getOrDefault(ReactionType.HEART, false)
+        );
+    }
+
+    // Dirty Set
+    public void markDirty(Long reportId) {
+        redisTemplate.opsForSet().add(DIRTY_SET, reportId.toString());
+    }
+
+    public Set<String> getDirtyReportIds() {
+        return redisTemplate.opsForSet().members(DIRTY_SET);
+    }
+
+    public void clearDirtyReportId(String reportId) {
+        redisTemplate.opsForSet().remove(DIRTY_SET, reportId);
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/repository/TuningReportRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/repository/TuningReportRepository.java
@@ -15,13 +15,23 @@ import java.util.Optional;
 @Repository
 public interface TuningReportRepository extends JpaRepository<TuningReport, Long> {
 
-    @Query("SELECT r FROM TuningReport r WHERE r.deletedAt IS NULL AND r.isVisible = true ORDER BY r.createdAt DESC")
-    Page<TuningReport> findAllNotDeletedOrderByCreatedAtDesc(Pageable pageable);
+    @Query("""
+    SELECT r FROM TuningReport r 
+    WHERE r.deletedAt IS NULL 
+      AND r.isVisible = true 
+      AND r.emailDomain = :emailDomain
+    ORDER BY r.createdAt DESC
+""")
+    Page<TuningReport> findAllNotDeletedByEmailDomainOrderByCreatedAtDesc(
+            @Param("emailDomain") String emailDomain,
+            Pageable pageable
+    );
 
     @Query("""
-    SELECT r FROM TuningReport r
-    WHERE r.deletedAt IS NULL
-    AND r.isVisible = true
+    SELECT r FROM TuningReport r 
+    WHERE r.deletedAt IS NULL 
+      AND r.isVisible = true 
+      AND r.emailDomain = :emailDomain
     ORDER BY (
         r.reactionCelebrate +
         r.reactionThumbsUp +
@@ -30,7 +40,10 @@ public interface TuningReportRepository extends JpaRepository<TuningReport, Long
         r.reactionHeart
     ) DESC
 """)
-    Page<TuningReport> findAllNotDeletedOrderByTotalReactionDesc(Pageable pageable);
+    Page<TuningReport> findAllNotDeletedByEmailDomainOrderByTotalReactionDesc(
+            @Param("emailDomain") String emailDomain,
+            Pageable pageable
+    );
 
     @Query("SELECT r FROM TuningReport r WHERE r.signalRoom = :signalRoom AND r.deletedAt IS NULL")
     Optional<TuningReport> findNotDeletedBySignalRoom(@Param("signalRoom") SignalRoom signalRoom);

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportFlushScheduler.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportFlushScheduler.java
@@ -1,0 +1,94 @@
+package com.hertz.hertz_be.domain.tuningreport.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hertz.hertz_be.domain.tuningreport.dto.response.TuningReportListResponse;
+import com.hertz.hertz_be.domain.tuningreport.entity.TuningReport;
+import com.hertz.hertz_be.domain.tuningreport.entity.TuningReportUserReaction;
+import com.hertz.hertz_be.domain.tuningreport.entity.enums.ReactionType;
+import com.hertz.hertz_be.domain.tuningreport.repository.TuningReportCacheManager;
+import com.hertz.hertz_be.domain.tuningreport.repository.TuningReportRepository;
+import com.hertz.hertz_be.domain.tuningreport.repository.TuningReportUserReactionRepository;
+import com.hertz.hertz_be.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TuningReportFlushScheduler {
+    private final TuningReportCacheManager cacheManager;
+    private final TuningReportRepository reportRepo;
+    private final TuningReportUserReactionRepository reactionRepo;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Transactional
+    @Scheduled(cron = "0 0/30 * * * *")
+    public void flushDirtyReports() {
+        Set<String> dirty = cacheManager.getDirtyReportIds();
+        if (dirty.isEmpty()) return;
+
+        Set<String> pages = cacheManager.scanPageKeys();
+
+        for (String pageKey : pages) {
+            for (String rid : dirty) {
+                if (!redisTemplate.opsForHash().hasKey(pageKey, rid)) continue;
+                try {
+                    String json = (String) redisTemplate.opsForHash().get(pageKey, rid);
+
+                    // ✅ Jackson이 내부 static class도 잘 deserialize 가능하므로 아래처럼 사용해도 문제 없음
+                    TuningReportListResponse.ReportItem item =
+                            objectMapper.readValue(json, TuningReportListResponse.ReportItem.class);
+
+                    Long reportId = Long.valueOf(rid);
+                    TuningReport report = reportRepo.findById(reportId)
+                            .orElseThrow(() -> new IllegalArgumentException("Report not found"));
+
+                    // ✅ 반응 수 반영 (getReactions())
+                    report.updateReactionsFrom(item.getReactions());
+                    reportRepo.save(report);
+
+                    // ✅ 유저별 반응 동기화
+                    String userPattern = String.format("reports:%d:user:*", reportId);
+                    Set<String> userKeys = redisTemplate.keys(userPattern);
+
+                    for (String uk : userKeys) {
+                        Long userId = Long.valueOf(uk.split(":")[3]);
+                        for (ReactionType type : ReactionType.values()) {
+                            Boolean reacted = cacheManager.getUserReaction(reportId, userId, type);
+                            if (reacted != null) {
+                                if (reacted) {
+                                    if (!reactionRepo.existsByReportIdAndUserIdAndReactionType(
+                                            reportId, userId, type)) {
+                                        reactionRepo.save(
+                                                TuningReportUserReaction.builder()
+                                                        .report(report)
+                                                        .user(User.of(userId))
+                                                        .reactionType(type)
+                                                        .build()
+                                        );
+                                    }
+                                } else {
+                                    reactionRepo.deleteByReportIdAndUserIdAndReactionType(
+                                            reportId, userId, type);
+                                }
+                            }
+                        }
+                    }
+
+                    cacheManager.clearDirtyReportId(rid);
+                    log.info("[FLUSHED] reportId={} synchronized.", reportId);
+                } catch (Exception e) {
+                    log.warn("[FLUSH FAILED] reportId={} error: {}", rid, e.getMessage());
+                }
+            }
+        }
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportFlushScheduler.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportFlushScheduler.java
@@ -67,13 +67,13 @@ public class TuningReportFlushScheduler {
                 TuningReport report = reportRepo.findById(reportId)
                         .orElseThrow(() -> new IllegalArgumentException("Report not found"));
 
-                // 반응 수 반영
+                // 각 게시글의 반응 수 동기화
                 report.updateReactionsFrom(item.getReactions());
                 reportRepo.save(report);
 
-                // 유저별 반응 동기화
+                // 각 게시글에 대한 유저별 반응 동기화
                 String userPattern = String.format("reports:%d:user:*", reportId);
-                Set<String> userKeys = redisTemplate.keys(userPattern); // NOTE: SCAN 권장
+                Set<String> userKeys = redisTemplate.keys(userPattern);
 
                 for (String uk : userKeys) {
                     try {

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportFlushScheduler.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportFlushScheduler.java
@@ -1,6 +1,8 @@
 package com.hertz.hertz_be.domain.tuningreport.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.hertz.hertz_be.domain.tuningreport.dto.response.TuningReportListResponse;
 import com.hertz.hertz_be.domain.tuningreport.entity.TuningReport;
 import com.hertz.hertz_be.domain.tuningreport.entity.TuningReportUserReaction;
@@ -27,68 +29,71 @@ public class TuningReportFlushScheduler {
     private final TuningReportRepository reportRepo;
     private final TuningReportUserReactionRepository reactionRepo;
     private final RedisTemplate<String, String> redisTemplate;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
     @Transactional
-    @Scheduled(cron = "0 0/30 * * * *")
+    @Scheduled(cron = "0 0/2 * * * *")
     public void flushDirtyReports() {
         Set<String> dirty = cacheManager.getDirtyReportIds();
         if (dirty.isEmpty()) return;
 
-        Set<String> pages = cacheManager.scanPageKeys();
+        for (String rid : dirty) {
+            try {
+                Long reportId = Long.valueOf(rid);
+                String reportKey = cacheManager.reportItemKey(reportId);
+                String json = redisTemplate.opsForValue().get(reportKey);
 
-        for (String pageKey : pages) {
-            for (String rid : dirty) {
-                if (!redisTemplate.opsForHash().hasKey(pageKey, rid)) continue;
-                try {
-                    String json = (String) redisTemplate.opsForHash().get(pageKey, rid);
+                if (json == null) continue;
 
-                    // ✅ Jackson이 내부 static class도 잘 deserialize 가능하므로 아래처럼 사용해도 문제 없음
-                    TuningReportListResponse.ReportItem item =
-                            objectMapper.readValue(json, TuningReportListResponse.ReportItem.class);
+                TuningReportListResponse.ReportItem item =
+                        objectMapper.readValue(json, TuningReportListResponse.ReportItem.class);
 
-                    Long reportId = Long.valueOf(rid);
-                    TuningReport report = reportRepo.findById(reportId)
-                            .orElseThrow(() -> new IllegalArgumentException("Report not found"));
+                TuningReport report = reportRepo.findById(reportId)
+                        .orElseThrow(() -> new IllegalArgumentException("Report not found"));
 
-                    // ✅ 반응 수 반영 (getReactions())
-                    report.updateReactionsFrom(item.getReactions());
-                    reportRepo.save(report);
+                // ✅ 반응 수 반영
+                report.updateReactionsFrom(item.getReactions());
+                reportRepo.save(report);
 
-                    // ✅ 유저별 반응 동기화
-                    String userPattern = String.format("reports:%d:user:*", reportId);
-                    Set<String> userKeys = redisTemplate.keys(userPattern);
+                // ✅ 유저별 반응 동기화
+                String userPattern = String.format("reports:%d:user:*", reportId);
+                Set<String> userKeys = redisTemplate.keys(userPattern);
 
-                    for (String uk : userKeys) {
-                        Long userId = Long.valueOf(uk.split(":")[3]);
-                        for (ReactionType type : ReactionType.values()) {
-                            Boolean reacted = cacheManager.getUserReaction(reportId, userId, type);
-                            if (reacted != null) {
-                                if (reacted) {
-                                    if (!reactionRepo.existsByReportIdAndUserIdAndReactionType(
-                                            reportId, userId, type)) {
-                                        reactionRepo.save(
-                                                TuningReportUserReaction.builder()
-                                                        .report(report)
-                                                        .user(User.of(userId))
-                                                        .reactionType(type)
-                                                        .build()
-                                        );
-                                    }
-                                } else {
-                                    reactionRepo.deleteByReportIdAndUserIdAndReactionType(
-                                            reportId, userId, type);
+                for (String uk : userKeys) {
+                    Long userId = Long.valueOf(uk.split(":")[3]);
+                    for (ReactionType type : ReactionType.values()) {
+                        Boolean reacted = cacheManager.getUserReaction(reportId, userId, type);
+                        if (reacted != null) {
+                            boolean exists = reactionRepo.existsByReportIdAndUserIdAndReactionType(reportId, userId, type);
+                            if (reacted) {
+                                if (!exists) {
+                                    reactionRepo.save(
+                                            TuningReportUserReaction.builder()
+                                                    .report(report)
+                                                    .user(User.of(userId))
+                                                    .reactionType(type)
+                                                    .build()
+                                    );
+                                }
+                            } else {
+                                if (exists) {
+                                    reactionRepo.deleteByReportIdAndUserIdAndReactionType(reportId, userId, type);
                                 }
                             }
                         }
                     }
-
-                    cacheManager.clearDirtyReportId(rid);
-                    log.info("[FLUSHED] reportId={} synchronized.", reportId);
-                } catch (Exception e) {
-                    log.warn("[FLUSH FAILED] reportId={} error: {}", rid, e.getMessage());
                 }
+
+                cacheManager.clearDirtyReportId(rid);
+                log.info("✅ [FLUSHED] reportId={} synchronized successfully.", reportId);
+
+            } catch (Exception e) {
+                log.warn("❌ [FLUSH FAILED] reportId={} error: {}", rid, e.getMessage());
             }
         }
     }
+
+
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportFlushScheduler.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportFlushScheduler.java
@@ -39,7 +39,7 @@ public class TuningReportFlushScheduler {
             .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
     @Transactional
-    @Scheduled(cron = "0 0/1 * * * *")
+    @Scheduled(cron = "0 0/30 * * * *")
     public void flushDirtyReports() {
         Set<String> dirty = cacheManager.getDirtyReportIds();
         if (dirty.isEmpty()) return;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportReactionService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportReactionService.java
@@ -57,9 +57,8 @@ public class TuningReportReactionService {
             public Object execute(RedisOperations ops) {
                 ops.multi();
                 ops.opsForHash().put(userKey, type.name(), isReacted ? "1" : "0");
-                ops.opsForSet().add("dirty:reports", reportId.toString());
                 ops.expire(userKey, Duration.ofMinutes(35));
-                ops.expire("dirty:reports", Duration.ofMinutes(35));
+                cacheManager.markDirty(reportId);
                 return ops.exec();
             }
         });

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportReactionService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportReactionService.java
@@ -106,7 +106,7 @@ public class TuningReportReactionService {
             }
 
             // 해당 도메인과 해당 사용자와 관련 모든 캐시된 데이터 TTL 갱신
-            refreshTuningReportTTL(userId, domain);
+            cacheManager.refreshTuningReportTTL(userId, domain);
 
         } catch (Exception e) {
             log.warn("❌ 분산 락 처리 실패: reportId={}, error={}", reportId, e.getMessage());
@@ -118,12 +118,5 @@ public class TuningReportReactionService {
         }
 
         return new TuningReportReactionResponse(reportId, type, isReacted, newCount);
-    }
-
-    @Async
-    private void refreshTuningReportTTL (Long userId, String domain) {
-        cacheManager.refreshUserDomainTTL(userId);
-        cacheManager.refreshAllUserReactionTTLByScan(userId);
-        cacheManager.refreshReportListTTL(domain);
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportReactionService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportReactionService.java
@@ -1,29 +1,99 @@
 package com.hertz.hertz_be.domain.tuningreport.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hertz.hertz_be.domain.tuningreport.dto.request.TuningReportReactionToggleRequest;
+import com.hertz.hertz_be.domain.tuningreport.dto.response.TuningReportListResponse;
 import com.hertz.hertz_be.domain.tuningreport.dto.response.TuningReportReactionResponse;
 import com.hertz.hertz_be.domain.tuningreport.entity.TuningReport;
 import com.hertz.hertz_be.domain.tuningreport.entity.TuningReportUserReaction;
 import com.hertz.hertz_be.domain.tuningreport.entity.enums.ReactionType;
+import com.hertz.hertz_be.domain.tuningreport.repository.TuningReportCacheManager;
 import com.hertz.hertz_be.domain.tuningreport.repository.TuningReportRepository;
 import com.hertz.hertz_be.domain.tuningreport.repository.TuningReportUserReactionRepository;
 import com.hertz.hertz_be.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.CannotAcquireLockException;
 import org.springframework.dao.DeadlockLoserDataAccessException;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.core.RedisOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.SessionCallback;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class TuningReportReactionService {
 
-    private final TuningReportRepository tuningReportRepository;
-    private final TuningReportUserReactionRepository tuningReportUserReactionRepository;
+    private final TuningReportCacheManager cacheManager;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final TuningReportRepository reportRepo;
+    private final TuningReportUserReactionRepository reactionRepo;
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
+    public TuningReportReactionResponse toggleReportReaction(
+            Long userId,
+            Long reportId,
+            TuningReportReactionToggleRequest req
+    ) {
+        ReactionType type = req.reactionType();
+
+        if (cacheManager.isReportCached(reportId)) {
+            return toggleWithCache(reportId, userId, type);
+        } else {
+            return toggleWithDbFallback(reportId, userId, type);
+        }
+    }
+
+    // 캐시 기반 처리
+    private TuningReportReactionResponse toggleWithCache(Long reportId, Long userId, ReactionType type) {
+        boolean isReacted;
+        String pageKey = cacheManager.pageKey();
+        String userKey = cacheManager.userKey(reportId, userId);
+
+        Boolean current = cacheManager.getUserReaction(reportId, userId, type);
+        boolean already = current != null && current;
+        isReacted = !already;
+
+        redisTemplate.execute(new SessionCallback<List<Object>>() {
+            @Override
+            public List<Object> execute(RedisOperations ops) throws DataAccessException {
+                ops.multi();
+                ops.opsForHash().increment(pageKey, type.name(), isReacted ? 1L : -1L);
+                ops.opsForHash().put(userKey, type.name(), isReacted ? "1" : "0");
+                ops.opsForSet().add("dirty:reports", reportId.toString());
+                ops.expire(pageKey, Duration.ofMinutes(35));
+                ops.expire("dirty:reports", Duration.ofMinutes(35));
+                return ops.exec();
+            }
+        });
+
+        try {
+            String json = redisTemplate.opsForHash().get(pageKey, reportId.toString()).toString();
+            if (json != null) {
+                TuningReportListResponse.ReportItem item = objectMapper.readValue(json, TuningReportListResponse.ReportItem.class);
+                if (isReacted) item.getReactions().increase(type);
+                else item.getReactions().decrease(type);
+                redisTemplate.opsForHash().put(pageKey, reportId.toString(), objectMapper.writeValueAsString(item));
+            }
+        } catch (JsonProcessingException ignored) {}
+
+        Object cnt = redisTemplate.opsForHash().get(pageKey, type.name());
+        int newCount = 0;
+        if (cnt instanceof String s) newCount = Integer.parseInt(s);
+        else if (cnt instanceof Integer i) newCount = i;
+
+        return new TuningReportReactionResponse(reportId, type, isReacted, newCount);
+    }
+
+    // DB 기반 처리
     @Transactional
     @Retryable(
             value = {
@@ -34,44 +104,29 @@ public class TuningReportReactionService {
             maxAttempts = 3,
             backoff = @Backoff(delay = 100, multiplier = 2)
     )
-    public TuningReportReactionResponse toggleReportReaction(Long userId, Long reportId, TuningReportReactionToggleRequest request) {
-
-        // 먼저 PESSIMISTIC_WRITE 락 걸고 가져옴
-        TuningReport report = tuningReportRepository.findWithLockById(reportId)
+    protected TuningReportReactionResponse toggleWithDbFallback(Long reportId, Long userId, ReactionType type) {
+        boolean isReacted;
+        TuningReport report = reportRepo.findWithLockById(reportId)
                 .orElseThrow(() -> new IllegalArgumentException("리포트가 존재하지 않습니다."));
 
-        ReactionType reactionType = request.reactionType();
-        boolean isReacted;
-
-        boolean alreadyExists = tuningReportUserReactionRepository.existsByReportIdAndUserIdAndReactionType(
-                reportId, userId, reactionType);
-
-        if (alreadyExists) {
-            // 수치 먼저 감소 후 삭제
-            report.decreaseReaction(reactionType);
-            tuningReportUserReactionRepository.deleteByReportIdAndUserIdAndReactionType(reportId, userId, reactionType);
+        boolean exists = reactionRepo.existsByReportIdAndUserIdAndReactionType(reportId, userId, type);
+        if (exists) {
+            report.decreaseReaction(type);
+            reactionRepo.deleteByReportIdAndUserIdAndReactionType(reportId, userId, type);
             isReacted = false;
         } else {
-            // 저장 후 수치 증가
-            TuningReportUserReaction reaction = TuningReportUserReaction.builder()
-                    .report(report)
-                    .user(User.of(userId))
-                    .reactionType(reactionType)
-                    .build();
-
-            tuningReportUserReactionRepository.save(reaction);
-            report.increaseReaction(reactionType);
+            reactionRepo.save(
+                    TuningReportUserReaction.builder()
+                            .report(report)
+                            .user(User.of(userId))
+                            .reactionType(type)
+                            .build()
+            );
+            report.increaseReaction(type);
             isReacted = true;
         }
 
-        int reactionCount = switch (reactionType) {
-            case CELEBRATE -> report.getReactionCelebrate();
-            case THUMBS_UP -> report.getReactionThumbsUp();
-            case LAUGH -> report.getReactionLaugh();
-            case EYES -> report.getReactionEyes();
-            case HEART -> report.getReactionHeart();
-        };
-
-        return new TuningReportReactionResponse(reportId, reactionType, isReacted, reactionCount);
+        int count = report.getCountByType(type);
+        return new TuningReportReactionResponse(reportId, type, isReacted, count);
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportReactionService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportReactionService.java
@@ -74,15 +74,8 @@ public class TuningReportReactionService {
             isReacted = !already;
 
             // Step 2: 유저 상태 + Dirty Set 저장
-            redisTemplate.execute(new SessionCallback<>() {
-                @Override
-                public Object execute(RedisOperations ops) {
-                    ops.multi();
-                    ops.opsForHash().put(userKey, type.name(), isReacted ? "1" : "0");
-                    cacheManager.markDirty(reportId);
-                    return ops.exec();
-                }
-            });
+            redisTemplate.opsForHash().put(userKey, type.name(), isReacted ? "1" : "0");
+            cacheManager.markDirty(reportId);
 
             // Step 3: ReportItem 캐시 읽고 수정
             String json = redisTemplate.opsForValue().get(reportKey);

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportReactionService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportReactionService.java
@@ -85,18 +85,15 @@ public class TuningReportReactionService {
             if (json != null) {
                 TuningReportListResponse.ReportItem item = objectMapper.readValue(json, TuningReportListResponse.ReportItem.class);
 
-                // reactions 수정
                 if (isReacted) item.getReactions().increase(type);
                 else item.getReactions().decrease(type);
 
-                // myReactions 수정
                 if (item.getMyReactions() == null)
                     item.setMyReactions(new TuningReportListResponse.MyReactions());
                 item.getMyReactions().set(type, isReacted);
 
                 redisTemplate.opsForValue().set(reportKey, objectMapper.writeValueAsString(item), Duration.ofMinutes(35));
 
-                // 최신 카운트 추출
                 newCount = switch (type) {
                     case CELEBRATE -> item.getReactions().getCelebrate();
                     case THUMBS_UP -> item.getReactions().getThumbsUp();

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportReactionService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportReactionService.java
@@ -94,6 +94,9 @@ public class TuningReportReactionService {
 
                 redisTemplate.opsForValue().set(reportKey, objectMapper.writeValueAsString(item), Duration.ofMinutes(35));
 
+                String listKey = cacheManager.pageListKey();
+                redisTemplate.expire(listKey, Duration.ofMinutes(35));
+
                 newCount = switch (type) {
                     case CELEBRATE -> item.getReactions().getCelebrate();
                     case THUMBS_UP -> item.getReactions().getThumbsUp();

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportReactionService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportReactionService.java
@@ -74,7 +74,7 @@ public class TuningReportReactionService {
                 public Object execute(RedisOperations ops) {
                     ops.multi();
                     ops.opsForHash().put(userKey, type.name(), isReacted ? "1" : "0");
-                    ops.expire(userKey, Duration.ofMinutes(35));
+                    ops.expire(userKey, cacheManager.getTTLDurForTuningReport());
                     cacheManager.markDirty(reportId);
                     return ops.exec();
                 }
@@ -92,10 +92,10 @@ public class TuningReportReactionService {
                     item.setMyReactions(new TuningReportListResponse.MyReactions());
                 item.getMyReactions().set(type, isReacted);
 
-                redisTemplate.opsForValue().set(reportKey, objectMapper.writeValueAsString(item), Duration.ofMinutes(35));
+                redisTemplate.opsForValue().set(reportKey, objectMapper.writeValueAsString(item), cacheManager.getTTLDurForTuningReport());
 
                 String listKey = cacheManager.pageListKey();
-                redisTemplate.expire(listKey, Duration.ofMinutes(35));
+                redisTemplate.expire(listKey, cacheManager.getTTLDurForTuningReport());
 
                 newCount = switch (type) {
                     case CELEBRATE -> item.getReactions().getCelebrate();

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportReactionTransactionalService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportReactionTransactionalService.java
@@ -1,0 +1,63 @@
+package com.hertz.hertz_be.domain.tuningreport.service;
+
+import com.hertz.hertz_be.domain.tuningreport.dto.response.TuningReportReactionResponse;
+import com.hertz.hertz_be.domain.tuningreport.entity.TuningReport;
+import com.hertz.hertz_be.domain.tuningreport.entity.TuningReportUserReaction;
+import com.hertz.hertz_be.domain.tuningreport.entity.enums.ReactionType;
+import com.hertz.hertz_be.domain.tuningreport.repository.TuningReportRepository;
+import com.hertz.hertz_be.domain.tuningreport.repository.TuningReportUserReactionRepository;
+import com.hertz.hertz_be.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.CannotAcquireLockException;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.DeadlockLoserDataAccessException;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TuningReportReactionTransactionalService {
+
+    private final TuningReportRepository reportRepo;
+    private final TuningReportUserReactionRepository reactionRepo;
+
+    @Transactional
+    @Retryable(
+            value = {
+                    ObjectOptimisticLockingFailureException.class,
+                    DeadlockLoserDataAccessException.class,
+                    CannotAcquireLockException.class,
+                    DataAccessException.class
+            },
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 100, multiplier = 2)
+    )
+    public TuningReportReactionResponse toggleWithDbFallback(Long reportId, Long userId, ReactionType type) {
+        boolean isReacted;
+        TuningReport report = reportRepo.findWithLockById(reportId)
+                .orElseThrow(() -> new IllegalArgumentException("리포트가 존재하지 않습니다."));
+
+        boolean exists = reactionRepo.existsByReportIdAndUserIdAndReactionType(reportId, userId, type);
+        if (exists) {
+            report.decreaseReaction(type);
+            reactionRepo.deleteByReportIdAndUserIdAndReactionType(reportId, userId, type);
+            isReacted = false;
+        } else {
+            reactionRepo.save(
+                    TuningReportUserReaction.builder()
+                            .report(report)
+                            .user(User.of(userId))
+                            .reactionType(type)
+                            .build()
+            );
+            report.increaseReaction(type);
+            isReacted = true;
+        }
+
+        int count = report.getCountByType(type);
+        return new TuningReportReactionResponse(reportId, type, isReacted, count);
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportService.java
@@ -1,7 +1,6 @@
 package com.hertz.hertz_be.domain.tuningreport.service;
 
 import com.hertz.hertz_be.domain.tuningreport.dto.response.TuningReportListResponse;
-import com.hertz.hertz_be.domain.tuningreport.entity.TuningReport;
 import com.hertz.hertz_be.domain.tuningreport.entity.TuningReportUserReaction;
 import com.hertz.hertz_be.domain.tuningreport.entity.enums.ReactionType;
 import com.hertz.hertz_be.domain.tuningreport.entity.enums.TuningReportSortType;
@@ -10,11 +9,9 @@ import com.hertz.hertz_be.domain.tuningreport.repository.TuningReportRepository;
 import com.hertz.hertz_be.domain.tuningreport.repository.TuningReportUserReactionRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
@@ -26,22 +23,20 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class TuningReportService {
 
-    private final TuningReportRepository tuningReportRepository;
-    private final TuningReportUserReactionRepository tuningReportUserReactionRepository;
+    private final TuningReportTransactionalService transactionalService;
     private final TuningReportCacheManager cacheManager;
     private final RedisTemplate<String, String> redisTemplate;
+    private final TuningReportRepository tuningReportRepository;
+    private final TuningReportUserReactionRepository tuningReportUserReactionRepository;
 
-    @Transactional(readOnly = true)
     public TuningReportListResponse getReportList(Long userId, int page, int size, TuningReportSortType sort) {
         if (isCacheApplicable(page, size, sort)) {
             List<TuningReportListResponse.ReportItem> cachedItems = loadOrCacheReports(page, size, sort);
-
             List<TuningReportListResponse.ReportItem> enriched = enrichWithUserReactions(cachedItems, userId);
-
             return createResponse(enriched, page, size);
         }
 
-        return fetchDirectlyFromDB(userId, page, size, sort);
+        return transactionalService.fetchDirectlyFromDB(userId, page, size, sort);
     }
 
     private boolean isCacheApplicable(int page, int size, TuningReportSortType sort) {
@@ -53,25 +48,14 @@ public class TuningReportService {
         if (items == null) {
             log.info("게시글 리스트 반환 시 캐싱 hit ⚠️");
             var pageReq = PageRequest.of(page, size);
-            var reports = sort.fetch(pageReq, tuningReportRepository);
+            var reports = sort.fetch(pageReq, transactionalService.getTuningReportRepository());
             items = reports.stream()
-                    .map(this::toReportItemWithoutReactions)
+                    .map(transactionalService::toReportItemWithoutReactions)
                     .collect(Collectors.toList());
             cacheManager.cacheReportList(items);
         }
         log.info("캐싱 되기 위해 load된 item 수: {}", items.size());
         return items;
-    }
-
-    private TuningReportListResponse.ReportItem toReportItemWithoutReactions(TuningReport report) {
-        return new TuningReportListResponse.ReportItem(
-                report.getCreatedAt(), report.getId(), report.getTitle(), report.getContent(),
-                new TuningReportListResponse.Reactions (
-                        report.getReactionCelebrate(), report.getReactionThumbsUp(),
-                        report.getReactionLaugh(), report.getReactionEyes(), report.getReactionHeart()
-                ),
-                null
-        );
     }
 
     private List<TuningReportListResponse.ReportItem> enrichWithUserReactions(List<TuningReportListResponse.ReportItem> items, Long userId) {
@@ -80,11 +64,10 @@ public class TuningReportService {
                 .toList();
 
         List<TuningReportUserReaction> dbList =
-                tuningReportUserReactionRepository.findAllByUserIdAndReportIdIn(userId, reportIds);
+                transactionalService.getTuningReportUserReactionRepository().findAllByUserIdAndReportIdIn(userId, reportIds);
 
         log.info("💡 사용자 {}에 대해 DB에서 조회된 반응 수: {}", userId, dbList.size());
 
-        // 캐싱 먼저 수행
         dbList.forEach(reaction ->
                 cacheManager.setUserReaction(
                         reaction.getReport().getId(),
@@ -94,14 +77,12 @@ public class TuningReportService {
                 )
         );
 
-        // 사용자별 반응 목록 맵핑
         Map<Long, Set<ReactionType>> userReactionMap = dbList.stream()
                 .collect(Collectors.groupingBy(
                         r -> r.getReport().getId(),
                         Collectors.mapping(TuningReportUserReaction::getReactionType, Collectors.toSet())
                 ));
 
-        // 최종 응답 객체 변환
         return items.stream()
                 .map(item -> {
                     Set<ReactionType> reactions = userReactionMap.getOrDefault(item.getReportId(), Set.of());
@@ -127,56 +108,4 @@ public class TuningReportService {
         boolean isLast = items.size() < size;
         return new TuningReportListResponse(items, page, size, isLast);
     }
-
-    private TuningReportListResponse fetchDirectlyFromDB(Long userId, int page, int size, TuningReportSortType sort) {
-        PageRequest pageRequest = PageRequest.of(page, size);
-        Page<TuningReport> reports = sort.fetch(pageRequest, tuningReportRepository);
-
-        List<Long> reportIds = reports.stream().map(TuningReport::getId).toList();
-        List<TuningReportUserReaction> userReactions =
-                tuningReportUserReactionRepository.findAllByUserIdAndReportIdIn(userId, reportIds);
-
-        Map<Long, Set<ReactionType>> userReactionMap = userReactions.stream()
-                .collect(Collectors.groupingBy(
-                        r -> r.getReport().getId(),
-                        Collectors.mapping(TuningReportUserReaction::getReactionType, Collectors.toSet())
-                ));
-
-        List<TuningReportListResponse.ReportItem> reportItems = reports.stream()
-                .map(report -> toReportItemWithReactions(report, userReactionMap.getOrDefault(report.getId(), Set.of())))
-                .collect(Collectors.toList());
-
-        log.info("DB에서 바로 반환된 item 수: {}", reportItems.size());
-        return new TuningReportListResponse(
-                reportItems,
-                reports.getNumber(),
-                reports.getSize(),
-                reports.isLast()
-        );
-    }
-
-    private TuningReportListResponse.ReportItem toReportItemWithReactions(TuningReport report, Set<ReactionType> myReactions) {
-        return new TuningReportListResponse.ReportItem(
-                report.getCreatedAt(),
-                report.getId(),
-                report.getTitle(),
-                report.getContent(),
-                new TuningReportListResponse.Reactions(
-                        report.getReactionCelebrate(),
-                        report.getReactionThumbsUp(),
-                        report.getReactionLaugh(),
-                        report.getReactionEyes(),
-                        report.getReactionHeart()
-                ),
-                new TuningReportListResponse.MyReactions(
-                        myReactions.contains(ReactionType.CELEBRATE),
-                        myReactions.contains(ReactionType.THUMBS_UP),
-                        myReactions.contains(ReactionType.LAUGH),
-                        myReactions.contains(ReactionType.EYES),
-                        myReactions.contains(ReactionType.HEART)
-                )
-        );
-    }
-
-
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportService.java
@@ -66,7 +66,6 @@ public class TuningReportService {
         Map<Long, Set<ReactionType>> userReactionMap;
 
         if (anyCached) {
-            // ✅ Redis에 전부 존재 → 캐시에서 생성
             userReactionMap = reportIds.stream().collect(Collectors.toMap(
                     reportId -> reportId,
                     reportId -> Arrays.stream(ReactionType.values())
@@ -75,11 +74,8 @@ public class TuningReportService {
             ));
             log.info("✅ Redis에서 사용자 {}의 반응 정보 조회 완료 (DB 미조회)", userId);
         } else {
-            // ❌ 캐시 누락 → DB 조회 후 캐싱
             List<TuningReportUserReaction> dbList =
                     transactionalService.getTuningReportUserReactionRepository().findAllByUserIdAndReportIdIn(userId, reportIds);
-
-            log.info("💡 사용자 {}에 대해 DB에서 조회된 반응 수: {}", userId, dbList.size());
 
             dbList.forEach(reaction ->
                     cacheManager.setUserReaction(

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportService.java
@@ -5,11 +5,14 @@ import com.hertz.hertz_be.domain.tuningreport.entity.TuningReport;
 import com.hertz.hertz_be.domain.tuningreport.entity.TuningReportUserReaction;
 import com.hertz.hertz_be.domain.tuningreport.entity.enums.ReactionType;
 import com.hertz.hertz_be.domain.tuningreport.entity.enums.TuningReportSortType;
+import com.hertz.hertz_be.domain.tuningreport.repository.TuningReportCacheManager;
 import com.hertz.hertz_be.domain.tuningreport.repository.TuningReportRepository;
 import com.hertz.hertz_be.domain.tuningreport.repository.TuningReportUserReactionRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,24 +21,120 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class TuningReportService {
 
     private final TuningReportRepository tuningReportRepository;
     private final TuningReportUserReactionRepository tuningReportUserReactionRepository;
+    private final TuningReportCacheManager cacheManager;
+    private final RedisTemplate<String, String> redisTemplate;
 
     @Transactional(readOnly = true)
     public TuningReportListResponse getReportList(Long userId, int page, int size, TuningReportSortType sort) {
-        PageRequest pageRequest = PageRequest.of(page, size);
-        Page<TuningReport> reports = sort.fetch(pageRequest, tuningReportRepository); // 정렬 타입에 따라
+        if (isCacheApplicable(page, size, sort)) {
+            List<TuningReportListResponse.ReportItem> cachedItems = loadOrCacheReports(page, size, sort);
 
-        List<Long> reportIds = reports.stream()
-                .map(TuningReport::getId)
+            List<TuningReportListResponse.ReportItem> enriched = enrichWithUserReactions(cachedItems, userId);
+
+            return createResponse(enriched, page, size);
+        }
+
+        return fetchDirectlyFromDB(userId, page, size, sort);
+    }
+
+    private boolean isCacheApplicable(int page, int size, TuningReportSortType sort) {
+        return page == 0 && size == 10 && sort == TuningReportSortType.LATEST;
+    }
+
+    private List<TuningReportListResponse.ReportItem> loadOrCacheReports(int page, int size, TuningReportSortType sort) {
+        List<TuningReportListResponse.ReportItem> items = cacheManager.getCachedReportList();
+        if (items == null) {
+            log.info("게시글 리스트 반환 시 캐싱 hit ⚠️");
+            var pageReq = PageRequest.of(page, size);
+            var reports = sort.fetch(pageReq, tuningReportRepository);
+            items = reports.stream()
+                    .map(this::toReportItemWithoutReactions)
+                    .collect(Collectors.toList());
+            cacheManager.cacheReportList(items);
+        }
+        log.info("캐싱 되기 위해 load된 item 수: {}", items.size());
+        return items;
+    }
+
+    private TuningReportListResponse.ReportItem toReportItemWithoutReactions(TuningReport report) {
+        return new TuningReportListResponse.ReportItem(
+                report.getCreatedAt(), report.getId(), report.getTitle(), report.getContent(),
+                new TuningReportListResponse.Reactions (
+                        report.getReactionCelebrate(), report.getReactionThumbsUp(),
+                        report.getReactionLaugh(), report.getReactionEyes(), report.getReactionHeart()
+                ),
+                null
+        );
+    }
+
+    private List<TuningReportListResponse.ReportItem> enrichWithUserReactions(List<TuningReportListResponse.ReportItem> items, Long userId) {
+        List<Long> reportIds = items.stream()
+                .map(TuningReportListResponse.ReportItem::getReportId)
                 .toList();
 
-        List<TuningReportUserReaction> userReactions = tuningReportUserReactionRepository
-                .findAllByUserIdAndReportIdIn(userId, reportIds);
+        List<TuningReportUserReaction> dbList =
+                tuningReportUserReactionRepository.findAllByUserIdAndReportIdIn(userId, reportIds);
+
+        log.info("💡 사용자 {}에 대해 DB에서 조회된 반응 수: {}", userId, dbList.size());
+
+        // 캐싱 먼저 수행
+        dbList.forEach(reaction ->
+                cacheManager.setUserReaction(
+                        reaction.getReport().getId(),
+                        userId,
+                        reaction.getReactionType(),
+                        true
+                )
+        );
+
+        // 사용자별 반응 목록 맵핑
+        Map<Long, Set<ReactionType>> userReactionMap = dbList.stream()
+                .collect(Collectors.groupingBy(
+                        r -> r.getReport().getId(),
+                        Collectors.mapping(TuningReportUserReaction::getReactionType, Collectors.toSet())
+                ));
+
+        // 최종 응답 객체 변환
+        return items.stream()
+                .map(item -> {
+                    Set<ReactionType> reactions = userReactionMap.getOrDefault(item.getReportId(), Set.of());
+                    return new TuningReportListResponse.ReportItem(
+                            item.getCreatedDate(),
+                            item.getReportId(),
+                            item.getTitle(),
+                            item.getContent(),
+                            item.getReactions(),
+                            new TuningReportListResponse.MyReactions(
+                                    reactions.contains(ReactionType.CELEBRATE),
+                                    reactions.contains(ReactionType.THUMBS_UP),
+                                    reactions.contains(ReactionType.LAUGH),
+                                    reactions.contains(ReactionType.EYES),
+                                    reactions.contains(ReactionType.HEART)
+                            )
+                    );
+                })
+                .toList();
+    }
+
+    private TuningReportListResponse createResponse(List<TuningReportListResponse.ReportItem> items, int page, int size) {
+        boolean isLast = items.size() < size;
+        return new TuningReportListResponse(items, page, size, isLast);
+    }
+
+    private TuningReportListResponse fetchDirectlyFromDB(Long userId, int page, int size, TuningReportSortType sort) {
+        PageRequest pageRequest = PageRequest.of(page, size);
+        Page<TuningReport> reports = sort.fetch(pageRequest, tuningReportRepository);
+
+        List<Long> reportIds = reports.stream().map(TuningReport::getId).toList();
+        List<TuningReportUserReaction> userReactions =
+                tuningReportUserReactionRepository.findAllByUserIdAndReportIdIn(userId, reportIds);
 
         Map<Long, Set<ReactionType>> userReactionMap = userReactions.stream()
                 .collect(Collectors.groupingBy(
@@ -44,37 +143,40 @@ public class TuningReportService {
                 ));
 
         List<TuningReportListResponse.ReportItem> reportItems = reports.stream()
-                .map(report -> {
-                    Set<ReactionType> myReaction = userReactionMap.getOrDefault(report.getId(), Set.of());
+                .map(report -> toReportItemWithReactions(report, userReactionMap.getOrDefault(report.getId(), Set.of())))
+                .collect(Collectors.toList());
 
-                    return new TuningReportListResponse.ReportItem(
-                            report.getCreatedAt(),
-                            report.getId(),
-                            report.getTitle(),
-                            report.getContent(),
-                            new TuningReportListResponse.ReportItem.Reactions(
-                                    report.getReactionCelebrate(),
-                                    report.getReactionThumbsUp(),
-                                    report.getReactionLaugh(),
-                                    report.getReactionEyes(),
-                                    report.getReactionHeart()
-                            ),
-                            new TuningReportListResponse.ReportItem.MyReactions(
-                                    myReaction.contains(ReactionType.CELEBRATE),
-                                    myReaction.contains(ReactionType.THUMBS_UP),
-                                    myReaction.contains(ReactionType.LAUGH),
-                                    myReaction.contains(ReactionType.EYES),
-                                    myReaction.contains(ReactionType.HEART)
-                            )
-                    );
-                }).toList();
-
+        log.info("DB에서 바로 반환된 item 수: {}", reportItems.size());
         return new TuningReportListResponse(
-            reportItems,
-            reports.getNumber(),
-            reports.getSize(),
-            reports.isLast()
+                reportItems,
+                reports.getNumber(),
+                reports.getSize(),
+                reports.isLast()
         );
     }
+
+    private TuningReportListResponse.ReportItem toReportItemWithReactions(TuningReport report, Set<ReactionType> myReactions) {
+        return new TuningReportListResponse.ReportItem(
+                report.getCreatedAt(),
+                report.getId(),
+                report.getTitle(),
+                report.getContent(),
+                new TuningReportListResponse.Reactions(
+                        report.getReactionCelebrate(),
+                        report.getReactionThumbsUp(),
+                        report.getReactionLaugh(),
+                        report.getReactionEyes(),
+                        report.getReactionHeart()
+                ),
+                new TuningReportListResponse.MyReactions(
+                        myReactions.contains(ReactionType.CELEBRATE),
+                        myReactions.contains(ReactionType.THUMBS_UP),
+                        myReactions.contains(ReactionType.LAUGH),
+                        myReactions.contains(ReactionType.EYES),
+                        myReactions.contains(ReactionType.HEART)
+                )
+        );
+    }
+
 
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportService.java
@@ -46,7 +46,7 @@ public class TuningReportService {
         if (items == null) {
             log.info("게시글 리스트 반환 시 캐싱 hit ⚠️");
             var pageReq = PageRequest.of(page, size);
-            var reports = sort.fetch(pageReq, transactionalService.getTuningReportRepository());
+            var reports = sort.fetch(pageReq, transactionalService.getTuningReportRepository(), domain);
             items = reports.stream()
                     .map(transactionalService::toReportItemWithoutReactions)
                     .collect(Collectors.toList());

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportService.java
@@ -5,12 +5,9 @@ import com.hertz.hertz_be.domain.tuningreport.entity.TuningReportUserReaction;
 import com.hertz.hertz_be.domain.tuningreport.entity.enums.ReactionType;
 import com.hertz.hertz_be.domain.tuningreport.entity.enums.TuningReportSortType;
 import com.hertz.hertz_be.domain.tuningreport.repository.TuningReportCacheManager;
-import com.hertz.hertz_be.domain.tuningreport.repository.TuningReportRepository;
-import com.hertz.hertz_be.domain.tuningreport.repository.TuningReportUserReactionRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -25,9 +22,6 @@ public class TuningReportService {
 
     private final TuningReportTransactionalService transactionalService;
     private final TuningReportCacheManager cacheManager;
-    private final RedisTemplate<String, String> redisTemplate;
-    private final TuningReportRepository tuningReportRepository;
-    private final TuningReportUserReactionRepository tuningReportUserReactionRepository;
 
     public TuningReportListResponse getReportList(Long userId, int page, int size, TuningReportSortType sort) {
         if (isCacheApplicable(page, size, sort)) {

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportTransactionalService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportTransactionalService.java
@@ -1,0 +1,93 @@
+package com.hertz.hertz_be.domain.tuningreport.service;
+
+import com.hertz.hertz_be.domain.tuningreport.dto.response.TuningReportListResponse;
+import com.hertz.hertz_be.domain.tuningreport.entity.TuningReport;
+import com.hertz.hertz_be.domain.tuningreport.entity.TuningReportUserReaction;
+import com.hertz.hertz_be.domain.tuningreport.entity.enums.ReactionType;
+import com.hertz.hertz_be.domain.tuningreport.entity.enums.TuningReportSortType;
+import com.hertz.hertz_be.domain.tuningreport.repository.TuningReportRepository;
+import com.hertz.hertz_be.domain.tuningreport.repository.TuningReportUserReactionRepository;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Set;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Getter
+public class TuningReportTransactionalService {
+
+    private final TuningReportRepository tuningReportRepository;
+    private final TuningReportUserReactionRepository tuningReportUserReactionRepository;
+
+    @Transactional(readOnly = true)
+    public TuningReportListResponse fetchDirectlyFromDB(Long userId, int page, int size, TuningReportSortType sort) {
+        PageRequest pageRequest = PageRequest.of(page, size);
+        Page<TuningReport> reports = sort.fetch(pageRequest, tuningReportRepository);
+
+        List<Long> reportIds = reports.stream().map(TuningReport::getId).toList();
+        List<TuningReportUserReaction> userReactions =
+                tuningReportUserReactionRepository.findAllByUserIdAndReportIdIn(userId, reportIds);
+
+        Map<Long, Set<ReactionType>> userReactionMap = userReactions.stream()
+                .collect(Collectors.groupingBy(
+                        r -> r.getReport().getId(),
+                        Collectors.mapping(TuningReportUserReaction::getReactionType, Collectors.toSet())
+                ));
+
+        List<TuningReportListResponse.ReportItem> reportItems = reports.stream()
+                .map(report -> toReportItemWithReactions(report, userReactionMap.getOrDefault(report.getId(), Set.of())))
+                .collect(Collectors.toList());
+
+        log.info("DB에서 바로 반환된 item 수: {}", reportItems.size());
+        return new TuningReportListResponse(
+                reportItems,
+                reports.getNumber(),
+                reports.getSize(),
+                reports.isLast()
+        );
+    }
+
+    public TuningReportListResponse.ReportItem toReportItemWithoutReactions(TuningReport report) {
+        return new TuningReportListResponse.ReportItem(
+                report.getCreatedAt(), report.getId(), report.getTitle(), report.getContent(),
+                new TuningReportListResponse.Reactions (
+                        report.getReactionCelebrate(), report.getReactionThumbsUp(),
+                        report.getReactionLaugh(), report.getReactionEyes(), report.getReactionHeart()
+                ),
+                null
+        );
+    }
+
+    private TuningReportListResponse.ReportItem toReportItemWithReactions(TuningReport report, Set<ReactionType> myReactions) {
+        return new TuningReportListResponse.ReportItem(
+                report.getCreatedAt(),
+                report.getId(),
+                report.getTitle(),
+                report.getContent(),
+                new TuningReportListResponse.Reactions(
+                        report.getReactionCelebrate(),
+                        report.getReactionThumbsUp(),
+                        report.getReactionLaugh(),
+                        report.getReactionEyes(),
+                        report.getReactionHeart()
+                ),
+                new TuningReportListResponse.MyReactions(
+                        myReactions.contains(ReactionType.CELEBRATE),
+                        myReactions.contains(ReactionType.THUMBS_UP),
+                        myReactions.contains(ReactionType.LAUGH),
+                        myReactions.contains(ReactionType.EYES),
+                        myReactions.contains(ReactionType.HEART)
+                )
+        );
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportTransactionalService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/tuningreport/service/TuningReportTransactionalService.java
@@ -7,6 +7,7 @@ import com.hertz.hertz_be.domain.tuningreport.entity.enums.ReactionType;
 import com.hertz.hertz_be.domain.tuningreport.entity.enums.TuningReportSortType;
 import com.hertz.hertz_be.domain.tuningreport.repository.TuningReportRepository;
 import com.hertz.hertz_be.domain.tuningreport.repository.TuningReportUserReactionRepository;
+import com.hertz.hertz_be.domain.user.repository.UserRepository;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -28,11 +29,13 @@ public class TuningReportTransactionalService {
 
     private final TuningReportRepository tuningReportRepository;
     private final TuningReportUserReactionRepository tuningReportUserReactionRepository;
+    private final UserRepository userRepository;
 
     @Transactional(readOnly = true)
     public TuningReportListResponse fetchDirectlyFromDB(Long userId, int page, int size, TuningReportSortType sort) {
+        String domain = userRepository.findDistinctEmailDomains(userId);
         PageRequest pageRequest = PageRequest.of(page, size);
-        Page<TuningReport> reports = sort.fetch(pageRequest, tuningReportRepository);
+        Page<TuningReport> reports = sort.fetch(pageRequest, tuningReportRepository, domain);
 
         List<Long> reportIds = reports.stream().map(TuningReport::getId).toList();
         List<TuningReportUserReaction> userReactions =

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/aop/HibernateQueryCountAspect.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/aop/HibernateQueryCountAspect.java
@@ -1,0 +1,39 @@
+package com.hertz.hertz_be.global.aop;
+
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.*;
+import org.hibernate.Session;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.stat.Statistics;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class HibernateQueryCountAspect {
+
+    private final EntityManager entityManager;
+
+    @Around("execution(* com.hertz.hertz_be.domain.tuningreport.controller.TuningReportController.*(..))")
+    public Object countHibernateQueriesOfTuningReportController(ProceedingJoinPoint joinPoint) throws Throwable {
+        Session session = entityManager.unwrap(Session.class);
+        SessionFactoryImplementor sessionFactory = (SessionFactoryImplementor) session.getSessionFactory();
+        Statistics stats = sessionFactory.getStatistics();
+
+        long beforeCount = stats.getQueryExecutionCount();
+
+        long startTime = System.currentTimeMillis();
+        Object result = joinPoint.proceed(); // 실제 메서드 실행
+        long endTime = System.currentTimeMillis();
+
+        long afterCount = stats.getQueryExecutionCount();
+        long executedCount = afterCount - beforeCount;
+
+        log.info("🧠 Hibernate가 총 {}개의 쿼리를 {}ms 동안 실행했습니다 - 메서드: {}", executedCount, (endTime - startTime), joinPoint.getSignature());
+        return result;
+    }
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/batch/TuningReportVisibilityWriter.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/batch/TuningReportVisibilityWriter.java
@@ -4,6 +4,7 @@ import com.hertz.hertz_be.domain.alarm.service.AlarmService;
 import com.hertz.hertz_be.domain.tuningreport.entity.TuningReport;
 import com.hertz.hertz_be.domain.tuningreport.repository.TuningReportCacheManager;
 import com.hertz.hertz_be.domain.tuningreport.repository.TuningReportRepository;
+import com.hertz.hertz_be.domain.tuningreport.service.TuningReportFlushScheduler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.item.Chunk;
 import org.springframework.batch.item.ItemWriter;
@@ -17,6 +18,7 @@ public class TuningReportVisibilityWriter implements ItemWriter<TuningReport> {
     private final AlarmService alarmService;
     private final TuningReportRepository tuningReportRepository;
     private final TuningReportCacheManager tuningReportCacheManager;
+    private final TuningReportFlushScheduler tuningReportFlushScheduler;
 
     @Override
     @Transactional
@@ -30,6 +32,8 @@ public class TuningReportVisibilityWriter implements ItemWriter<TuningReport> {
         }
 
         alarmService.createTuningReportAlarm(emailDomain, coupleCount);
+
+        tuningReportFlushScheduler.flushDirtyReports();
         tuningReportCacheManager.invalidateDomainCache(emailDomain);
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/batch/TuningReportVisibilityWriter.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/batch/TuningReportVisibilityWriter.java
@@ -2,6 +2,7 @@ package com.hertz.hertz_be.global.batch;
 
 import com.hertz.hertz_be.domain.alarm.service.AlarmService;
 import com.hertz.hertz_be.domain.tuningreport.entity.TuningReport;
+import com.hertz.hertz_be.domain.tuningreport.repository.TuningReportCacheManager;
 import com.hertz.hertz_be.domain.tuningreport.repository.TuningReportRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.batch.item.Chunk;
@@ -15,6 +16,7 @@ public class TuningReportVisibilityWriter implements ItemWriter<TuningReport> {
 
     private final AlarmService alarmService;
     private final TuningReportRepository tuningReportRepository;
+    private final TuningReportCacheManager tuningReportCacheManager;
 
     @Override
     @Transactional
@@ -28,5 +30,6 @@ public class TuningReportVisibilityWriter implements ItemWriter<TuningReport> {
         }
 
         alarmService.createTuningReportAlarm(emailDomain, coupleCount);
+        tuningReportCacheManager.invalidateDomainCache(emailDomain);
     }
 }

--- a/hertz-be/src/main/resources/application-dev.properties
+++ b/hertz-be/src/main/resources/application-dev.properties
@@ -4,6 +4,7 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.show-sql=false
 spring.jpa.open-in-view=false
+spring.jpa.properties.hibernate.generate_statistics=true
 
 # JWT AT expiration time
 jwt.at.expiration-minutes=300

--- a/hertz-be/src/main/resources/application-local.properties
+++ b/hertz-be/src/main/resources/application-local.properties
@@ -4,6 +4,7 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.show-sql=true
 spring.jpa.open-in-view=false
+spring.jpa.properties.hibernate.generate_statistics=true
 
 # JWT AT expiration time
 jwt.at.expiration-minutes=300

--- a/hertz-be/src/main/resources/application-prod.properties
+++ b/hertz-be/src/main/resources/application-prod.properties
@@ -4,6 +4,7 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.show-sql=false
 spring.jpa.open-in-view=false
+spring.jpa.properties.hibernate.generate_statistics=false
 
 # JWT AT expiration time
 jwt.at.expiration-minutes=30

--- a/hertz-be/src/main/resources/application-test.properties
+++ b/hertz-be/src/main/resources/application-test.properties
@@ -3,6 +3,7 @@ spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.generate_statistics=true
 
 # JWT AT expiration time
 jwt.at.expiration-minutes=30

--- a/hertz-be/src/main/resources/application.properties
+++ b/hertz-be/src/main/resources/application.properties
@@ -13,6 +13,7 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.data.redis.host=${REDIS_HOST}
 spring.data.redis.port=${REDIS_PORT}
 spring.data.redis.password=${REDIS_PASSWORD}
+redisson.config={"singleServerConfig":{"address":"redis://${REDIS_HOST}:${REDIS_PORT}","password":"${REDIS_PASSWORD}"},"threads":4,"nettyThreads":4}
 
 # Random Nickname URL
 external.api.nickname-url=https://nickname.hwanmoo.kr/?format=text&max_length=10


### PR DESCRIPTION
## 🔗 관련 이슈
- #363 

## ✏️ 변경 사항
- 튜닝 레포트 반응 API에 Cache Aside + Write Back 전략 도입
- Redis 캐싱 및 동기화 매니저 클래스 구현
- 도메인 기반 캐시 키 적용 및 TTL 갱신 로직 추가
- Redis TTL Jitter 및 Mutex Lock으로 Stampede 방지
- Redisson 기반 분산락 도입으로 Race Condition 대응
- DB 동기화를 위한 batch write-back 및 flushDirtyReports 구현
- AOP 기반 성능 측정 및 Redis SCAN 도입

---

## 📋 상세 설명

### 🔧 작업 배경
최근 150 VU 기준 부하 테스트에서 60,300 쿼리 발생, 평균 응답시간 2.46초, CPU 사용률 100%, DB CPU 40~50%를 기록하며 **튜닝 레포트 반응 API의 병목 현상**이 드러났습니다. 특히 캐시 미적용으로 인한 중복 조회/쓰기 부하가 집중된 것으로 분석되어, Cache Aside + Write Back 전략을 기반으로 성능 최적화를 진행했습니다.

#### 1. Cache Aside 전략 적용
- Redis 캐시 miss 시 DB 조회 후 Redis 저장 (TTL 5~10분 + jitter)
- 사용자별 도메인 기반 캐시 키 관리  
  - 예: `report:{domain}:{userId}` 형태
- 반응 시점마다 관련 키들의 TTL 갱신 로직 적용 (조회, 반응, 취소 등)

#### 2. Write Back 전략 구현
- 반응 API 처리 시 Redis에만 먼저 반영 → `flushDirtyReports`에 추가
- 배치성 비동기 DB 반영 처리 (`Executor` 기반 주기적 sync, 30분 간격)
- 새 레포트 발행 시 즉시 flushDirty → 캐시 무효화 및 TTL 초기화

#### 3. Cache Stampede 대응
- TTL 설정에 랜덤 지터 도입 (TTL: 5~10분 + jitter)
- 캐시 miss 시 병렬 로딩 방지를 위해 Redisson 기반 Mutex Lock 적용

#### 4. Race Condition 방지 및 성능 개선
- 도메인별 TTL 갱신 시 Redisson 분산락 도입으로 동시 갱신 방지
- 기존 DB 중심 비즈니스 로직과 Redis 캐싱 중심 로직 명확히 분리
- `redisTemplate.keys()` → `SCAN` 명령어로 전환해 성능 및 안정성 확보
- AOP 기반 쿼리 성능 측정 기능 추가 (`@MeasureQuery` 어노테이션 활용)

### 기타 개선 사항
- `TuningReportListResponse` → class로 변경 (record → class)하여 Redis 저장 가능하게 처리
- 캐시 TTL 갱신 범위 확장 (`pageListKey`, `myReactKey`, `reactionKey` 등 포함)
- 필요없는 메서드 제거, 하드코딩 제거 및 주석/로깅 정리
- 순환 참조 해결 및 동기화 보장 로직 리팩터링

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 없음

## 📎 참고 자료 (선택)
- 없음
