### PR TITLE
[#374] Refactor: 채널방 목록 내 각 채팅방마다 lastPageNumber 추가 (프론트 페이지네이션 관련 요청)

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/v3/ChannelSummaryDto.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/dto/response/v3/ChannelSummaryDto.java
@@ -20,6 +20,7 @@ public class ChannelSummaryDto {
     private boolean isRead;
     private String category;
     private String relationType;
+    private int lastPageNumber;
 
     public static com.hertz.hertz_be.domain.channel.dto.response.v3.ChannelSummaryDto fromProjectionWithDecrypt(ChannelRoomProjection p, AESUtil aesUtil) {
         String decryptedMessage;
@@ -37,7 +38,8 @@ public class ChannelSummaryDto {
                 p.getLastMessageTime(),
                 p.getIsRead(),
                 p.getCategory(),
-                p.getRelationType()
+                p.getRelationType(),
+                p.getLastPageNumber()
         );
     }
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/SignalRoomRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/SignalRoomRepository.java
@@ -56,7 +56,9 @@ public interface SignalRoomRepository extends JpaRepository<SignalRoom, Long> {
             WHEN sr.sender_matching_status = 'UNMATCHED' OR sr.receiver_matching_status = 'UNMATCHED'
                 THEN 'UNMATCHED'
             ELSE 'SIGNAL'
-        END AS relationType
+        END AS relationType,
+        CEIL(
+            (SELECT COUNT(*) FROM signal_message sm3 WHERE sm3.signal_room_id = sr.id) / :pageSize * 1.0) - 1 AS lastPageNumber
     FROM signal_room sr
     JOIN user u ON 
         (CASE 
@@ -81,6 +83,7 @@ public interface SignalRoomRepository extends JpaRepository<SignalRoom, Long> {
             nativeQuery = true)
     Page<ChannelRoomProjection> findChannelRoomsWithPartnerAndLastMessage(
             @Param("userId") Long userId,
+            @Param("pageSize") int pageSize,
             Pageable pageable
     );
 

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/projection/ChannelRoomProjection.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/projection/ChannelRoomProjection.java
@@ -15,4 +15,5 @@ public interface ChannelRoomProjection {
     Long getSenderUserId();
     Long getReceiverUserId();
     String getCategory();
+    int getLastPageNumber();
 }

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v1/ChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v1/ChannelService.java
@@ -1,6 +1,5 @@
 package com.hertz.hertz_be.domain.channel.service.v1;
 
-import com.corundumstudio.socketio.SocketIOServer;
 import com.hertz.hertz_be.domain.channel.dto.request.v3.SendMessageRequestDto;
 import com.hertz.hertz_be.domain.channel.dto.response.v1.*;
 import com.hertz.hertz_be.domain.channel.service.AsyncChannelService;
@@ -37,7 +36,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
-import org.springframework.transaction.support.TransactionSynchronizationAdapter;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.reactive.function.client.WebClient;
 
@@ -418,7 +416,7 @@ public class ChannelService {
     @Transactional(readOnly = true)
     public ChannelListResponseDto getPersonalSignalRoomList(Long userId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<ChannelRoomProjection> result = signalRoomRepository.findChannelRoomsWithPartnerAndLastMessage(userId, pageable);
+        Page<ChannelRoomProjection> result = signalRoomRepository.findChannelRoomsWithPartnerAndLastMessage(userId, size, pageable);
 
         if (result.isEmpty()) {
             return null;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v3/ChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v3/ChannelService.java
@@ -68,7 +68,7 @@ public class ChannelService {
     @Transactional(readOnly = true)
     public ChannelListResponseDto getPersonalSignalRoomList(Long userId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<ChannelRoomProjection> result = signalRoomRepository.findChannelRoomsWithPartnerAndLastMessage(userId, pageable);
+        Page<ChannelRoomProjection> result = signalRoomRepository.findChannelRoomsWithPartnerAndLastMessage(userId, size, pageable);
 
         if (result.isEmpty()) {
             return null;


### PR DESCRIPTION
## 🔗 관련 이슈
- #374 

## ✏️ 변경 사항
- 채널 목록 API 응답에 lastPageNumber 필드를 포함하여, 클라이언트에서 마지막 페이지 계산 로직을 제거하고 UX 흐름을 개선함

## 📋 상세 설명
- 현재 채팅방 목록 API/api/v3/channel?page={page}&size={size}는 마지막 페이지 번호 정보를 포함하지 않아, 프론트 측에서 스크롤 처리나 페이지 이동 시 전체 페이지 수를 알기 어려운 상황
- 채팅방 진입 시 위에서 아래로 메시지를 훑는 부자연스러운 UX가 발생
- 서버에서 각 사용자의 채널 총 개수를 기준으로 lastPageNumber를 계산하여 응답에 포함시키는 방법으로 수정

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [x] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.
