### PR TITLE
Fix: FCM Initializer 시 예외 코드 처리

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/webpush/FCMInitializer.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/webpush/FCMInitializer.java
@@ -35,7 +35,7 @@ public class FCMInitializer {
                 log.info("✅ FirebaseApp already initialized");
             }
         } catch (Exception e) {
-            log.error("❌ FCM initialization FAIL");
+            log.error("❌ FCM initialization FAIL", e);
         }
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/webpush/FCMInitializer.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/webpush/FCMInitializer.java
@@ -28,10 +28,14 @@ public class FCMInitializer {
                     .setCredentials(GoogleCredentials.fromStream(is))
                     .build();
 
-            if (FirebaseApp.getApps().isEmpty()) {
+            if (FirebaseApp.getApps().stream().noneMatch(app -> app.getName().equals(FirebaseApp.DEFAULT_APP_NAME))) {
                 FirebaseApp.initializeApp(options);
-                log.info("FirebaseApp initialization complete");
+                log.info("🔥 FirebaseApp initialization SUCCESS");
+            } else {
+                log.info("✅ FirebaseApp already initialized");
             }
+        } catch (Exception e) {
+            log.error("❌ FCM initialization FAIL");
         }
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈


## ✏️ 변경 사항
- FCM Initializer 시 오류가 발생하여 채팅방에 접근을 하지 못하는 현상 발생

## 📋 상세 설명
- FCMInitializer라는 Bean 생성 과정에서 `@PostConstruct` 또는 InitializingBean의 `afterPropertiesSet()` 같은 초기화 메서드에서 예외가 터져서 애플리케이션이 실행되지 못한 것으로 추정
- FirebaseApp이 중복 생성되는지 의심
- 이전 테스트나 실행에서 FirebaseApp이 이미 초기화됐는데 다시 초기화하려고 할 경우 에러가 발생함
> 기존
```
if (FirebaseApp.getApps().isEmpty()) {
    FirebaseApp.initializeApp(options);
    log.info("FirebaseApp initialization complete");
}
```
> 변경
```
if (FirebaseApp.getApps().stream().noneMatch(app -> app.getName().equals(FirebaseApp.DEFAULT_APP_NAME))) {
    FirebaseApp.initializeApp(options);
    log.info("🔥 FirebaseApp initialization SUCCESS");
}
```
- 추가로 try-catch 활용하여 자세한 로그 추적 추가

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.
