### PR TITLE
Chore: FCM Initialize 과정을 ClassPath -> FileStream 형식으로 변경

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/global/webpush/FCMInitializer.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/global/webpush/FCMInitializer.java
@@ -6,9 +6,9 @@ import com.google.firebase.FirebaseOptions;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
 
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -20,10 +20,8 @@ public class FCMInitializer {
     private String fcmCredentials;
 
     @PostConstruct
-    public void initialize() throws IOException {
-        ClassPathResource resource = new ClassPathResource(fcmCredentials);
-
-        try (InputStream is = resource.getInputStream()) {
+    public void initialize() {
+        try (InputStream is = resolveInputStream(fcmCredentials)) {
             FirebaseOptions options = FirebaseOptions.builder()
                     .setCredentials(GoogleCredentials.fromStream(is))
                     .build();
@@ -37,5 +35,10 @@ public class FCMInitializer {
         } catch (Exception e) {
             log.error("❌ FCM initialization FAIL", e);
         }
+    }
+
+    private InputStream resolveInputStream(String path) throws IOException {
+        log.info("📂 Loading FCM credentials from path: {}", path);
+        return new FileInputStream(path);
     }
 }

--- a/hertz-be/src/main/resources/application.properties
+++ b/hertz-be/src/main/resources/application.properties
@@ -87,7 +87,7 @@ spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.Strin
 spring.kafka.producer.value-serializer=org.springframework.kafka.support.serializer.JsonSerializer
 
 # WebPush
-fcm.certification=tuning-fcm-certification.json
+fcm.certification=src/main/resources/tuning-fcm-certification.json
 
 #### Actuator
 management.endpoints.web.exposure.include=health,info,prometheus


### PR DESCRIPTION
## 🔗 관련 이슈

## ✏️ 변경 사항
- ClassPath로 fcm관련 json을 읽어오는 과정에 docker 관련 이슈로 인해 수정

## 📋 상세 설명
- Kubernetes Secret은 classpath가 아닌 파일시스템에 마운트되기 때문
- 절대 경로로 접근하는 방법으로 수정

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.
