### PR TITLE
Refactor: 채널방 상세페이지 조회 시 pageSize 고정

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v1/ChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v1/ChannelService.java
@@ -63,6 +63,9 @@ public class ChannelService {
     private final WebClient webClient;
     private final AESUtil aesUtil;
 
+    @Value("${channel.message.page.size}")
+    private int channelMessagePageSize;
+
     @Autowired
     public ChannelService(UserRepository userRepository,
                           TuningRepository tuningRepository,
@@ -416,7 +419,7 @@ public class ChannelService {
     @Transactional(readOnly = true)
     public ChannelListResponseDto getPersonalSignalRoomList(Long userId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<ChannelRoomProjection> result = signalRoomRepository.findChannelRoomsWithPartnerAndLastMessage(userId, size, pageable);
+        Page<ChannelRoomProjection> result = signalRoomRepository.findChannelRoomsWithPartnerAndLastMessage(userId, channelMessagePageSize, pageable);
 
         if (result.isEmpty()) {
             return null;

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v3/ChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v3/ChannelService.java
@@ -30,8 +30,10 @@ import com.hertz.hertz_be.global.infra.ai.dto.response.AiChatReportResponseDto;
 import com.hertz.hertz_be.global.util.AESUtil;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -64,11 +66,13 @@ public class ChannelService {
     private final AESUtil aesUtil;
     private final TuningAiClient tuningAiClient;
 
+    @Value("${channel.message.page.size}")
+    private int channelMessagePageSize;
 
     @Transactional(readOnly = true)
     public ChannelListResponseDto getPersonalSignalRoomList(Long userId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<ChannelRoomProjection> result = signalRoomRepository.findChannelRoomsWithPartnerAndLastMessage(userId, size, pageable);
+        Page<ChannelRoomProjection> result = signalRoomRepository.findChannelRoomsWithPartnerAndLastMessage(userId, channelMessagePageSize, pageable);
 
         if (result.isEmpty()) {
             return null;

--- a/hertz-be/src/main/resources/application.properties
+++ b/hertz-be/src/main/resources/application.properties
@@ -93,4 +93,7 @@ fcm.certification=tuning-fcm-certification.json
 management.endpoints.web.exposure.include=health,info,prometheus
 
 #### Prometheus
-management.metrics.export.prometheus.enabled=true
+management.prometheus.metrics.export.enabled=true
+
+# Channel Message PageSize
+channel.message.page.size=20


### PR DESCRIPTION
## 🔗 관련 이슈
- 

## ✏️ 변경 사항
- 채널방 상세페에지 조회 시 pageSize를 고정하도록 환경변수 추가
- 해당 pageSize를 기준으로 lastPageNumber를 계산할 수 있도록 함

## 📋 상세 설명


## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.
