### PR TITLE
[#394] Refactor: 채팅 목록 조회 API N+1 문제 해결 및 성능 개선

### DIFF
--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/SignalRoom.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/entity/SignalRoom.java
@@ -7,6 +7,7 @@ import com.hertz.hertz_be.domain.tuningreport.entity.TuningReport;
 import com.hertz.hertz_be.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.BatchSize;
 import org.hibernate.annotations.CreationTimestamp;
 
 import java.time.LocalDateTime;
@@ -67,6 +68,7 @@ public class SignalRoom {
     private LocalDateTime senderExitedAt = null;
 
     @OneToMany(mappedBy = "signalRoom")
+    @BatchSize(size = 50)
     @Builder.Default
     private List<SignalMessage> messages = new ArrayList<>();
 

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/SignalRoomRepository.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/SignalRoomRepository.java
@@ -2,7 +2,7 @@ package com.hertz.hertz_be.domain.channel.repository;
 
 import com.hertz.hertz_be.domain.channel.entity.SignalRoom;
 import com.hertz.hertz_be.domain.channel.entity.enums.MatchingStatus;
-import com.hertz.hertz_be.domain.channel.repository.projection.ChannelRoomProjection;
+import com.hertz.hertz_be.domain.channel.repository.projection.SignalRoomRepositoryCustom;
 import com.hertz.hertz_be.domain.user.entity.User;
 import com.hertz.hertz_be.domain.channel.entity.enums.Category;
 import io.lettuce.core.dynamic.annotation.Param;
@@ -16,7 +16,7 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 import java.util.Optional;
 
-public interface SignalRoomRepository extends JpaRepository<SignalRoom, Long> {
+public interface SignalRoomRepository extends JpaRepository<SignalRoom, Long>, SignalRoomRepositoryCustom {
     boolean existsBySenderUserAndReceiverUser(User sender, User receiver);
 
     Optional<SignalRoom> findByUserPairSignal(String userPairSignal);

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/SignalRoomRepositoryImpl.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/SignalRoomRepositoryImpl.java
@@ -1,0 +1,80 @@
+package com.hertz.hertz_be.domain.channel.repository;
+
+import com.hertz.hertz_be.domain.channel.entity.SignalRoom;
+import com.hertz.hertz_be.domain.channel.repository.projection.SignalRoomRepositoryCustom;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.Comparator;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class SignalRoomRepositoryImpl implements SignalRoomRepositoryCustom {
+
+    private final EntityManager em;
+
+    @Override
+    public List<Long> findSignalRoomIdsOrderByLastMessageTime(Long userId, int offset, int limit) {
+        return em.createQuery("""
+                select sr.id
+                from SignalRoom sr
+                left join sr.messages m
+                where sr.senderUser.id = :userId or sr.receiverUser.id = :userId
+                group by sr.id
+                order by max(m.sendAt) desc
+            """, Long.class)
+                .setParameter("userId", userId)
+                .setFirstResult(offset)
+                .setMaxResults(limit)
+                .getResultList();
+    }
+
+    public List<SignalRoom> findAllWithUsersByIds(List<Long> ids) {
+        return em.createQuery("""
+        select distinct sr from SignalRoom sr
+        left join fetch sr.senderUser su
+        left join fetch su.userOauth
+        left join fetch sr.receiverUser ru
+        left join fetch ru.userOauth
+        left join fetch sr.tuningReport tr
+        where sr.id in :ids
+        """, SignalRoom.class)
+                .setParameter("ids", ids)
+                .getResultList();
+    }
+
+    public Long countSignalRoomsByUser(Long userId) {
+        return em.createQuery("""
+        select count(sr)
+        from SignalRoom sr
+        where sr.senderUser.id = :userId or sr.receiverUser.id = :userId
+        """, Long.class)
+                .setParameter("userId", userId)
+                .getSingleResult();
+    }
+
+    public Page<SignalRoom> findAllOrderByLastMessageTimeWithUsers(Long userId, Pageable pageable) {
+        int offset = (int) pageable.getOffset();
+        int limit = pageable.getPageSize();
+
+        List<Long> ids = findSignalRoomIdsOrderByLastMessageTime(userId, offset, limit);
+
+        if (ids.isEmpty()) {
+            return new PageImpl<>(List.of(), pageable, 0);
+        }
+
+        List<SignalRoom> rooms = findAllWithUsersByIds(ids);
+        Long total = countSignalRoomsByUser(userId);
+
+        // 정렬 보존을 위해 id 순서를 기준으로 다시 정렬
+        rooms.sort(Comparator.comparingInt(room -> ids.indexOf(room.getId())));
+
+        return new PageImpl<>(rooms, pageable, total);
+    }
+
+}

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/projection/SignalRoomRepositoryCustom.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/repository/projection/SignalRoomRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.hertz.hertz_be.domain.channel.repository.projection;
+
+import com.hertz.hertz_be.domain.channel.entity.SignalRoom;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface SignalRoomRepositoryCustom {
+    List<Long> findSignalRoomIdsOrderByLastMessageTime(Long userId, int offset, int limit);
+    Page<SignalRoom> findAllOrderByLastMessageTimeWithUsers(Long userId, Pageable pageable);
+}
+

--- a/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v3/ChannelService.java
+++ b/hertz-be/src/main/java/com/hertz/hertz_be/domain/channel/service/v3/ChannelService.java
@@ -72,7 +72,8 @@ public class ChannelService {
     @Transactional(readOnly = true)
     public ChannelListResponseDto getPersonalSignalRoomList(Long userId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
-        Page<SignalRoom> signalRooms = signalRoomRepository.findAllOrderByLastMessageTimeDesc(userId, pageable);
+        Page<SignalRoom> signalRooms = signalRoomRepository.findAllOrderByLastMessageTimeWithUsers(userId, pageable);
+
 
         if (signalRooms.isEmpty()) {
             return new ChannelListResponseDto(List.of(), page, size, true);

--- a/hertz-be/src/test/java/com/hertz/hertz_be/domain/channel/service/v3/ChannelServiceTest.java
+++ b/hertz-be/src/test/java/com/hertz/hertz_be/domain/channel/service/v3/ChannelServiceTest.java
@@ -100,7 +100,7 @@ public class ChannelServiceTest {
         when(aesUtil.decrypt("encrypted-msg")).thenReturn("decrypted-msg");
 
         Page<SignalRoom> roomPage = new PageImpl<>(List.of(room1, room2));
-        when(signalRoomRepository.findAllOrderByLastMessageTimeDesc(eq(1L), any(PageRequest.class))).thenReturn(roomPage);
+        when(signalRoomRepository.findAllOrderByLastMessageTimeWithUsers(eq(1L), any(PageRequest.class))).thenReturn(roomPage);
 
         ChannelListResponseDto result = channelService.getPersonalSignalRoomList(1L, 0, 10);
 
@@ -117,7 +117,7 @@ public class ChannelServiceTest {
         when(room.getMessages()).thenReturn(List.of());
 
         Page<SignalRoom> roomPage = new PageImpl<>(List.of(room));
-        when(signalRoomRepository.findAllOrderByLastMessageTimeDesc(eq(1L), any(PageRequest.class))).thenReturn(roomPage);
+        when(signalRoomRepository.findAllOrderByLastMessageTimeWithUsers(eq(1L), any(PageRequest.class))).thenReturn(roomPage);
 
         ChannelListResponseDto result = channelService.getPersonalSignalRoomList(1L, 0, 10);
 
@@ -139,7 +139,7 @@ public class ChannelServiceTest {
         when(aesUtil.decrypt("bad-encrypted-msg")).thenThrow(new RuntimeException("decryption failed"));
 
         Page<SignalRoom> roomPage = new PageImpl<>(List.of(room));
-        when(signalRoomRepository.findAllOrderByLastMessageTimeDesc(eq(1L), any(PageRequest.class))).thenReturn(roomPage);
+        when(signalRoomRepository.findAllOrderByLastMessageTimeWithUsers(eq(1L), any(PageRequest.class))).thenReturn(roomPage);
 
         ChannelListResponseDto result = channelService.getPersonalSignalRoomList(1L, 0, 10);
 


### PR DESCRIPTION
## 🔗 관련 이슈
- #394

## ✏️ 변경 사항

- 채팅 목록 조회 API(`getPersonalSignalRoomList`)의 성능을 개선하기 위해 N+1 문제 해결
- 기존 nativeQuery 기반 조회 로직을 JPQL + fetch join 방식으로 리팩토링
- OneToMany 관계(`SignalRoom → SignalMessage`)에 `@BatchSize` 적용

---

## 📋 상세 설명

### 🔧 작업 배경
- 기존 채팅 목록 API는 `SignalRoom → senderUser`, `receiverUser`, `messages` 연관 데이터를 Lazy 로딩하면서 **N+1 문제** 발생
- 특히 메시지 수가 많은 경우 **전체 채팅방 수만큼 추가 쿼리**가 실행되어 성능 저하
- 기존 native 쿼리는 `fetch join`, `@BatchSize`와 같은 JPA 최적화 전략 적용이 어려움

### 📌 주요 변경 사항

1. **JPQL + Fetch Join 적용**
   - `ManyToOne` 관계인 `senderUser`, `receiverUser`에 `fetch join` 적용
   - → 사용자 정보를 한 번에 로딩하여 N+1 문제 제거

2. **`@BatchSize` 적용**
   - `OneToMany` 관계인 `messages`에 `@BatchSize(size = 50)` 적용
   - → JPA가 IN 쿼리로 일괄 로딩하여 성능 개선

3. **페이징 보장**
   - `fetch join`은 `OneToMany` 관계에 사용 시 row 수 증가로 페이징 불가능
   - → `@BatchSize`로 우회하여 **페이징과 N+1 해결을 모두 만족**

---

## ✅ 체크리스트
- [x] 기능이 정상적으로 동작하는지 확인했습니다.
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 없음

## 📎 참고 자료 (선택)
- 없음
