### PR TITLE
Fix: WebPush Redis 내 저장된 key 값 관련 소스 누락 조치

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/config/SecurityConfig.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/config/SecurityConfig.java
@@ -47,8 +47,7 @@ public class SecurityConfig {
                                 "/v3/api-docs",
                                 "/v3/api-docs/**",
                                 "/swagger-resources/**",
-                                "/webjars/**",
-                                "/api/push/token"
+                                "/webjars/**"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )
@@ -62,7 +61,6 @@ public class SecurityConfig {
         CorsConfiguration corsConfiguration = new CorsConfiguration();
         corsConfiguration.setAllowedOrigins(List.of(
                 "http://localhost:3000",
-                "http://localhost:5500",
                 "https://hertz-tuning.com",
                 "https://dev.hertz-tuning.com",
                 "https://local.hertz-tuning.com:3000",

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/config/SecurityConfig.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/config/SecurityConfig.java
@@ -47,7 +47,8 @@ public class SecurityConfig {
                                 "/v3/api-docs",
                                 "/v3/api-docs/**",
                                 "/swagger-resources/**",
-                                "/webjars/**"
+                                "/webjars/**",
+                                "/api/push/token"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )
@@ -61,6 +62,7 @@ public class SecurityConfig {
         CorsConfiguration corsConfiguration = new CorsConfiguration();
         corsConfiguration.setAllowedOrigins(List.of(
                 "http://localhost:3000",
+                "http://localhost:5500",
                 "https://hertz-tuning.com",
                 "https://dev.hertz-tuning.com",
                 "https://local.hertz-tuning.com:3000",

--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/webpush/token/FCMTokenDao.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/webpush/token/FCMTokenDao.java
@@ -14,18 +14,18 @@ public class FCMTokenDao {
 
     public void saveToken(Long userId, String token) {
         tokenRedisTemplate.opsForValue()
-                .set("fcm-token-userId-" + String.valueOf(userId), token);
+                .set("fcm-token-userId-" + userId, token);
     }
 
     public String getToken(Long userId) {
-        return tokenRedisTemplate.opsForValue().get(String.valueOf(userId));
+        return tokenRedisTemplate.opsForValue().get("fcm-token-userId-" + userId);
     }
 
     public void deleteToken(Long userId) {
-        tokenRedisTemplate.delete(String.valueOf(userId));
+        tokenRedisTemplate.delete("fcm-token-userId-" + userId);
     }
 
     public boolean hasKey(Long userId) {
-        return tokenRedisTemplate.hasKey(String.valueOf(userId));
+        return tokenRedisTemplate.hasKey("fcm-token-userId-" + userId);
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
- Redis 내 Token에 대해 key 값을 불러올 때에 소스가 누락되어 올바르지 않은 key를 부르고 있는 이슈

## ✏️ 변경 사항
- key 값을 동일하게 불러올 수 있도록 조치함

## 📋 상세 설명

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.
